### PR TITLE
fix: 수집 워크플로우 동시성 분리 및 포스트 품질 개선

### DIFF
--- a/.github/workflows/collect-coinmarketcap.yml
+++ b/.github/workflows/collect-coinmarketcap.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-coinmarketcap
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-crypto-news.yml
+++ b/.github/workflows/collect-crypto-news.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-crypto-news
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-defi-llama.yml
+++ b/.github/workflows/collect-defi-llama.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-defi-llama
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-fmp-calendar.yml
+++ b/.github/workflows/collect-fmp-calendar.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-fmp-calendar
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-geopolitical.yml
+++ b/.github/workflows/collect-geopolitical.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-geopolitical
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-market-indicators.yml
+++ b/.github/workflows/collect-market-indicators.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-market-indicators
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-political-trades.yml
+++ b/.github/workflows/collect-political-trades.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-political-trades
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-regulatory.yml
+++ b/.github/workflows/collect-regulatory.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-regulatory
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-social-media.yml
+++ b/.github/workflows/collect-social-media.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-social-media
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-stock-news.yml
+++ b/.github/workflows/collect-stock-news.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-stock-news
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/collect-worldmonitor-news.yml
+++ b/.github/workflows/collect-worldmonitor-news.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-data
+  group: collect-worldmonitor-news
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/continuous-improvement-loop.yml
+++ b/.github/workflows/continuous-improvement-loop.yml
@@ -24,9 +24,6 @@ jobs:
           fetch-depth: 0
           ref: main
 
-      - name: OpenCode sync - git pull
-        run: bash scripts/opencode_git_pull.sh
-
       - name: Ralph loop - improve post quality
         uses: ./.github/actions/python-collect
         with:

--- a/scripts/collect_defi_llama.py
+++ b/scripts/collect_defi_llama.py
@@ -693,12 +693,14 @@ def build_post_content(
     if protocols and chains:
         top_p = protocols[0]
         top_c = chains[0]
+        p_name = top_p.get('name', 'Unknown')
+        c_name = top_c.get('name', 'Unknown')
         content_parts.append(
-            f"1. **프로토콜**: {top_p.get('name', 'Unknown')}이 TVL "
+            f"1. **프로토콜**: {p_name} — TVL "
             f"{_format_tvl(top_p.get('tvl', 0))}로 1위를 유지하고 있습니다."
         )
         content_parts.append(
-            f"2. **체인**: {top_c.get('name', 'Unknown')}이 TVL "
+            f"2. **체인**: {c_name} — TVL "
             f"{_format_tvl(top_c.get('tvl', 0))}로 체인 생태계를 주도합니다."
         )
     content_parts.append("")

--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -1542,16 +1542,21 @@ class ThemeSummarizer:
 
             kw_str = ", ".join(display_kw)
 
-            # Use varied templates instead of one fixed pattern
+            # Use varied templates to avoid repetitive phrasing
             templates = [
                 f"{kw_str} 중심으로 {count}건의 뉴스가 수집되었습니다.",
-                f"{kw_str} 이슈가 {count}건으로 주목받고 있습니다.",
-                f"{count}건의 뉴스에서 {kw_str} 키워드가 부각되고 있습니다.",
+                f"{count}건의 뉴스에서 {kw_str} 관련 동향이 포착되었습니다.",
+                f"{kw_str} 관련 {count}건의 소식이 확인되었습니다.",
+                f"{kw_str} 흐름에 {count}건의 뉴스가 집중되고 있습니다.",
+                f"{count}건의 기사에서 {kw_str} 키워드가 부각되고 있습니다.",
+                f"{kw_str} 이슈로 {count}건의 보도가 이어지고 있습니다.",
+                f"{kw_str} 테마에서 {count}건의 뉴스가 감지되었습니다.",
             ]
             import datetime as _dt
 
             today_str = _dt.datetime.now(tz=_dt.UTC).date().isoformat()
-            seed = hash((today_str, count, kw_str))
+            # Use theme name in seed so different themes get different templates
+            seed = hash((today_str, kw_str))
             return templates[seed % len(templates)]
 
         # Strategy 2: Best description snippet from top articles


### PR DESCRIPTION
## Summary
- **수집 워크플로우 동시성 그룹 분리**: 11개 collect 워크플로우가 공유하던 `collect-data` 그룹을 각각 개별 그룹으로 분리하여 병렬 실행 가능하도록 수정
- **OpenClaw 루프 실패 수정**: deprecated `opencode_git_pull.sh` (exit 1) 단계를 제거하여 매시간 improvement loop 정상화
- **DeFi 리포트 한국어 조사 오류**: "Lido이 TVL" → "Lido — TVL" (영문 이름 뒤 조사 문제 해결)
- **테마 브리핑 반복 패턴 개선**: 3개 → 7개 템플릿 + 테마명 기반 시드로 동일 포스트 내 다른 테마가 다른 문장 사용

## Test plan
- [ ] OpenClaw Hourly Improvement Loop 워크플로우가 정상 실행되는지 확인
- [ ] 수집 워크플로우 2개 이상 동시 트리거 시 취소 없이 병렬 실행 확인
- [ ] 새로 생성된 포스트에서 테마별 브리핑 문장 다양성 확인
- [ ] DeFi 리포트에서 "— TVL" 형식 정상 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)