### PR TITLE
feat: 라이트 모드 테마 지원 추가

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -28,6 +28,14 @@
           </svg>
         </button>
       </div>
+      <button class="theme-toggle" id="theme-toggle" aria-label="테마 변경" type="button">
+        <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+        </svg>
+        <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+        </svg>
+      </button>
       <div class="lang-toggle-wrapper notranslate" translate="no">
         <button class="lang-toggle" id="lang-toggle" aria-label="언어 변경" data-i18n-aria="change_language" aria-expanded="false" aria-controls="lang-dropdown" type="button">
           <svg class="globe-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,10 @@
   <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/images/favicon-32.png' | relative_url }}">
   <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
   <link rel="manifest" href="{{ '/manifest.json' | relative_url }}">
-  <meta name="theme-color" content="#0d1117">
+  <meta name="theme-color" content="#0d1117" id="meta-theme-color">
+  <script>
+    (function(){var t=localStorage.getItem('theme');if(!t){t=window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark';}if(t==='light'){document.documentElement.setAttribute('data-theme','light');document.querySelector('#meta-theme-color')&&document.querySelector('#meta-theme-color').setAttribute('content','#ffffff');}})();
+  </script>
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
@@ -135,5 +138,41 @@
     window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
   </script>
   <script defer src="/_vercel/speed-insights/script.js"></script>
+  <script>
+  (function() {
+    var toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+    var metaColor = document.getElementById('meta-theme-color');
+
+    function getTheme() {
+      var saved = localStorage.getItem('theme');
+      if (saved) return saved;
+      return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+    }
+
+    function applyTheme(theme) {
+      if (theme === 'light') {
+        document.documentElement.setAttribute('data-theme', 'light');
+        if (metaColor) metaColor.setAttribute('content', '#ffffff');
+      } else {
+        document.documentElement.removeAttribute('data-theme');
+        if (metaColor) metaColor.setAttribute('content', '#0d1117');
+      }
+    }
+
+    toggle.addEventListener('click', function() {
+      var current = document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+      var next = current === 'light' ? 'dark' : 'light';
+      localStorage.setItem('theme', next);
+      applyTheme(next);
+    });
+
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function(e) {
+      if (!localStorage.getItem('theme')) {
+        applyTheme(e.matches ? 'light' : 'dark');
+      }
+    });
+  })();
+  </script>
 </body>
 </html>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -5401,3 +5401,565 @@ a:focus-visible {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ================================
+   LIGHT MODE - Theme Override
+   ================================ */
+
+// Theme toggle button
+.theme-toggle {
+  background: none;
+  border: 1px solid rgba($border-color, 0.4);
+  border-radius: 8px;
+  padding: 0.4rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $text-secondary;
+  transition: all 0.2s ease;
+  width: 36px;
+  height: 36px;
+
+  &:hover {
+    background: rgba($accent-blue, 0.1);
+    border-color: rgba($accent-blue, 0.3);
+    color: var(--accent-blue);
+  }
+
+  .icon-sun,
+  .icon-moon {
+    width: 18px;
+    height: 18px;
+  }
+
+  .icon-sun { display: none; }
+  .icon-moon { display: block; }
+}
+
+[data-theme="light"] .theme-toggle {
+  border-color: rgba(208, 215, 222, 0.6);
+  color: #656d76;
+
+  &:hover {
+    background: rgba(9, 105, 218, 0.08);
+    border-color: rgba(9, 105, 218, 0.3);
+    color: #0969da;
+  }
+
+  .icon-sun { display: block; }
+  .icon-moon { display: none; }
+}
+
+// Core overrides
+[data-theme="light"] {
+  // Body
+  body, & {
+    background: linear-gradient(180deg, #ffffff 0%, #f6f8fa 100%);
+    color: var(--text-primary);
+  }
+
+  // Links
+  a {
+    color: var(--accent-blue);
+    &:hover { color: darken(#0969da, 10%); }
+  }
+
+  // Header
+  .site-header {
+    background: rgba(255, 255, 255, 0.92);
+    border-bottom-color: rgba(208, 215, 222, 0.6);
+    box-shadow: 0 1px 4px rgba(31, 35, 40, 0.06);
+
+    .site-logo {
+      color: var(--text-primary);
+      &:hover { color: var(--accent-blue); }
+    }
+  }
+
+  .site-nav {
+    a, .nav-link {
+      color: var(--text-secondary);
+      &:hover, &.active { color: var(--accent-blue); }
+    }
+
+    .nav-dropdown-menu {
+      background: #ffffff;
+      border-color: var(--border-color);
+      box-shadow: 0 8px 24px rgba(31, 35, 40, 0.08);
+
+      a {
+        color: var(--text-primary);
+        &:hover { background: #f6f8fa; color: var(--accent-blue); }
+      }
+    }
+  }
+
+  .nav-toggle { color: var(--text-primary); }
+
+  // Reading progress bar
+  .reading-progress {
+    background: var(--reading-progress);
+  }
+
+  // Hero
+  .hero {
+    background: linear-gradient(135deg, rgba(9, 105, 218, 0.06) 0%, rgba(130, 80, 223, 0.06) 100%);
+
+    &::before {
+      background: radial-gradient(circle at 50% 50%, rgba(9, 105, 218, 0.06) 0%, transparent 70%);
+    }
+
+    h1 {
+      background: linear-gradient(135deg, #1f2328 0%, #0969da 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+    }
+
+    p { color: var(--text-secondary); }
+  }
+
+  // Cards
+  .category-card {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: rgba(208, 215, 222, 0.6);
+
+    &:hover {
+      box-shadow: 0 12px 24px rgba(31, 35, 40, 0.08);
+      border-color: var(--accent-blue);
+    }
+
+    h3 { color: var(--text-primary); }
+    p { color: var(--text-secondary); }
+  }
+
+  // Post cards
+  .post-card {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: rgba(208, 215, 222, 0.5);
+
+    &:hover {
+      box-shadow: 0 8px 24px rgba(31, 35, 40, 0.08);
+      border-color: var(--accent-blue);
+    }
+
+    .post-title { color: var(--text-primary); }
+    .post-excerpt { color: var(--text-secondary); }
+
+    .post-card-meta {
+      color: var(--text-secondary);
+      border-top-color: rgba(208, 215, 222, 0.3);
+    }
+  }
+
+  // Post category badge
+  .post-category {
+    background: rgba(9, 105, 218, 0.08);
+    color: var(--accent-blue);
+    border-color: rgba(9, 105, 218, 0.15);
+    box-shadow: none;
+
+    &.cat-crypto-news {
+      background: rgba(247, 147, 26, 0.08);
+      color: #b35e00;
+      border-color: rgba(247, 147, 26, 0.15);
+    }
+    &.cat-stock-news {
+      background: rgba(9, 105, 218, 0.08);
+      color: #0550ae;
+      border-color: rgba(9, 105, 218, 0.15);
+    }
+    &.cat-crypto-trading-journal,
+    &.cat-stock-trading-journal {
+      background: rgba(26, 127, 55, 0.08);
+      color: #116329;
+      border-color: rgba(26, 127, 55, 0.15);
+    }
+    &.cat-security-alerts {
+      background: rgba(207, 34, 46, 0.06);
+      color: #a40e26;
+      border-color: rgba(207, 34, 46, 0.15);
+    }
+    &.cat-market-analysis {
+      background: rgba(130, 80, 223, 0.06);
+      color: #6639ba;
+      border-color: rgba(130, 80, 223, 0.15);
+    }
+    &.cat-regulatory-news {
+      background: rgba(154, 103, 0, 0.06);
+      color: #7d4e00;
+      border-color: rgba(154, 103, 0, 0.15);
+    }
+    &.cat-political-trades {
+      background: rgba(207, 34, 46, 0.06);
+      color: #a40e26;
+      border-color: rgba(207, 34, 46, 0.15);
+    }
+  }
+
+  // Tags
+  .tag {
+    background: rgba(246, 248, 250, 0.9);
+    color: var(--text-secondary);
+    border-color: rgba(208, 215, 222, 0.5);
+
+    &:hover {
+      background: rgba(130, 80, 223, 0.08);
+      color: #6639ba;
+      border-color: rgba(130, 80, 223, 0.2);
+    }
+  }
+
+  // Post detail
+  .post-detail {
+    .post-header h1 {
+      background: linear-gradient(135deg, #1f2328 0%, rgba(31, 35, 40, 0.85) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+    }
+
+    .post-breadcrumb {
+      a { color: var(--text-secondary); &:hover { color: var(--accent-blue); } }
+      svg { color: var(--text-secondary); }
+    }
+
+    .post-meta-enhanced {
+      .post-meta-item { color: var(--text-secondary); }
+    }
+
+    .post-summary {
+      background: linear-gradient(135deg, rgba(246, 248, 250, 0.8) 0%, rgba(255, 255, 255, 0.9) 100%);
+      border-color: rgba(208, 215, 222, 0.4);
+      border-left-color: var(--accent-blue);
+      box-shadow: 0 4px 12px rgba(31, 35, 40, 0.04);
+
+      .summary-label { color: var(--accent-blue); &::before { background: var(--accent-blue); } }
+      p { color: rgba(31, 35, 40, 0.9); }
+    }
+
+    .post-content {
+      color: rgba(31, 35, 40, 0.92);
+
+      .post-lead {
+        color: rgba(31, 35, 40, 0.95);
+        background: linear-gradient(135deg, rgba(246, 248, 250, 0.7) 0%, rgba(255, 255, 255, 0.6) 100%);
+        border-color: rgba(208, 215, 222, 0.3);
+        box-shadow: 0 4px 12px rgba(31, 35, 40, 0.04);
+      }
+
+      h2, h3 { color: var(--text-primary); }
+
+      h2 {
+        border-bottom-color: rgba(208, 215, 222, 0.4);
+        &::before { background: linear-gradient(90deg, #0969da 0%, #8250df 100%); }
+      }
+
+      h3::before { color: var(--accent-blue); }
+
+      a { color: var(--accent-blue); }
+
+      strong { color: var(--text-primary); }
+
+      blockquote {
+        background: var(--blockquote-bg);
+        border-left-color: var(--accent-blue);
+        color: var(--text-secondary);
+      }
+
+      code {
+        background: var(--code-bg);
+        color: #cf222e;
+        border-color: rgba(208, 215, 222, 0.4);
+      }
+
+      pre {
+        background: #f6f8fa;
+        border-color: rgba(208, 215, 222, 0.4);
+
+        code {
+          color: var(--text-primary);
+          background: transparent;
+          border: none;
+        }
+      }
+
+      table {
+        th {
+          background: rgba(246, 248, 250, 0.8);
+          color: var(--text-primary);
+          border-color: rgba(208, 215, 222, 0.4);
+        }
+
+        td {
+          border-color: rgba(208, 215, 222, 0.3);
+          color: var(--text-primary);
+        }
+
+        tr:nth-child(even) td {
+          background: rgba(246, 248, 250, 0.4);
+        }
+
+        tr:hover td {
+          background: rgba(9, 105, 218, 0.04);
+        }
+      }
+
+      img {
+        border-color: rgba(208, 215, 222, 0.3);
+        box-shadow: 0 4px 12px rgba(31, 35, 40, 0.06);
+      }
+
+      // Alert boxes
+      .alert, [class*="alert-"] {
+        border-color: rgba(208, 215, 222, 0.3);
+      }
+
+      .alert-info {
+        background: var(--alert-info-bg);
+        border-left-color: var(--accent-blue);
+        color: var(--text-primary);
+      }
+
+      .alert-warning {
+        background: var(--alert-warning-bg);
+        border-left-color: var(--accent-orange);
+        color: var(--text-primary);
+      }
+
+      .alert-success {
+        background: var(--alert-success-bg);
+        border-left-color: var(--accent-green);
+        color: var(--text-primary);
+      }
+
+      .alert-danger {
+        background: var(--alert-danger-bg);
+        border-left-color: var(--accent-red);
+        color: var(--text-primary);
+      }
+    }
+  }
+
+  // TOC
+  .post-toc {
+    background: rgba(246, 248, 250, 0.8);
+    border-color: rgba(208, 215, 222, 0.4);
+
+    .toc-header {
+      color: var(--text-primary);
+      border-bottom-color: rgba(208, 215, 222, 0.3);
+    }
+
+    .toc-list a {
+      color: var(--text-secondary);
+      &:hover, &.active { color: var(--accent-blue); }
+    }
+  }
+
+  // Post engagement
+  .post-engagement {
+    .post-source-link a {
+      background: rgba(246, 248, 250, 0.8);
+      color: var(--accent-blue);
+      border-color: rgba(208, 215, 222, 0.4);
+      &:hover { background: rgba(9, 105, 218, 0.06); }
+    }
+
+    .share-label { color: var(--text-secondary); }
+
+    .share-btn {
+      background: rgba(246, 248, 250, 0.8);
+      color: var(--text-secondary);
+      border-color: rgba(208, 215, 222, 0.4);
+      &:hover { background: rgba(9, 105, 218, 0.06); color: var(--accent-blue); border-color: rgba(9, 105, 218, 0.2); }
+    }
+  }
+
+  // Related posts
+  .related-posts {
+    h3 { color: var(--text-primary); }
+
+    .related-post-card {
+      background: rgba(246, 248, 250, 0.6);
+      border-color: rgba(208, 215, 222, 0.4);
+
+      &:hover { border-color: var(--accent-blue); box-shadow: 0 6px 16px rgba(31, 35, 40, 0.06); }
+      h4 { color: var(--text-primary); }
+      time { color: var(--text-secondary); }
+    }
+  }
+
+  // Post navigation
+  .post-nav {
+    .post-nav-link {
+      background: rgba(246, 248, 250, 0.6);
+      border-color: rgba(208, 215, 222, 0.4);
+      &:hover { border-color: var(--accent-blue); box-shadow: 0 4px 12px rgba(31, 35, 40, 0.06); }
+      .post-nav-label { color: var(--text-secondary); }
+      .post-nav-title { color: var(--text-primary); }
+    }
+  }
+
+  // Search overlay
+  .search-overlay {
+    background: var(--search-overlay-bg);
+
+    .search-overlay-input {
+      background: #ffffff;
+      color: var(--text-primary);
+      border-color: rgba(208, 215, 222, 0.6);
+      &::placeholder { color: var(--text-secondary); }
+      &:focus { border-color: var(--accent-blue); box-shadow: 0 0 0 3px rgba(9, 105, 218, 0.12); }
+    }
+
+    .search-overlay-close { color: var(--text-secondary); &:hover { color: var(--text-primary); } }
+  }
+
+  .search-result-item {
+    border-bottom-color: rgba(208, 215, 222, 0.3);
+    a { color: var(--text-primary); &:hover { color: var(--accent-blue); } }
+    small { color: var(--text-secondary); }
+  }
+
+  // Stat items
+  .stat-item {
+    background: rgba(246, 248, 250, 0.6);
+    border-color: rgba(208, 215, 222, 0.3);
+    .stat-value { color: var(--accent-blue); }
+    .stat-label { color: var(--text-secondary); }
+  }
+
+  // Source tags
+  .source-tag {
+    color: var(--text-secondary);
+    background: rgba(246, 248, 250, 0.7);
+    border-color: rgba(208, 215, 222, 0.3);
+  }
+
+  // Footer
+  .site-footer, footer {
+    background: #f6f8fa;
+    border-top-color: rgba(208, 215, 222, 0.5);
+    color: var(--text-secondary);
+
+    a { color: var(--accent-blue); }
+  }
+
+  // Pagination
+  .pagination {
+    a, span {
+      background: rgba(246, 248, 250, 0.8);
+      color: var(--text-secondary);
+      border-color: rgba(208, 215, 222, 0.4);
+    }
+    a:hover { background: rgba(9, 105, 218, 0.06); color: var(--accent-blue); border-color: rgba(9, 105, 218, 0.2); }
+    .current { background: var(--accent-blue); color: #ffffff; border-color: var(--accent-blue); }
+  }
+
+  // Lang toggle
+  .lang-toggle {
+    border-color: rgba(208, 215, 222, 0.5);
+    &:hover { background: rgba(9, 105, 218, 0.06); }
+    .lang-code { color: var(--text-primary); }
+  }
+
+  .lang-dropdown {
+    background: #ffffff;
+    border-color: rgba(208, 215, 222, 0.5);
+    box-shadow: 0 8px 24px rgba(31, 35, 40, 0.08);
+
+    .lang-option {
+      color: var(--text-primary);
+      &:hover { background: #f6f8fa; }
+    }
+  }
+
+  // Scroll hint
+  .scroll-hint {
+    color: var(--text-secondary);
+  }
+
+  // Table wrapper
+  .table-wrap {
+    &.is-scrollable::after {
+      background: linear-gradient(to left, rgba(255, 255, 255, 0.9), transparent);
+    }
+  }
+
+  // Image placeholder
+  .post-image-placeholder {
+    background: #f6f8fa;
+    color: var(--text-secondary);
+    border-color: rgba(208, 215, 222, 0.3);
+  }
+
+  // Figure caption
+  .post-figure figcaption {
+    color: var(--text-secondary);
+  }
+
+  // Lightbox
+  .lightbox-overlay {
+    background: rgba(255, 255, 255, 0.92);
+    .lightbox-close { color: var(--text-primary); &:hover { background: rgba(31, 35, 40, 0.06); } }
+  }
+
+  // Load more button
+  .load-more-btn {
+    background: rgba(246, 248, 250, 0.8);
+    border-color: rgba(208, 215, 222, 0.5);
+    color: var(--accent-blue);
+    &:hover { background: rgba(9, 105, 218, 0.06); border-color: rgba(9, 105, 218, 0.3); }
+    .load-more-count { color: var(--text-secondary); }
+  }
+
+  // Translate notice
+  #translate-notice {
+    background: linear-gradient(90deg, #f0f4ff, #f6f8fa) !important;
+    color: #0550ae !important;
+    border-bottom-color: rgba(208, 215, 222, 0.4) !important;
+
+    a { color: #0969da !important; }
+  }
+
+  // Skip to content
+  .skip-to-content {
+    background: #ffffff;
+    color: var(--accent-blue);
+  }
+
+  // Responsive mobile menu
+  @media (max-width: 768px) {
+    .site-nav {
+      background: #ffffff;
+      border-color: rgba(208, 215, 222, 0.5);
+    }
+  }
+
+  // Details/summary
+  details {
+    background: rgba(246, 248, 250, 0.6);
+    border-color: rgba(208, 215, 222, 0.4);
+
+    summary {
+      color: var(--text-primary);
+      &:hover { background: rgba(9, 105, 218, 0.04); }
+    }
+  }
+
+  // News cards within post content
+  .news-card, .card {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: rgba(208, 215, 222, 0.4);
+    box-shadow: 0 2px 8px rgba(31, 35, 40, 0.04);
+
+    &:hover {
+      box-shadow: 0 4px 12px rgba(31, 35, 40, 0.06);
+      border-color: rgba(9, 105, 218, 0.2);
+    }
+  }
+
+  // Price change indicators keep their semantic colors
+  .price-up, .change-positive { color: #1a7f37; }
+  .price-down, .change-negative { color: #cf222e; }
+}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -41,3 +41,57 @@ $shadow-glow-purple: 0 0 20px rgba(188, 140, 255, 0.3);
 $glass-bg: rgba(22, 27, 34, 0.8);
 $glass-border: rgba(48, 54, 61, 0.6);
 $glass-hover: rgba(28, 33, 40, 0.9);
+
+// CSS Custom Properties - Dark (default)
+:root {
+  --bg-primary: #{$bg-primary};
+  --bg-secondary: #{$bg-secondary};
+  --bg-card: #{$bg-card};
+  --text-primary: #{$text-primary};
+  --text-secondary: #{$text-secondary};
+  --accent-blue: #{$accent-blue};
+  --accent-green: #{$accent-green};
+  --accent-red: #{$accent-red};
+  --accent-orange: #{$accent-orange};
+  --accent-purple: #{$accent-purple};
+  --border-color: #{$border-color};
+  --shadow-alpha: 0.2;
+  --glass-bg: #{$glass-bg};
+  --glass-border: #{$glass-border};
+  --code-bg: #1a1f29;
+  --blockquote-bg: rgba(88, 166, 255, 0.06);
+  --table-stripe: rgba(22, 27, 34, 0.4);
+  --alert-info-bg: rgba(88, 166, 255, 0.08);
+  --alert-warning-bg: rgba(210, 153, 34, 0.08);
+  --alert-success-bg: rgba(63, 185, 80, 0.08);
+  --alert-danger-bg: rgba(248, 81, 73, 0.08);
+  --search-overlay-bg: rgba(13, 17, 23, 0.92);
+  --reading-progress: linear-gradient(90deg, #58a6ff, #bc8cff);
+}
+
+// CSS Custom Properties - Light
+[data-theme="light"] {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f6f8fa;
+  --bg-card: #ffffff;
+  --text-primary: #1f2328;
+  --text-secondary: #656d76;
+  --accent-blue: #0969da;
+  --accent-green: #1a7f37;
+  --accent-red: #cf222e;
+  --accent-orange: #9a6700;
+  --accent-purple: #8250df;
+  --border-color: #d0d7de;
+  --shadow-alpha: 0.06;
+  --glass-bg: rgba(255, 255, 255, 0.85);
+  --glass-border: rgba(208, 215, 222, 0.6);
+  --code-bg: #f6f8fa;
+  --blockquote-bg: rgba(9, 105, 218, 0.04);
+  --table-stripe: rgba(246, 248, 250, 0.6);
+  --alert-info-bg: rgba(9, 105, 218, 0.06);
+  --alert-warning-bg: rgba(154, 103, 0, 0.06);
+  --alert-success-bg: rgba(26, 127, 55, 0.06);
+  --alert-danger-bg: rgba(207, 34, 46, 0.06);
+  --search-overlay-bg: rgba(255, 255, 255, 0.95);
+  --reading-progress: linear-gradient(90deg, #0969da, #8250df);
+}


### PR DESCRIPTION
## Summary
- CSS 커스텀 프로퍼티 기반 다크/라이트 테마 시스템 구축
- 헤더에 해/달 아이콘 테마 토글 버튼 추가 (검색 옆)
- OS 테마 설정 자동 감지 + localStorage 저장
- FOUC(Flash of Unstyled Content) 방지: `<head>` 즉시 적용 스크립트

## Light Mode Coverage
헤더, 히어로, 카테고리 카드, 포스트 카드, 포스트 상세(TOC, 요약, 코드블록, 테이블, 알림, 인용), 검색 오버레이, 관련 포스트, 페이지네이션, 푸터, 라이트박스, 언어 토글, 번역 배너

## Test plan
- [ ] Jekyll Deploy CI 통과
- [ ] Code Quality CI 통과
- [ ] 다크 모드 기본 렌더링 정상
- [ ] 토글 버튼 클릭 시 라이트 모드 전환
- [ ] 새로고침 후 테마 유지 (localStorage)
- [ ] OS 다크/라이트 모드 설정 변경 시 자동 감지

🤖 Generated with [Claude Code](https://claude.com/claude-code)