### PR TITLE
fix: ruff S110 try-except-pass 경고 수정

### DIFF
--- a/scripts/collect_stock_news.py
+++ b/scripts/collect_stock_news.py
@@ -416,8 +416,8 @@ def main():
                                 "section": "US Market",
                             }
                         )
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("yfinance symbol %s parse error: %s", sym, exc)
         except ImportError:
             logger.debug("yfinance not available for US market fallback")
         except Exception as e:


### PR DESCRIPTION
## Summary
- `collect_stock_news.py`의 yfinance 심볼 파싱에서 bare `except-pass`를 `logger.debug`로 교체
- ruff S110 보안 규칙 위반 수정

## Test plan
- [ ] Code Quality 워크플로우 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)