### PR TITLE
perf: Vercel 배포 설정 최적화

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,13 @@
+scripts/
+_state/
+.github/
+.claude/
+.omc/
+.venv/
+.env
+.env.example
+docs/
+*.pyc
+__pycache__/
+.ruff_cache/
+opencode.json

--- a/vercel.json
+++ b/vercel.json
@@ -2,13 +2,16 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "jekyll",
   "installCommand": "bundle install --jobs 4 --retry 3",
-  "buildCommand": "bundle exec jekyll build --config _config.yml",
+  "buildCommand": "JEKYLL_ENV=production bundle exec jekyll build --config _config.yml",
   "outputDirectory": "_site",
+  "regions": ["icn1"],
+  "trailingSlash": true,
+  "ignoreCommand": "bash -c 'git diff HEAD^ HEAD --name-only | grep -qvE \"^(scripts/|_state/|\\.github/|\\.claude/|\\.omc/|docs/|README\\.md|opencode\\.json)\"'",
   "redirects": [
     {
       "source": "/investing/:path*",
       "destination": "/:path*",
-      "permanent": false
+      "permanent": true
     }
   ],
   "headers": [
@@ -20,11 +23,17 @@
         { "key": "X-XSS-Protection", "value": "1; mode=block" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" }
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" }
       ]
     },
     {
-      "source": "/assets/(.*)",
+      "source": "/assets/css/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/assets/js/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
@@ -33,6 +42,30 @@
       "source": "/assets/images/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/assets/fonts/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/search.json",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=600, stale-while-revalidate=86400" }
+      ]
+    },
+    {
+      "source": "/feed.xml",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=600, stale-while-revalidate=86400" }
+      ]
+    },
+    {
+      "source": "/sitemap.xml",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- `ignoreCommand` 추가로 사이트 무관 변경(scripts, _state, .github 등) 시 빌드 스킵 → rate limit 방지
- `.vercelignore` 추가로 불필요 파일 업로드 제거 (빌드 속도 개선)
- `regions: icn1` (서울) 설정으로 한국 사용자 응답 속도 개선
- 캐시 전략 세분화: 정적 자산(1년 immutable), API/피드(5분+SWR), 사이트맵(1시간+SWR)

## Test plan
- [ ] Vercel 빌드 정상 동작 확인
- [ ] scripts/ 전용 커밋 시 빌드 스킵 확인
- [ ] 사이트 접속 및 정적 자산 캐시 헤더 확인
- [ ] trailing slash 리다이렉트 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)