### PR TITLE
feat: 포스트 품질 및 한국어 처리 개선

### DIFF
--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -48,6 +48,12 @@ def _clean_description(text: str) -> str:
         "Click here ",
         "Share this ",
         "Follow us ",
+        # Korean boilerplate
+        "무단전재 및 재배포 금지",
+        "저작권자 ©",
+        "기사제보 및 보도자료",
+        "네이버 뉴스스탠드에서",
+        "카카오톡에서 받아보기",
     ]:
         if text.startswith(noise):
             return ""
@@ -64,7 +70,12 @@ def _clean_description(text: str) -> str:
     text = re.sub(
         r"\s+[-–—]?\s*(?:디지털투데이|연합인포맥스|펜앤마이크|네이트|복지TV\S*"
         r"|ER\s*이코노믹리뷰|v\.daum\.net|매일경제|한국경제|조선일보|중앙일보"
-        r"|경향신문|한겨레|BBS불교방송|이데일리|뉴시스|아시아경제)\s*$",
+        r"|경향신문|한겨레|BBS불교방송|이데일리|뉴시스|아시아경제"
+        r"|서울경제|뉴스1|노컷뉴스|SBS뉴스|MBC뉴스|KBS뉴스|JTBC|채널A|TV조선|연합뉴스"
+        r"|파이낸셜뉴스|헤럴드경제|머니투데이|더팩트|데일리안|뉴데일리|오마이뉴스"
+        r"|프레시안|시사저널|주간조선|한겨레21|인사이트|위키트리|ZDNet\s*Korea"
+        r"|핀포인트뉴스|공감신문|브레이크뉴스|한국글로벌뉴스|gukjenews\.com|ilyoseoul\.co\.kr"
+        r")\s*$",
         "",
         text,
     )
@@ -252,7 +263,33 @@ def _extract_title_entities(title: str) -> list:
     # Korean entities (2+ chars)
     kr_entities = re.findall(r"[가-힣]{2,}", title)
     # Proper nouns (capitalized words, not common English)
-    _COMMON = {"The", "And", "For", "With", "Has", "Are", "Its", "But", "How", "Why", "What", "New", "All", "Can"}
+    _COMMON = {
+        "The", "And", "For", "With", "Has", "Are", "Its", "But", "How", "Why",
+        "What", "New", "All", "Can", "Now", "Get", "Set", "May", "Not",
+        "Other", "Others", "Another", "Being", "Having", "Doing",
+        "Becomes", "Become", "Getting", "Going", "Coming", "Making",
+        "Says", "Said", "Warns", "Faces", "Shows", "Finds", "Takes",
+        "Gives", "Looks", "Tells", "Seems", "Turns", "Leads", "Holds",
+        "Spikes", "Spike", "Surges", "Surge", "Drops", "Drop", "Falls",
+        "First", "Last", "Next", "After", "Before", "During", "Under",
+        "Over", "About", "Every", "Where", "Which", "While", "Their",
+        "These", "Those", "Could", "Would", "Should", "Might", "Still",
+        "Just", "Also", "More", "Most", "Some", "Much", "Many", "Each",
+        "Only", "Even", "Very", "Here", "There", "Then", "Than", "Into",
+        "From", "This", "That", "Been", "Were", "Will", "Your", "They",
+        "Them", "Such", "Like", "Near", "Amid", "Ahead", "Along",
+        "Among", "Above", "Below", "Behind", "Between", "Through",
+        "Against", "Within", "Without", "Across", "Inside",
+        "Global", "World", "Major", "Latest", "Breaking", "Live",
+        "Watch", "Alert", "Update", "Report", "Check",
+        "Shares", "Stock", "Stocks", "Market", "Markets",
+        "Price", "Prices", "Trade", "Trades", "Trading",
+        "Company", "Companies", "Industry",
+        "Million", "Billion", "Trillion",
+        "Today", "Yesterday", "Tomorrow", "Year", "Week", "Month",
+    }
+    _NOISE_TICKERS = {"CEO", "IPO", "SEC", "FED", "GDP", "CPI", "ETF", "AI", "USD", "FOR", "THE", "ARE", "HAS", "NOT", "BUT", "ALL", "CAN", "NOW", "HOW", "NEW", "CBS", "FBI", "GOP"}
+    tickers = [t for t in tickers if t not in _NOISE_TICKERS]
     proper = [w for w in re.findall(r"\b[A-Z][a-z]{2,}\b", title) if w not in _COMMON]
 
     entities.extend(values)
@@ -332,6 +369,30 @@ def _analyze_korean_title(title: str) -> str:
 
     if any(kw in title for kw in ["관세", "무역", "수출", "수입"]):
         return "통상·무역 정책 관련 소식입니다. 글로벌 공급망과 수출 기업 실적에 영향을 줄 수 있습니다."
+
+    if any(kw in title for kw in ["배당", "주주환원", "자사주"]):
+        return "배당·주주환원 정책 관련 소식입니다. 배당 수익률과 자사주 매입 규모가 주가에 긍정적 영향을 줄 수 있습니다."
+
+    if any(kw in title for kw in ["부동산", "아파트", "전세", "분양"]):
+        return "부동산 시장 관련 소식입니다. 금리·정책 변화에 따른 부동산 시장 흐름을 주시해야 합니다."
+
+    if any(kw in title for kw in ["인수", "합병", "M&A"]):
+        return "기업 인수·합병(M&A) 관련 소식입니다. 인수 프리미엄과 시너지 효과가 양사 주가에 영향을 줍니다."
+
+    if any(kw in title for kw in ["디파이", "디지털자산", "가상자산", "코인", "블록체인"]):
+        return "디지털 자산·블록체인 관련 소식입니다. 규제 동향과 기술 발전이 시장 방향의 핵심 변수입니다."
+
+    if any(kw in title for kw in ["AI", "인공지능", "챗봇", "생성형"]):
+        return "AI·인공지능 관련 소식입니다. AI 산업 성장에 따른 관련주 투자 기회를 점검해 보세요."
+
+    if any(kw in title for kw in ["2차전지", "배터리", "전기차", "EV"]):
+        return "2차전지·전기차 관련 소식입니다. 글로벌 전기차 수요와 배터리 기술 경쟁이 섹터 성장을 좌우합니다."
+
+    if any(kw in title for kw in ["외국인", "기관", "순매수", "순매도", "수급"]):
+        return "외국인·기관 수급 동향입니다. 대규모 순매수/순매도는 시장 방향성의 중요한 선행 지표입니다."
+
+    if any(kw in title for kw in ["실적", "어닝", "매출", "영업이익"]):
+        return "기업 실적 관련 소식입니다. 실적 서프라이즈 여부와 컨센서스 대비 결과가 주가 방향을 결정합니다."
 
     # Fallback: extract key nouns from title
     nouns = re.findall(r"[가-힣]{2,}", title)[:3]
@@ -417,6 +478,27 @@ def _analyze_english_title(title: str, title_lower: str) -> str:
     if any(kw in title_lower for kw in ["daylight", "spring forward"]):
         return "서머타임(DST) 전환이 증시에 미치는 영향을 분석한 기사입니다. 계절적 패턴 참고용 데이터입니다."
 
+    if any(kw in title_lower for kw in ["gold", "silver", "precious metal"]):
+        return "귀금속 시장 관련 소식입니다. 금·은 가격은 인플레이션 헤지와 안전자산 수요의 바로미터입니다."
+
+    if any(kw in title_lower for kw in ["real estate", "housing", "mortgage"]):
+        return "부동산·주택 시장 관련 소식입니다. 모기지 금리와 주택 공급이 경기 흐름의 핵심 지표입니다."
+
+    if any(kw in title_lower for kw in ["m&a", "merger", "acquisition", "takeover"]):
+        return "기업 인수·합병(M&A) 관련 소식입니다. 딜 성사 여부와 인수 프리미엄이 관련주 가격에 영향을 미칩니다."
+
+    if any(kw in title_lower for kw in ["dividend", "buyback", "shareholder"]):
+        return "배당·주주환원 관련 소식입니다. 배당 정책 변화와 자사주 매입은 장기 투자 매력도를 높입니다."
+
+    if any(kw in title_lower for kw in ["china", "chinese", "beijing"]):
+        return "중국 경제·시장 관련 소식입니다. 중국 경기 흐름은 글로벌 원자재·무역에 직접적 영향을 미칩니다."
+
+    if any(kw in title_lower for kw in ["japan", "yen", "nikkei", "boj"]):
+        return "일본 경제·시장 관련 소식입니다. 엔화 약세와 BOJ 정책이 글로벌 캐리트레이드에 영향을 줍니다."
+
+    if any(kw in title_lower for kw in ["eu ", "europe", "euro", "ecb"]):
+        return "유럽 경제·시장 관련 소식입니다. ECB 통화정책과 유럽 경기 흐름이 글로벌 시장에 영향을 미칩니다."
+
     # Fallback: extract meaningful entities
     entities = _extract_title_entities(title)
     if entities:
@@ -449,7 +531,10 @@ def generate_synthetic_description(
         return f"{label} 공지사항입니다." + (f" ({entity_str})" if entity_str else "")
 
     if entity_str:
-        return f"{entity_str} 관련 시장 뉴스입니다. 투자 판단 시 원문을 확인하세요."
+        return f"{label}에서 {entity_str} 관련 소식을 전했습니다."
+    # Final fallback: use source label for minimal context
+    if label and label != source:
+        return f"{label}에서 보도한 소식입니다. 원문에서 세부 내용을 확인하세요."
     return title
 
 
@@ -557,7 +642,15 @@ def enrich_items(
                 item["title_ko"] = ko
 
         desc = item.get("description", "")
-        if desc and detect_language(desc) == "en" and not desc.startswith(("구글 뉴스", "에서 보도")):
+        if desc and detect_language(desc) == "en" and not any(
+            desc.startswith(prefix) for prefix in (
+                "구글 뉴스", "에서 보도", "시장", "규제", "암호화폐", "비트코인",
+                "이더리움", "거래소", "연준", "인플레이션", "미국", "한국",
+                "관세", "지정학", "기업 실적", "고용", "보안", "금융",
+                "AI·", "반도체", "원유", "귀금속", "부동산", "배당",
+                "디지털", "2차전지", "외국인", "중국", "일본", "유럽",
+            )
+        ):
             ko_desc = translate_to_korean(desc)
             if ko_desc != desc:
                 item["description_ko"] = ko_desc

--- a/scripts/common/rss_fetcher.py
+++ b/scripts/common/rss_fetcher.py
@@ -25,6 +25,46 @@ def get_feed_health() -> Dict[str, Dict[str, Any]]:
     return dict(_feed_health)
 
 
+# Common source suffixes to strip from RSS titles
+_SOURCE_SUFFIX_RE = re.compile(
+    r"\s*[-–—|]\s*(?:"
+    # English media
+    r"Reuters|Bloomberg|CNBC|CNN|BBC|AP\s*(?:News)?|Forbes|WSJ"
+    r"|Yahoo\s*Finance|MarketWatch|The\s*(?:Block|Verge|Guardian)"
+    r"|CBS\s*(?:News|뉴스)?|NBC\s*News|ABC\s*News|Fox\s*(?:News|Business)"
+    r"|Variety|Barron'?s|Motley\s*Fool|Nasdaq"
+    # Korean media
+    r"|디지털투데이|연합인포맥스|펜앤마이크|네이트|복지TV\S*"
+    r"|이코노믹리뷰|매일경제|한국경제|조선일보|중앙일보"
+    r"|경향신문|한겨레|이데일리|뉴시스|아시아경제"
+    r"|서울경제|뉴스1|노컷뉴스|SBS뉴스|MBC뉴스|KBS뉴스"
+    r"|JTBC|채널A|TV조선|연합뉴스|파이낸셜뉴스"
+    r"|헤럴드경제|머니투데이|더팩트|데일리안|뉴데일리"
+    r"|오마이뉴스|프레시안|시사저널|공감신문|브레이크뉴스"
+    r"|한국글로벌뉴스|핀포인트뉴스|글로벌이코노믹|비즈니스포스트|토큰포스트|블록미디어|코인데스크코리아|디센터"
+    r"|전자신문|ZDNet\s*Korea|IT조선|디지털데일리|바이라인네트워크"
+    r"|BBS불교방송|ER\s*이코노믹리뷰"
+    # Domain suffixes
+    r"|v\.daum\.net|gukjenews\.com|ilyoseoul\.co\.kr"
+    r"|ir\.edaily\.co\.kr|simplywall\.st"
+    r"|[a-z][a-z0-9-]*\.(?:com|co\.kr|net|org|io)"
+    r")\s*$",
+    re.IGNORECASE,
+)
+
+
+def _clean_rss_title(title: str) -> str:
+    """Remove trailing source names and decorative markers from RSS titles."""
+    cleaned = _SOURCE_SUFFIX_RE.sub("", title).strip()
+    # Remove decorative prefixes like "▒종합 경제정보 미디어 - 이데일리IR▒"
+    cleaned = re.sub(r"^[▒▶▷►◆◇■□●○※☆★\[\]【】〔〕]+\s*", "", cleaned)
+    cleaned = re.sub(r"\s*[▒▶▷►◆◇■□●○※☆★\[\]【】〔〕]+\s*$", "", cleaned)
+    # Remove Korean news category tags like "[속보]", "[단독]", "(종합)", "(1보)"
+    cleaned = re.sub(r"^\s*[\[〈<]\s*(?:속보|단독|긴급|종합|1보|2보|3보|포토|영상|인터뷰)\s*[\]〉>]\s*", "", cleaned)
+    cleaned = re.sub(r"^\s*\(\s*(?:속보|단독|종합|1보|2보|3보)\s*\)\s*", "", cleaned)
+    return cleaned if len(cleaned) >= 10 else title
+
+
 def fetch_rss_feed(
     url: str,
     source_name: str,
@@ -94,6 +134,16 @@ def fetch_rss_feed(
                 if desc_el:
                     raw_desc = desc_el.get_text(strip=True)
                     cleaned_desc = BeautifulSoup(raw_desc, "html.parser").get_text(" ", strip=True)
+                    # Remove Korean news boilerplate
+                    cleaned_desc = re.sub(
+                        r"(?:무단\s*전재\s*및\s*재배포\s*금지|저작권자\s*©[^.]*\.|"
+                        r"기사제보[^.]*\.|ⓒ[^.]*\.)",
+                        "",
+                        cleaned_desc,
+                    )
+                    # Remove trailing whitespace/dots artifacts
+                    cleaned_desc = re.sub(r"\s*\.{2,}\s*$", "", cleaned_desc)
+                    cleaned_desc = re.sub(r"\s+", " ", cleaned_desc).strip()
                     description = truncate_sentence(sanitize_string(cleaned_desc, 600), 300)
 
                 published_str = date_el.get_text(strip=True) if date_el else ""
@@ -106,6 +156,7 @@ def fetch_rss_feed(
                             continue
 
                 title = remove_sponsored_text(title)
+                title = _clean_rss_title(title)
                 description = remove_sponsored_text(description)
 
                 # Extract image URL from RSS entry

--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -86,12 +86,15 @@ def _generate_title_based_desc(title: str, theme_key: str) -> str:
         "altcoin": "알트코인 시장 동향 관련 소식입니다.",
         "regulation": "암호화폐 규제 및 정책 관련 소식입니다.",
         "price": "가격 및 시장 움직임 관련 소식입니다.",
+        "price_market": "가격 및 시장 움직임 관련 소식입니다.",
         "defi": "탈중앙화 금융(DeFi) 관련 소식입니다.",
         "nft": "NFT 및 디지털 자산 관련 소식입니다.",
+        "nft_web3": "NFT·Web3 생태계 관련 소식입니다.",
         "exchange": "거래소 동향 관련 소식입니다.",
         "macro": "거시경제 및 금리 관련 소식입니다.",
         "ai_tech": "AI 및 기술 관련 소식입니다.",
         "politics": "정치 및 정책 관련 소식입니다.",
+        "security": "보안 및 해킹 관련 소식입니다.",
     }
 
     # Check if title is already Korean
@@ -104,10 +107,17 @@ def _generate_title_based_desc(title: str, theme_key: str) -> str:
             return f"{clean}. {ctx}"
         return clean
 
-    # English title: provide analytical context
+    # English title: provide analytical context in Korean
     ctx = _THEME_CONTEXT.get(theme_key, "관련 소식입니다.")
-    # Remove source suffix (e.g., " - Reuters", " | Bloomberg")
-    clean = re.sub(r"\s*[-–—|]\s*(?:Reuters|Bloomberg|CNBC|CNN|BBC|AP|Forbes|WSJ)\s*$", "", title, flags=re.I).strip()
+    # Remove source suffix (expanded list)
+    clean = re.sub(
+        r"\s*[-–—|]\s*(?:Reuters|Bloomberg|CNBC|CNN|BBC|AP|Forbes|WSJ"
+        r"|MarketWatch|Yahoo\s*Finance|The\s*(?:Block|Verge|Guardian)"
+        r"|Decrypt|CoinDesk|CoinTelegraph|Barron'?s)\s*$",
+        "",
+        title,
+        flags=re.I,
+    ).strip()
     if len(clean) > 120:
         clean = clean[:117] + "..."
     return f"{clean} — {ctx}"
@@ -115,10 +125,15 @@ def _generate_title_based_desc(title: str, theme_key: str) -> str:
 
 _GENERIC_DESC_PATTERNS = [
     re.compile(r"에서 보도한 뉴스입니다\.?$"),
+    re.compile(r"에서 보도한 소식입니다\.?$"),
+    re.compile(r"관련 소식을 전했습니다\.?$"),
+    re.compile(r"원문에서 세부 내용을 확인하세요\.?$"),
     re.compile(r"거래소 공지사항입니다\.?\s*$"),
     re.compile(r"please enable javascript", re.I),
     re.compile(r"^AMENDMENT NO\.", re.I),
     re.compile(r"^FORM\s+\d", re.I),
+    re.compile(r"^access denied", re.I),
+    re.compile(r"^403 forbidden", re.I),
 ]
 
 
@@ -1222,6 +1237,96 @@ class ThemeSummarizer:
         "방안부터",
         "전망까지",
         "주요뉴스",
+        # Additional English stop words
+        "for",
+        "you",
+        "crypto",
+        "cryptocurrency",
+        "blockchain",
+        "token",
+        "tokens",
+        "digital",
+        "asset",
+        "assets",
+        "trading",
+        "exchange",
+        "becomes",
+        "become",
+        "becoming",
+        "others",
+        "another",
+        "being",
+        "having",
+        "doing",
+        "going",
+        "getting",
+        "million",
+        "billion",
+        "trillion",
+        "during",
+        "without",
+        "within",
+        "against",
+        "really",
+        "already",
+        "enough",
+        "announces",
+        "announced",
+        "announcement",
+        "reports",
+        "reported",
+        "company",
+        "companies",
+        "global",
+        "world",
+        "international",
+        "major",
+        "breaking",
+        "shares",
+        "investors",
+        "investor",
+        "article",
+        "source",
+        "watch",
+        "alert",
+        "warns",
+        # Additional Korean stop words
+        "텔레그램",
+        "전송",
+        "알려진",
+        "보도",
+        "발표",
+        "것으로",
+        "있는",
+        "따르면",
+        "한다",
+        "있다",
+        "했다",
+        "된다",
+        "라고",
+        "에서",
+        "이번",
+        "통해",
+        "대해",
+        "위해",
+        "가운데",
+        "것이",
+        "하는",
+        "것을",
+    }
+
+    _NOISE_ENGLISH = {
+        "becomes", "become", "becoming", "spikes", "spike",
+        "gets", "getting", "other", "others", "another",
+        "makes", "making", "takes", "taking", "going",
+        "coming", "shows", "showing", "looks", "looking",
+        "gives", "giving", "being", "having", "doing",
+        "finds", "finding", "seems", "tells",
+        "warns", "warning", "faces", "facing", "says",
+        "might", "could", "should", "would", "every",
+        "where", "which", "while", "until", "since",
+        "among", "along", "above", "below", "ahead",
+        "across", "behind", "before", "during", "inside",
     }
 
     def _extract_title_keywords(self, articles: List[Dict[str, Any]], max_keywords: int = 5) -> List[str]:
@@ -1237,7 +1342,7 @@ class ThemeSummarizer:
             tokens = re.findall(r"\$[\d,.]+[KkMmBb]?%?|[\d,.]+%|[A-Za-z]{3,}|[가-힣]{2,}", title)
             for token in tokens:
                 normalized = token.lower() if re.match(r"[A-Za-z]", token) else token
-                if normalized not in self._STOP_WORDS and len(normalized) >= 2:
+                if normalized not in self._STOP_WORDS and normalized not in self._NOISE_ENGLISH and len(normalized) >= 2:
                     # Skip short generic English tokens (1-2 chars)
                     if re.match(r"^[a-z]{1,2}$", normalized):
                         continue
@@ -1273,11 +1378,26 @@ class ThemeSummarizer:
 
         # Strategy 1: Build keyword-based composite briefing
         keywords = self._extract_title_keywords(articles, max_keywords=5)
-        if len(keywords) >= 3:
-            # Generate a descriptive briefing
+        if len(keywords) >= 2:
             count = len(articles)
-            kw_str = ", ".join(keywords[:3])
-            return f"{kw_str} 관련 {count}건의 뉴스가 보고되었습니다."
+            # Separate Korean and English keywords for natural phrasing
+            kr_kw = [k for k in keywords if re.search(r"[가-힣]", k)]
+            en_kw = [k for k in keywords if not re.search(r"[가-힣]", k)]
+
+            # Build a more natural Korean briefing
+            display_kw = kr_kw[:3] if kr_kw else en_kw[:3]
+            if not display_kw:
+                display_kw = keywords[:3]
+
+            kw_str = ", ".join(display_kw)
+
+            # Use varied templates instead of one fixed pattern
+            templates = [
+                f"{kw_str} 중심으로 {count}건의 뉴스가 수집되었습니다.",
+                f"{kw_str} 이슈가 {count}건으로 주목받고 있습니다.",
+                f"{count}건의 뉴스에서 {kw_str} 키워드가 부각되고 있습니다.",
+            ]
+            return templates[count % len(templates)]
 
         # Strategy 2: Best description snippet from top articles
         best_desc = ""

--- a/scripts/common/utils.py
+++ b/scripts/common/utils.py
@@ -81,8 +81,8 @@ def detect_language(text: str) -> str:
     if not text:
         return "en"
     korean_chars = len(re.findall(r"[가-힣]", text))
-    total_chars = len(text.strip())
-    if total_chars > 0 and korean_chars / total_chars > 0.1:
+    total_chars = len(re.sub(r"\s+", "", text))
+    if total_chars > 0 and korean_chars >= 2 and korean_chars / total_chars > 0.2:
         return "ko"
     return "en"
 
@@ -93,6 +93,8 @@ def remove_sponsored_text(text: str) -> str:
         return text
     text = re.sub(r"\s*[Ss]ponsored\s+by\s+@?\S+.*$", "", text, flags=re.MULTILINE)
     text = re.sub(r"\s*[Aa][Dd]:\s+.*$", "", text, flags=re.MULTILINE)
+    # Remove decorative bracket markers
+    text = re.sub(r"[▒▶▷►◆◇■□●○※☆★]+", "", text)
     return text.strip()
 
 
@@ -112,11 +114,15 @@ def truncate_sentence(text: str, max_length: int = 300) -> str:
     if len(text) <= max_length:
         return text
     truncated = text[:max_length]
-    # Try to end at sentence boundary
-    for sep in [". ", "。", "! ", "? ", ".\n"]:
+    # Try Korean sentence endings first, then general
+    for sep in [
+        "다. ", "요. ", "음. ", "됩니다. ", "입니다. ", "습니다. ",
+        "했다. ", "됐다. ", "였다. ", "합니다. ",
+        ". ", "。", "! ", "? ", ".\n",
+    ]:
         last_sep = truncated.rfind(sep)
-        if last_sep > max_length * 0.5:
-            return truncated[: last_sep + 1].strip()
+        if last_sep > max_length * 0.4:
+            return truncated[: last_sep + len(sep)].strip()
     # Fall back to word boundary
     return truncate_text(text, max_length)
 
@@ -137,6 +143,20 @@ def validate_news_item(item: dict) -> Optional[dict]:
     if link and not validate_url(link):
         logger.debug("Skipping item with invalid URL: %r", link[:60])
         return None
+
+    # Filter noise titles (SEC forms, addresses, system pages)
+    _NOISE_TITLE_PATTERNS = [
+        r"^(?:Washington,?\s*DC\s*\d+)",
+        r"^(?:10-[KQ](?:\s|$))",
+        r"^(?:Form\s+\d)",
+        r"^(?:SEC\.gov\s*-?\s*SEC\.gov)",
+        r"^(?:EDGAR\s)",
+        r"^(?:AMENDMENT NO\.)",
+    ]
+    for pattern in _NOISE_TITLE_PATTERNS:
+        if re.match(pattern, title, re.IGNORECASE):
+            logger.debug("Skipping noise title: %r", title[:50])
+            return None
 
     # Fix description that's identical to title
     desc = item.get("description", "").strip()


### PR DESCRIPTION
## Summary
- **utils.py**: `truncate_sentence` 한국어 종결 패턴 10개 추가, `detect_language` 임계값 조정(10%→20%), `validate_news_item` SEC 노이즈 필터링
- **enrichment.py**: 한국어 제목 분석 8개 + 영어 제목 분석 7개 카테고리 추가, 한국어 보일러플레이트 정제, 번역 스킵 조건 개선
- **rss_fetcher.py**: 매체 9개 추가, `[속보]`/`[단독]` 태그 제거, RSS description 저작권 고지 자동 정제
- **summarizer.py**: `_THEME_CONTEXT` 누락 키 보완, `_GENERIC_DESC_PATTERNS` 확장, 영문 소스 제거 패턴 확장

## Test plan
- [x] `ruff check` 린트 통과
- [x] `truncate_sentence` 한국어 문장 종결 테스트 통과
- [x] `detect_language` 영어/한국어/혼합 텍스트 판정 테스트 통과
- [x] `validate_news_item` 노이즈 필터링 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)