### PR TITLE
fix: 구글 번역 CSP 차단 해결 및 스크롤 깜빡임 수정

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2706,8 +2706,6 @@ body {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    content-visibility: auto;
-    contain-intrinsic-size: auto 500px;
   }
 
   .date-group-header {

--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://translate.google.com https://translate.googleapis.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://translate.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com; frame-src https://translate.google.com; font-src 'self' data:;" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://translate.google.com https://translate.googleapis.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://translate.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://translate.googleapis.com https://translate.google.com; frame-src https://translate.google.com https://translate.googleapis.com; font-src 'self' data:;" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## Summary
- 구글 번역 CSP 차단 해결: `connect-src`에 `translate.googleapis.com`, `translate.google.com` 추가, `frame-src`에 `translate.googleapis.com` 추가
- 스크롤 시 흰색 화면 반짝임 수정: `content-visibility: auto` 제거 (off-screen 렌더링 지연이 원인)

## Test plan
- [ ] Vercel 배포 후 구글 번역 언어 변경 동작 확인 (EN, JA, ZH-CN, ES)
- [ ] 브라우저 콘솔에서 CSP 차단 에러 없는지 확인
- [ ] 홈페이지 스크롤 시 흰색 화면 깜빡임 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)