### PR TITLE
feat: 검색 기능 구현 및 개선

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,6 +91,7 @@
     {{ content }}
   </main>
   {% include footer.html %}
+  <script src="{{ '/assets/js/search.js' | relative_url }}" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
   <script>
   (function() {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2653,33 +2653,114 @@ body {
 }
 
 .search-result-item {
+  display: block;
   background: rgba($bg-card, 0.6);
   border: 1px solid rgba($border-color, 0.5);
   border-radius: 10px;
   padding: 1.25rem;
   transition: all 0.3s ease;
+  text-decoration: none;
+  color: $text-primary;
 
-  &:hover {
+  &:hover, &:focus {
     background: rgba($bg-card, 0.8);
     border-color: $accent-blue;
     transform: translateX(4px);
+    outline: none;
+  }
+}
+
+.search-result-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+
+  mark {
+    background: rgba($accent-blue, 0.25);
+    color: inherit;
+    padding: 0.1em 0.2em;
+    border-radius: 3px;
+  }
+}
+
+.search-result-item:hover .search-result-title {
+  color: var(--accent-blue);
+}
+
+.search-result-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+}
+
+.search-result-date {
+  color: $text-secondary;
+}
+
+.search-result-cat {
+  padding: 0.15em 0.5em;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba($accent-blue, 0.15);
+  color: $accent-blue;
+
+  &.cat-crypto { background: rgba($cat-crypto, 0.15); color: $cat-crypto; }
+  &.cat-stock { background: rgba($cat-stock, 0.15); color: $cat-stock; }
+  &.cat-journal { background: rgba($cat-journal, 0.15); color: $cat-journal; }
+  &.cat-security { background: rgba($cat-security, 0.15); color: $cat-security; }
+  &.cat-analysis { background: rgba($cat-analysis, 0.15); color: $cat-analysis; }
+  &.cat-regulatory { background: rgba($cat-regulatory, 0.15); color: $cat-regulatory; }
+  &.cat-political { background: rgba($cat-political, 0.15); color: $cat-political; }
+}
+
+.search-result-tag {
+  color: $text-secondary;
+  font-size: 0.75rem;
+}
+
+.search-result-snippet {
+  font-size: 0.85rem;
+  color: $text-secondary;
+  line-height: 1.5;
+
+  mark {
+    background: rgba($accent-blue, 0.2);
+    color: var(--text-primary);
+    padding: 0.1em 0.15em;
+    border-radius: 2px;
+  }
+}
+
+.search-result-count {
+  font-size: 0.8rem;
+  color: $text-secondary;
+  padding: 0 0.25rem 0.25rem;
+}
+
+.search-empty-state {
+  text-align: center;
+  padding: 3rem;
+  color: $text-secondary;
+
+  svg {
+    opacity: 0.4;
+    margin-bottom: 1rem;
   }
 
-  a {
-    color: $text-primary;
-    font-size: 1.05rem;
+  .search-empty-title {
+    font-size: 1.1rem;
     font-weight: 600;
-    display: block;
     margin-bottom: 0.5rem;
-
-    &:hover {
-      color: $accent-blue;
-    }
   }
 
-  small {
-    color: $text-secondary;
-    font-size: 0.85rem;
+  .search-empty-query {
+    font-size: 0.9rem;
+    opacity: 0.7;
   }
 }
 
@@ -5816,9 +5897,24 @@ a:focus-visible {
   }
 
   .search-result-item {
-    border-bottom-color: rgba(208, 215, 222, 0.3);
-    a { color: var(--text-primary); &:hover { color: var(--accent-blue); } }
-    small { color: var(--text-secondary); }
+    background: rgba(246, 248, 250, 0.8);
+    border-color: rgba(208, 215, 222, 0.5);
+    color: var(--text-primary);
+    &:hover, &:focus { background: #ffffff; border-color: var(--accent-blue); }
+  }
+
+  .search-result-title mark,
+  .search-result-snippet mark {
+    background: rgba(9, 105, 218, 0.15);
+    color: var(--text-primary);
+  }
+
+  .search-result-date,
+  .search-result-tag,
+  .search-result-snippet,
+  .search-result-count,
+  .search-empty-state {
+    color: var(--text-secondary);
   }
 
   // Stat items

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,69 +1,212 @@
 document.addEventListener('DOMContentLoaded', function() {
-  // Mobile nav toggle
-  const navToggle = document.querySelector('.nav-toggle');
-  const siteNav = document.querySelector('.site-nav');
-  if (navToggle && siteNav) {
-    navToggle.addEventListener('click', function() {
-      siteNav.classList.toggle('active');
-    });
-  }
-
-  // Simple search functionality
-  const searchInput = document.getElementById('search-input');
-  const searchResults = document.getElementById('search-results');
+  var searchInput = document.getElementById('search-input');
+  var searchResults = document.getElementById('search-results');
   if (!searchInput || !searchResults) return;
 
-  let posts = [];
-  fetch(searchInput.dataset.baseurl + '/search.json')
-    .then(function(response) { return response.json(); })
+  var posts = [];
+  var baseurl = searchInput.dataset.baseurl || '';
+
+  fetch(baseurl + '/search.json')
+    .then(function(r) { return r.json(); })
     .then(function(data) { posts = data; })
     .catch(function() { /* search index not available */ });
 
+  function t(key) {
+    return (typeof window.__t === 'function') ? window.__t(key) : key;
+  }
+
+  function escapeHtml(str) {
+    var div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  function highlightText(text, query) {
+    if (!text || !query) return escapeHtml(text || '');
+    var escaped = escapeHtml(text);
+    var regex = new RegExp('(' + query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'gi');
+    return escaped.replace(regex, '<mark>$1</mark>');
+  }
+
+  function getExcerptAround(text, query, maxLen) {
+    if (!text) return '';
+    var lower = text.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    if (idx === -1) return text.substring(0, maxLen);
+    var start = Math.max(0, idx - 40);
+    var end = Math.min(text.length, idx + query.length + 120);
+    var snippet = '';
+    if (start > 0) snippet += '...';
+    snippet += text.substring(start, end);
+    if (end < text.length) snippet += '...';
+    return snippet;
+  }
+
+  function getCategoryClass(cat) {
+    if (!cat) return '';
+    var lower = cat.toLowerCase();
+    if (lower.indexOf('crypto') !== -1) return 'cat-crypto';
+    if (lower.indexOf('stock') !== -1 || lower.indexOf('주식') !== -1) return 'cat-stock';
+    if (lower.indexOf('journal') !== -1 || lower.indexOf('저널') !== -1) return 'cat-journal';
+    if (lower.indexOf('security') !== -1 || lower.indexOf('보안') !== -1) return 'cat-security';
+    if (lower.indexOf('analysis') !== -1 || lower.indexOf('분석') !== -1) return 'cat-analysis';
+    if (lower.indexOf('regulat') !== -1 || lower.indexOf('규제') !== -1) return 'cat-regulatory';
+    if (lower.indexOf('politic') !== -1 || lower.indexOf('정치') !== -1) return 'cat-political';
+    return '';
+  }
+
+  function scoreResult(post, query) {
+    var score = 0;
+    var q = query.toLowerCase();
+    var title = (post.title || '').toLowerCase();
+    var tags = (post.tags || '').toLowerCase();
+    var categories = (post.categories || '').toLowerCase();
+    var excerpt = (post.excerpt || '').toLowerCase();
+    var content = (post.content || '').toLowerCase();
+
+    if (title === q) score += 100;
+    else if (title.indexOf(q) === 0) score += 80;
+    else if (title.indexOf(q) !== -1) score += 60;
+
+    if (tags.indexOf(q) !== -1) score += 40;
+    if (categories.indexOf(q) !== -1) score += 30;
+    if (excerpt.indexOf(q) !== -1) score += 20;
+    if (content.indexOf(q) !== -1) score += 10;
+
+    return score;
+  }
+
+  var debounceTimer;
   searchInput.addEventListener('input', function() {
-    var query = this.value.toLowerCase().trim();
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(function() {
+      performSearch();
+    }, 200);
+  });
+
+  function performSearch() {
+    var query = searchInput.value.trim();
     if (query.length < 2) {
-      searchResults.textContent = '';
+      searchResults.innerHTML = '';
       var hint = document.createElement('div');
-      hint.style.cssText = 'text-align: center; padding: 3rem; color: #8b949e;';
-      var hintP = document.createElement('p');
-      hintP.textContent = (typeof window.__t === 'function') ? window.__t('search_min_hint') : '검색어를 2자 이상 입력해주세요.';
-      hint.appendChild(hintP);
+      hint.className = 'search-empty-state';
+      hint.innerHTML = '<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>' +
+        '<p>' + escapeHtml(t('search_min_hint')) + '</p>';
       searchResults.appendChild(hint);
       return;
     }
 
-    var results = posts.filter(function(post) {
-      return post.title.toLowerCase().indexOf(query) !== -1 ||
-             (post.tags && post.tags.toLowerCase().indexOf(query) !== -1) ||
-             (post.categories && post.categories.toLowerCase().indexOf(query) !== -1);
-    }).slice(0, 10);
+    var q = query.toLowerCase();
+    var results = [];
+    for (var i = 0; i < posts.length; i++) {
+      var post = posts[i];
+      var s = scoreResult(post, q);
+      if (s > 0) {
+        results.push({ post: post, score: s });
+      }
+    }
+
+    results.sort(function(a, b) { return b.score - a.score; });
+    results = results.slice(0, 15);
+
+    searchResults.innerHTML = '';
 
     if (results.length === 0) {
-      searchResults.textContent = '';
       var noDiv = document.createElement('div');
-      noDiv.style.cssText = 'text-align: center; padding: 3rem; color: #8b949e;';
-      var noResultsText = (typeof window.__t === 'function') ? window.__t('no_results') : '검색 결과가 없습니다';
-      noDiv.innerHTML = '<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="opacity: 0.5; margin-bottom: 1rem;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg><p style="font-size: 1.1rem; font-weight: 600; margin-bottom: 0.5rem;">' + noResultsText + '</p>';
-      var noResultsFor = (typeof window.__t === 'function') ? window.__t('no_results_for') : '에 대한 포스트를 찾을 수 없습니다.';
-      var queryP = document.createElement('p');
-      queryP.textContent = '"' + query + '" ' + noResultsFor;
-      noDiv.appendChild(queryP);
+      noDiv.className = 'search-empty-state';
+      noDiv.innerHTML = '<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>' +
+        '<p class="search-empty-title">' + escapeHtml(t('no_results')) + '</p>' +
+        '<p class="search-empty-query">"' + escapeHtml(query) + '" ' + escapeHtml(t('no_results_for')) + '</p>';
       searchResults.appendChild(noDiv);
       return;
     }
 
-    searchResults.textContent = '';
-    results.forEach(function(post) {
-      var item = document.createElement('div');
+    var countDiv = document.createElement('div');
+    countDiv.className = 'search-result-count';
+    countDiv.textContent = results.length + (results.length >= 15 ? '+' : '') + ' results';
+    searchResults.appendChild(countDiv);
+
+    for (var j = 0; j < results.length; j++) {
+      var post = results[j].post;
+      var item = document.createElement('a');
+      item.href = post.url;
       item.className = 'search-result-item';
-      var link = document.createElement('a');
-      link.href = post.url;
-      link.textContent = post.title;
-      var meta = document.createElement('small');
-      meta.textContent = post.date + ' | ' + post.categories;
-      item.appendChild(link);
-      item.appendChild(meta);
+
+      var titleDiv = document.createElement('div');
+      titleDiv.className = 'search-result-title';
+      titleDiv.innerHTML = highlightText(post.title, query);
+
+      var metaDiv = document.createElement('div');
+      metaDiv.className = 'search-result-meta';
+
+      var dateSpan = document.createElement('span');
+      dateSpan.className = 'search-result-date';
+      dateSpan.textContent = post.date;
+      metaDiv.appendChild(dateSpan);
+
+      if (post.categories) {
+        var catSpan = document.createElement('span');
+        catSpan.className = 'search-result-cat ' + getCategoryClass(post.categories);
+        catSpan.textContent = post.categories;
+        metaDiv.appendChild(catSpan);
+      }
+
+      if (post.tags) {
+        var tagsArr = post.tags.split(', ');
+        for (var k = 0; k < Math.min(tagsArr.length, 3); k++) {
+          var tagSpan = document.createElement('span');
+          tagSpan.className = 'search-result-tag';
+          tagSpan.textContent = '#' + tagsArr[k];
+          metaDiv.appendChild(tagSpan);
+        }
+      }
+
+      item.appendChild(titleDiv);
+      item.appendChild(metaDiv);
+
+      var searchText = post.excerpt || post.content || '';
+      if (searchText) {
+        var snippetDiv = document.createElement('div');
+        snippetDiv.className = 'search-result-snippet';
+        snippetDiv.innerHTML = highlightText(getExcerptAround(searchText, query, 160), query);
+        item.appendChild(snippetDiv);
+      }
+
       searchResults.appendChild(item);
-    });
+    }
+  }
+
+  // Keyboard navigation
+  searchInput.addEventListener('keydown', function(e) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      var first = searchResults.querySelector('.search-result-item');
+      if (first) first.focus();
+    }
+  });
+
+  searchResults.addEventListener('keydown', function(e) {
+    var current = document.activeElement;
+    if (!current || !current.classList.contains('search-result-item')) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      var next = current.nextElementSibling;
+      while (next && !next.classList.contains('search-result-item')) {
+        next = next.nextElementSibling;
+      }
+      if (next) next.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      var prev = current.previousElementSibling;
+      while (prev && !prev.classList.contains('search-result-item')) {
+        prev = prev.previousElementSibling;
+      }
+      if (prev) prev.focus();
+      else searchInput.focus();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      window.location.href = current.href;
+    }
   });
 });

--- a/search.json
+++ b/search.json
@@ -8,7 +8,9 @@ layout: null
     "url": "{{ post.url | relative_url }}",
     "date": "{{ post.date | date: '%Y-%m-%d' }}",
     "categories": {{ post.categories | join: ', ' | jsonify }},
-    "tags": {{ post.tags | join: ', ' | jsonify }}
+    "tags": {{ post.tags | join: ', ' | jsonify }},
+    "excerpt": {{ post.excerpt | strip_html | strip_newlines | truncate: 200 | jsonify }},
+    "content": {{ post.content | strip_html | strip_newlines | truncate: 500 | jsonify }}
   }{% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
## Summary
- `search.js`가 레이아웃에 로드되지 않아 검색이 동작하지 않던 문제 수정
- `search.json`에 excerpt/content 필드 추가로 포스트 본문 검색 지원
- 검색 결과에 하이라이트, 카테고리 배지, 태그, 본문 스니펫 표시
- 관련도 점수 기반 정렬 및 키보드 내비게이션(화살표/Enter) 지원

## Test plan
- [ ] 검색 아이콘 클릭 → 오버레이 열림 → 검색어 입력 시 결과 표시
- [ ] 포스트 제목, 태그, 카테고리, 본문 내용으로 검색 가능 확인
- [ ] 검색어 하이라이트 표시 확인 (제목, 본문 스니펫)
- [ ] 카테고리 배지 색상별 표시 확인
- [ ] 키보드: 화살표 위/아래 탐색, Enter 이동
- [ ] 다크/라이트 모드 검색 결과 스타일 확인
- [ ] 모바일 반응형 검색 오버레이 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)