### PR TITLE
fix: 포스트 콘텐츠 번역 지원 강화

### DIFF
--- a/_includes/google-translate.html
+++ b/_includes/google-translate.html
@@ -16,7 +16,8 @@ function googleTranslateElementInit() {
       pageLanguage: 'ko',
       includedLanguages: 'en,ja,zh-CN,es',
       layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
-      autoDisplay: false
+      autoDisplay: true,
+      multilanguagePage: true
     }, 'google_translate_element');
     googleTranslateLoaded = true;
   } catch (e) {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -100,7 +100,7 @@
   <a href="#main-content" class="skip-to-content" data-i18n="skip_to_content">본문으로 건너뛰기</a>
   {% include header.html %}
   <div class="reading-progress" id="reading-progress"></div>
-  <main class="container" id="main-content">
+  <main class="container" id="main-content" translate="yes">
     {{ content }}
   </main>
   {% include footer.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -94,7 +94,7 @@ layout: default
 </section>
 
 <!-- Recent Posts - Date Grouped (Main Content) -->
-<section class="recent-posts-tabbed" aria-label="최근 포스트">
+<section class="recent-posts-tabbed" aria-label="최근 포스트" translate="yes">
   <div class="section-header">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect x="3" y="4" width="18" height="18" rx="2"/>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
 {% assign cat_data = site.data.categories[first_cat] %}
 {% assign cat_name = cat_data.name | default: first_cat %}
 
-<article class="post-detail">
+<article class="post-detail" translate="yes">
   <div class="post-breadcrumb">
     <a href="{{ '/' | relative_url }}" data-i18n="home">홈</a>
     <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><path d="M4 2l4 4-4 4"/></svg>
@@ -16,7 +16,7 @@ layout: default
   </div>
 
   <header class="post-header">
-    <h1>{{ page.title }}</h1>
+    <h1 translate="yes">{{ page.title }}</h1>
     <div class="post-meta-enhanced">
       <span class="post-meta-item">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -69,7 +69,7 @@ layout: default
     <ol class="toc-list" id="toc-list"></ol>
   </nav>
 
-  <div class="post-content prose-content">
+  <div class="post-content prose-content" translate="yes">
     {{ content }}
   </div>
 


### PR DESCRIPTION
## Summary
- `translate="yes"` 속성을 주요 콘텐츠 영역에 명시적으로 추가
  - `post.html`: `<article>`, `<h1>`, `.post-content` div
  - `default.html`: `<main>` 컨테이너
  - `home.html`: 최근 포스트 섹션
- Google Translate 위젯 설정 개선: `autoDisplay: true`, `multilanguagePage: true`

## Test plan
- [ ] 영어(EN) 선택 시 포스트 제목, 본문, 표 내용 번역 확인
- [ ] 일본어(JA) 선택 시 포스트 콘텐츠 번역 확인
- [ ] 홈페이지 포스트 카드 제목/설명 번역 확인
- [ ] 언어 토글 UI(KO/EN/JA 등)는 번역되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)