### PR TITLE
fix: P0 보안 2건 + 라이트모드 스타일 수정

### DIFF
--- a/.github/workflows/continuous-improvement-loop.yml
+++ b/.github/workflows/continuous-improvement-loop.yml
@@ -77,9 +77,10 @@ jobs:
 
       - name: Post loop priorities to Slack thread
         if: steps.slack.outputs.can_post == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.slack.outputs.token }}
         run: |
           python3 scripts/post_loop_to_slack.py \
-            --token "${{ steps.slack.outputs.token }}" \
             --channel "${{ steps.slack.outputs.channel }}" \
             --message-path _state/continuous-improvement-loop-slack.txt \
             --marker "[ultrawork-loop]"
@@ -105,9 +106,10 @@ jobs:
 
       - name: Post ops forum to Slack thread
         if: steps.slack_ops.outputs.can_post == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.slack_ops.outputs.token }}
         run: |
           python3 scripts/post_loop_to_slack.py \
-            --token "${{ steps.slack_ops.outputs.token }}" \
             --channel "${{ steps.slack_ops.outputs.channel }}" \
             --message-path _state/continuous-improvement-roles/continuous-improvement-loop-ops.txt \
             --marker "[multi-agent-forum]"
@@ -133,9 +135,10 @@ jobs:
 
       - name: Post security forum to Slack thread
         if: steps.slack_security.outputs.can_post == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.slack_security.outputs.token }}
         run: |
           python3 scripts/post_loop_to_slack.py \
-            --token "${{ steps.slack_security.outputs.token }}" \
             --channel "${{ steps.slack_security.outputs.channel }}" \
             --message-path _state/continuous-improvement-roles/continuous-improvement-loop-security.txt \
             --marker "[multi-agent-forum]"
@@ -161,9 +164,10 @@ jobs:
 
       - name: Post UI/UX forum to Slack thread
         if: steps.slack_dev.outputs.can_post == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.slack_dev.outputs.token }}
         run: |
           python3 scripts/post_loop_to_slack.py \
-            --token "${{ steps.slack_dev.outputs.token }}" \
             --channel "${{ steps.slack_dev.outputs.channel }}" \
             --message-path _state/continuous-improvement-roles/continuous-improvement-loop-uiux.txt \
             --marker "[multi-agent-forum]"

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -6823,6 +6823,39 @@ a:focus-visible {
     }
   }
 
+  // Stat grid light mode
+  .stat-grid .stat-item {
+    background: rgba(240, 243, 246, 0.8);
+    border-color: rgba(208, 215, 222, 0.4);
+
+    .stat-value { color: #0969da; }
+    .stat-label { color: #656d76; }
+  }
+
+  // Alert box light mode
+  .alert-box {
+    &.alert-urgent {
+      background: rgba(207, 34, 46, 0.06);
+      border-color: #cf222e;
+      strong, .alert-title { color: #cf222e; }
+    }
+    &.alert-info {
+      background: rgba(9, 105, 218, 0.06);
+      border-color: #0969da;
+      strong, .alert-title { color: #0969da; }
+    }
+    &.alert-warning {
+      background: rgba(191, 135, 0, 0.06);
+      border-color: #bf8700;
+      strong, .alert-title { color: #9a6700; }
+    }
+  }
+
+  // Theme distribution bars light mode
+  .bar-track {
+    background: rgba(208, 215, 222, 0.3);
+  }
+
   // Price change indicators keep their semantic colors
   .price-up, .change-positive { color: #1a7f37; }
   .price-down, .change-negative { color: #cf222e; }

--- a/scripts/common/config.py
+++ b/scripts/common/config.py
@@ -22,8 +22,13 @@ def get_ssl_verify():
     Allows disabling via DISABLE_SSL_VERIFY=true for local dev.
     """
     if os.environ.get("DISABLE_SSL_VERIFY", "").lower() in ("true", "1"):
+        if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
+            logger.error(
+                "DISABLE_SSL_VERIFY blocked in CI/GitHub Actions environment"
+            )
+            return True
         logger.critical(
-            "SSL verification disabled via DISABLE_SSL_VERIFY — MITM attacks possible. Do NOT use in production/CI."
+            "SSL verification disabled via DISABLE_SSL_VERIFY — MITM attacks possible. Local dev only."
         )
         return False
 


### PR DESCRIPTION
## Summary
- Slack 토큰 CLI 인자 노출을 환경변수(SLACK_BOT_TOKEN) 방식으로 전환 (continuous-improvement-loop.yml 4곳)
- CI/GitHub Actions 환경에서 DISABLE_SSL_VERIFY 사용 차단 (MITM 방지)
- 라이트모드에서 stat-grid, alert-box, bar-track 가독성 개선 (_sass/_custom.scss)

## Test plan
- [x] Jekyll 빌드 성공 확인
- [ ] GitHub Actions continuous-improvement-loop 정상 동작 확인
- [ ] 라이트모드 크립토 모니터링 리포트 스타일 확인