### PR TITLE
fix: 구글 번역 위젯 렌더링 및 로딩 개선

### DIFF
--- a/_includes/google-translate.html
+++ b/_includes/google-translate.html
@@ -180,7 +180,8 @@ function googleTranslateElementInit() {
     }
   }
 
-  function doTranslate(lang) {
+  function doTranslate(lang, attempt) {
+    attempt = attempt || 0;
     var sel = document.querySelector('.goog-te-combo');
     if (sel) {
       try {
@@ -196,10 +197,12 @@ function googleTranslateElementInit() {
           } else { safeRemove(sessionStorage, 'langReloadCount'); }
         }, 800);
       } catch(e) { setTimeout(function() { location.reload(); }, 200); }
+    } else if (attempt < 20) {
+      setTimeout(function() { doTranslate(lang, attempt + 1); }, 300);
     } else {
       safeSet(sessionStorage,'langChanging','false');
       safeSet(sessionStorage,'langApplied','true');
-      setTimeout(function() { location.reload(); }, 200);
+      location.reload();
     }
   }
 
@@ -309,11 +312,8 @@ function googleTranslateElementInit() {
     }).observe(document.body, {childList:true, subtree:true});
   }
 
-  var sysLang = getSystemLanguage(), curLang = getCurrentLang(), userPref = safeGet(localStorage, 'preferredLang');
-  var needsTranslate = (userPref && userPref !== 'system' && userPref !== 'ko') || (!userPref && sysLang !== 'ko') || (curLang !== 'ko');
-  if (needsTranslate) {
-    if (document.readyState === 'complete') setTimeout(loadTranslateScript, 100);
-    else window.addEventListener('load', function() { setTimeout(loadTranslateScript, 100); });
-  }
+  // Always load translate script so widget is ready when user clicks language
+  if (document.readyState === 'complete') setTimeout(loadTranslateScript, 100);
+  else window.addEventListener('load', function() { setTimeout(loadTranslateScript, 100); });
 })();
 </script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,7 +43,7 @@
           <button class="lang-option" data-lang="zh-CN" title="简体中文" role="menuitem"><span class="lang-flag">🇨🇳</span><span class="lang-name">简体中文</span></button>
           <button class="lang-option" data-lang="es" title="Español" role="menuitem"><span class="lang-flag">🇪🇸</span><span class="lang-name">Español</span></button>
         </div>
-        <div id="google_translate_element" style="display:none;"></div>
+        <div id="google_translate_element" style="position:absolute;top:-9999px;left:-9999px;opacity:0;pointer-events:none;"></div>
         {% include google-translate.html %}
       </div>
       <button class="theme-toggle" id="theme-toggle" aria-label="테마 변경" data-i18n-aria="change_theme" type="button">


### PR DESCRIPTION
## Summary
- `google_translate_element` div를 `display:none` → off-screen 배치로 변경하여 위젯 내부 select 렌더링 보장
- `doTranslate` 함수에 `.goog-te-combo` 폴링 추가 (300ms 간격, 최대 20회 = 6초 대기)
- 번역 스크립트를 항상 즉시 로드하여 사용자 클릭 시 위젯이 준비된 상태로 대기

## Test plan
- [ ] 영어(EN) 버튼 클릭 시 전체 포스트 내용 번역 확인
- [ ] 일본어(JA) 버튼 클릭 시 번역 확인
- [ ] 한국어(KO) 복원 확인
- [ ] 페이지 첫 로드 시 구글 번역 위젯이 보이지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)