### PR TITLE
fix: 구글 번역 CSP 도메인 보완 및 로딩 순서 개선

### DIFF
--- a/_includes/google-translate.html
+++ b/_includes/google-translate.html
@@ -180,6 +180,29 @@ function googleTranslateElementInit() {
     }
   }
 
+  function doTranslate(lang) {
+    var sel = document.querySelector('.goog-te-combo');
+    if (sel) {
+      try {
+        sel.value = lang;
+        sel.dispatchEvent(new Event('change', {bubbles:true}));
+        safeSet(sessionStorage,'langChanging','false');
+        safeSet(sessionStorage,'langApplied','true');
+        var reloadCount = parseInt(safeGet(sessionStorage, 'langReloadCount') || '0', 10);
+        setTimeout(function() {
+          if (getCurrentLang() !== lang && reloadCount < 3) {
+            safeSet(sessionStorage, 'langReloadCount', String(reloadCount + 1));
+            location.reload();
+          } else { safeRemove(sessionStorage, 'langReloadCount'); }
+        }, 800);
+      } catch(e) { setTimeout(function() { location.reload(); }, 200); }
+    } else {
+      safeSet(sessionStorage,'langChanging','false');
+      safeSet(sessionStorage,'langApplied','true');
+      setTimeout(function() { location.reload(); }, 200);
+    }
+  }
+
   function changeLang(lang) {
     if (safeGet(sessionStorage, 'langChanging') === 'true') return;
     safeSet(sessionStorage, 'langChanging', 'true');
@@ -199,13 +222,11 @@ function googleTranslateElementInit() {
     var cs = document.getElementById('current-lang'); if (LANG_MAP[lang] && cs) cs.textContent = LANG_MAP[lang];
     applyI18nStrings(lang);
     showTranslateNotice(lang);
-    var sel = document.querySelector('.goog-te-combo');
-    if (sel && translateScriptLoaded) {
-      try { sel.value = lang; sel.dispatchEvent(new Event('change', {bubbles:true})); safeSet(sessionStorage,'langChanging','false'); safeSet(sessionStorage,'langApplied','true');
-        var reloadCount = parseInt(safeGet(sessionStorage, 'langReloadCount') || '0', 10);
-        setTimeout(function() { if (getCurrentLang() !== lang && reloadCount < 3) { safeSet(sessionStorage, 'langReloadCount', String(reloadCount + 1)); location.reload(); } else { safeRemove(sessionStorage, 'langReloadCount'); } }, 500);
-      } catch(e) { setTimeout(function() { location.reload(); }, 150); }
-    } else { safeSet(sessionStorage,'langChanging','false'); safeSet(sessionStorage,'langApplied','true'); setTimeout(function() { location.reload(); }, 150); }
+    if (translateScriptLoaded && document.querySelector('.goog-te-combo')) {
+      doTranslate(lang);
+    } else {
+      loadTranslateScript(function() { setTimeout(function() { doTranslate(lang); }, 800); });
+    }
   }
 
   function applyI18nStrings(lang) {

--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://translate.google.com https://translate.googleapis.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://translate.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://translate.googleapis.com https://translate.google.com; frame-src https://translate.google.com https://translate.googleapis.com; font-src 'self' data:;" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://translate.google.com https://translate.googleapis.com https://www.gstatic.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://translate.googleapis.com https://www.gstatic.com https://translate.google.com; img-src 'self' data: https:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://translate.googleapis.com https://translate.google.com https://translate-pa.googleapis.com; frame-src https://translate.google.com https://translate.googleapis.com; font-src 'self' data:;" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## Summary
- CSP에 Google Translate 필수 도메인 추가: `www.gstatic.com` (script/style), `translate-pa.googleapis.com` (API), `translate.google.com` (style)
- `changeLang` 함수 개선: 번역 스크립트 미로드 시 `loadTranslateScript` 콜백으로 로드 후 번역 실행
- `doTranslate` 함수 분리로 안정적인 번역 적용 흐름 구현
- 번역 적용 확인 대기 시간 800ms로 조정

## Test plan
- [ ] 영어(EN) 클릭 시 페이지 번역 확인
- [ ] 일본어(JA) 클릭 시 페이지 번역 확인
- [ ] 중국어(CN) 클릭 시 페이지 번역 확인
- [ ] 한국어(KO) 복원 시 원래 상태로 돌아오는지 확인
- [ ] 브라우저 콘솔에서 CSP 차단 에러 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)