### PR TITLE
fix: GitHub Pages 빌드 최적화 및 헬스체크 429 오탐 방지

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,22 @@ name: Deploy Jekyll to GitHub Pages
 on:
   push:
     branches: ["main"]
+    paths:
+      - '_posts/**'
+      - '_layouts/**'
+      - '_includes/**'
+      - '_sass/**'
+      - '_data/**'
+      - '_config.yml'
+      - '_config_ghpages.yml'
+      - 'assets/**'
+      - 'pages/**'
+      - 'search.json'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'index.html'
+      - 'index.md'
+      - 'feed.xml'
   workflow_dispatch:
 
 permissions:
@@ -31,14 +47,6 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-
-      - name: Resolve Vercel scope context
-        run: |
-          if command -v vercel >/dev/null 2>&1; then
-            bash scripts/vercel_scope.sh context
-          else
-            echo "vercel CLI not installed in this job; skipping scope context check"
-          fi
 
       - name: Build with Jekyll
         run: bundle exec jekyll build --config _config.yml,_config_ghpages.yml --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/.github/workflows/site-health-check.yml
+++ b/.github/workflows/site-health-check.yml
@@ -21,24 +21,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Resolve Vercel scope context
-        run: |
-          if command -v vercel >/dev/null 2>&1; then
-            bash scripts/vercel_scope.sh context
-          else
-            echo "vercel CLI not installed in this job; skipping scope context check"
-          fi
-
       - name: Check site availability
         id: site_check
         run: |
           SITE_URL="https://investing.2twodragon.com/"
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$SITE_URL" --max-time 30 || echo "000")
+          MAX_RETRIES=3
+          RETRY_DELAY=30
+          HTTP_CODE="000"
+
+          for i in $(seq 1 $MAX_RETRIES); do
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$SITE_URL" --max-time 30 || echo "000")
+            echo "Attempt $i: HTTP $HTTP_CODE"
+
+            if [ "$HTTP_CODE" -eq 200 ]; then
+              echo "✅ Site is up (HTTP $HTTP_CODE)"
+              break
+            elif [ "$HTTP_CODE" -eq 429 ]; then
+              echo "⏳ Rate limited (429) - waiting ${RETRY_DELAY}s before retry..."
+              sleep $RETRY_DELAY
+              RETRY_DELAY=$((RETRY_DELAY * 2))
+            else
+              echo "❌ Site returned HTTP $HTTP_CODE"
+              break
+            fi
+          done
+
           echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
-          if [ "$HTTP_CODE" -eq 200 ]; then
-            echo "✅ Site is up (HTTP $HTTP_CODE)"
+          if [ "$HTTP_CODE" -eq 429 ]; then
+            echo "⚠️ Rate limit persisted after $MAX_RETRIES retries (not a real outage)"
+            echo "is_rate_limit=true" >> "$GITHUB_OUTPUT"
           else
-            echo "❌ Site returned HTTP $HTTP_CODE"
+            echo "is_rate_limit=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check recent posts exist
@@ -77,7 +90,7 @@ jobs:
           done
 
       - name: Create issue on failure
-        if: steps.site_check.outputs.http_code != '200'
+        if: steps.site_check.outputs.http_code != '200' && steps.site_check.outputs.is_rate_limit != 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -113,7 +126,7 @@ jobs:
 
       - name: Resolve Slack config
         id: slack
-        if: steps.site_check.outputs.http_code != '200'
+        if: steps.site_check.outputs.http_code != '200' && steps.site_check.outputs.is_rate_limit != 'true'
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: ops
@@ -134,7 +147,7 @@ jobs:
             ${{ secrets.SLACK_CHANNEL }}
 
       - name: Alert Slack on site failure
-        if: steps.site_check.outputs.http_code != '200' && steps.slack.outputs.can_post == 'true'
+        if: steps.site_check.outputs.http_code != '200' && steps.site_check.outputs.is_rate_limit != 'true' && steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@v2.1.1
         with:
           method: chat.postMessage


### PR DESCRIPTION
## Summary
- `deploy-pages.yml`에 path 필터 추가: scripts/, _state/, .github/ 변경 시 빌드 스킵으로 불필요한 배포 방지
- `site-health-check.yml` 429 rate limit 재시도 로직 (3회, 지수 백오프) 및 오탐 방지
- 양쪽 워크플로우에서 불필요한 `vercel_scope` 단계 제거

## Test plan
- [ ] scripts/ 전용 커밋 시 deploy-pages 워크플로우 미트리거 확인
- [ ] _posts/ 변경 시 deploy-pages 정상 트리거 확인
- [ ] workflow_dispatch로 수동 실행 가능 확인
- [ ] 헬스체크에서 429 시 이슈/Slack 미발송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)