### PR TITLE
fix: 테마 브리핑 중복 문장 방지

### DIFF
--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -1555,8 +1555,8 @@ class ThemeSummarizer:
             import datetime as _dt
 
             today_str = _dt.datetime.now(tz=_dt.UTC).date().isoformat()
-            # Use theme name in seed so different themes get different templates
-            seed = hash((today_str, kw_str))
+            # Use theme_key in seed so different themes get different templates
+            seed = hash((today_str, theme_key, kw_str))
             return templates[seed % len(templates)]
 
         # Strategy 2: Best description snippet from top articles


### PR DESCRIPTION
## Summary
- 동일 키워드가 여러 테마에 등장 시 같은 브리핑 템플릿이 선택되는 버그 수정
- 시드에 `theme_key`를 추가하여 테마별로 다른 문장이 생성되도록 개선

## Test plan
- [ ] 비트코인 테마와 규제/정책 테마에서 서로 다른 브리핑 문장이 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)