### PR TITLE
fix: 구글 번역 iframe 차단 및 Safari 흰색 깜빡임 수정

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
   <link rel="manifest" href="{{ '/manifest.json' | relative_url }}">
   <meta name="theme-color" content="#0d1117" id="meta-theme-color">
+  <style>html{background-color:#0d1117}html[data-theme="light"]{background-color:#ffffff}</style>
   <script>
     (function(){var t=localStorage.getItem('theme');if(!t){t=window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark';}if(t==='light'){document.documentElement.setAttribute('data-theme','light');document.querySelector('#meta-theme-color')&&document.querySelector('#meta-theme-color').setAttribute('content','#ffffff');}})();
   </script>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -17,8 +17,8 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
-  background: linear-gradient(180deg, $bg-primary 0%, color.adjust($bg-primary, $lightness: -2%) 100%);
-  color: $text-primary;
+  background-color: var(--bg-primary, $bg-primary);
+  color: var(--text-primary, $text-primary);
   line-height: 1.7;
   font-size: 16px;
   -webkit-font-smoothing: antialiased;

--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,7 @@
       "headers": [
         { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://translate.google.com https://translate.googleapis.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://translate.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://translate.googleapis.com https://translate.google.com; frame-src https://translate.google.com https://translate.googleapis.com; font-src 'self' data:;" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" }


### PR DESCRIPTION
## Summary
- `X-Frame-Options: DENY` → `SAMEORIGIN` 변경으로 Google Translate iframe 허용
- body `background`를 CSS 변수 `var(--bg-primary)` 기반으로 변경하여 다크/라이트 전환 시 깜빡임 제거
- `<html>`에 인라인 `background-color` 설정하여 CSS 로드 전 흰색 화면 방지
- body gradient 제거로 Safari scroll repaint 부하 감소

## Test plan
- [ ] 구글 번역 언어 변경 동작 확인 (EN, JA, ZH-CN, ES)
- [ ] Safari에서 스크롤 시 흰색 깜빡임 없는지 확인
- [ ] 다크 모드 ↔ 라이트 모드 전환 시 배경색 즉시 변경 확인
- [ ] 페이지 첫 로드 시 흰색 번쩍임 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)