### PR TITLE
feat: 최근 포스트 UI/UX 대폭 개선

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -119,49 +119,77 @@ layout: default
     <h2>최근 포스트</h2>
   </div>
 
-  <div class="posts-tabs" role="tablist" aria-label="카테고리 필터">
-    <button class="posts-tab active" role="tab" aria-selected="true" data-category="all">
-      전체
-      <span class="tab-count">{{ site.posts | size }}</span>
-    </button>
-    {% assign crypto_posts = site.posts | where_exp: "post", "post.categories contains 'crypto-news' or post.categories contains 'crypto-trading-journal'" %}
-    <button class="posts-tab" role="tab" aria-selected="false" data-category="crypto">
-      암호화폐
-      <span class="tab-count">{{ crypto_posts | size }}</span>
-    </button>
-    {% assign stock_posts = site.posts | where_exp: "post", "post.categories contains 'stock-news' or post.categories contains 'stock-trading-journal'" %}
-    <button class="posts-tab" role="tab" aria-selected="false" data-category="stock">
-      주식
-      <span class="tab-count">{{ stock_posts | size }}</span>
-    </button>
-    {% assign analysis_posts = site.posts | where_exp: "post", "post.categories contains 'market-analysis' or post.categories contains 'worldmonitor'" %}
-    <button class="posts-tab" role="tab" aria-selected="false" data-category="analysis">
-      분석
-      <span class="tab-count">{{ analysis_posts | size }}</span>
-    </button>
-    {% assign regulatory_posts = site.posts | where_exp: "post", "post.categories contains 'regulatory-news'" %}
-    <button class="posts-tab" role="tab" aria-selected="false" data-category="regulatory">
-      규제
-      <span class="tab-count">{{ regulatory_posts | size }}</span>
-    </button>
-    {% assign social_posts = site.posts | where_exp: "post", "post.categories contains 'social-media'" %}
-    <button class="posts-tab" role="tab" aria-selected="false" data-category="social">
-      소셜
-      <span class="tab-count">{{ social_posts | size }}</span>
-    </button>
-    {% assign security_posts = site.posts | where_exp: "post", "post.categories contains 'security-alerts'" %}
-    <button class="posts-tab" role="tab" aria-selected="false" data-category="security">
-      보안
-      <span class="tab-count">{{ security_posts | size }}</span>
-    </button>
-    {% assign political_posts = site.posts | where_exp: "post", "post.categories contains 'political-trades'" %}
-    <button class="posts-tab" role="tab" aria-selected="false" data-category="political">
-      정치
-      <span class="tab-count">{{ political_posts | size }}</span>
-    </button>
+  <!-- Sort & View Controls -->
+  <div class="posts-controls">
+    <div class="posts-tabs" role="tablist" aria-label="카테고리 필터">
+      <button class="posts-tab active" role="tab" aria-selected="true" data-category="all">
+        전체
+        <span class="tab-count">{{ site.posts | size }}</span>
+      </button>
+      {% assign crypto_posts = site.posts | where_exp: "post", "post.categories contains 'crypto-news' or post.categories contains 'crypto-trading-journal'" %}
+      <button class="posts-tab" role="tab" aria-selected="false" data-category="crypto">
+        암호화폐
+        <span class="tab-count">{{ crypto_posts | size }}</span>
+      </button>
+      {% assign stock_posts = site.posts | where_exp: "post", "post.categories contains 'stock-news' or post.categories contains 'stock-trading-journal'" %}
+      <button class="posts-tab" role="tab" aria-selected="false" data-category="stock">
+        주식
+        <span class="tab-count">{{ stock_posts | size }}</span>
+      </button>
+      {% assign analysis_posts = site.posts | where_exp: "post", "post.categories contains 'market-analysis' or post.categories contains 'worldmonitor'" %}
+      <button class="posts-tab" role="tab" aria-selected="false" data-category="analysis">
+        분석
+        <span class="tab-count">{{ analysis_posts | size }}</span>
+      </button>
+      {% assign regulatory_posts = site.posts | where_exp: "post", "post.categories contains 'regulatory-news'" %}
+      <button class="posts-tab" role="tab" aria-selected="false" data-category="regulatory">
+        규제
+        <span class="tab-count">{{ regulatory_posts | size }}</span>
+      </button>
+      {% assign social_posts = site.posts | where_exp: "post", "post.categories contains 'social-media'" %}
+      <button class="posts-tab" role="tab" aria-selected="false" data-category="social">
+        소셜
+        <span class="tab-count">{{ social_posts | size }}</span>
+      </button>
+      {% assign security_posts = site.posts | where_exp: "post", "post.categories contains 'security-alerts'" %}
+      <button class="posts-tab" role="tab" aria-selected="false" data-category="security">
+        보안
+        <span class="tab-count">{{ security_posts | size }}</span>
+      </button>
+      {% assign political_posts = site.posts | where_exp: "post", "post.categories contains 'political-trades'" %}
+      <button class="posts-tab" role="tab" aria-selected="false" data-category="political">
+        정치
+        <span class="tab-count">{{ political_posts | size }}</span>
+      </button>
+    </div>
+    <div class="posts-sort-view">
+      <div class="posts-sort" role="group" aria-label="정렬">
+        <button class="sort-btn active" data-sort="recent" aria-pressed="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          최신순
+        </button>
+        <button class="sort-btn" data-sort="popular" aria-pressed="false">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+          인기순
+        </button>
+      </div>
+      <div class="view-toggle" role="group" aria-label="뷰 전환">
+        <button class="view-btn active" data-view="card" aria-pressed="true" aria-label="카드뷰">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+        </button>
+        <button class="view-btn" data-view="list" aria-pressed="false" aria-label="리스트뷰">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+        </button>
+      </div>
+    </div>
   </div>
 
-  <div class="posts-tab-content" role="tabpanel">
+  <!-- Visible count indicator -->
+  <div class="posts-count-bar">
+    <span id="posts-visible-count"></span>
+  </div>
+
+  <div class="posts-tab-content" role="tabpanel" id="posts-container">
     {% comment %} 1단계: 고정(pin) 포스트 먼저 출력 {% endcomment %}
     {% for post in site.posts %}
       {% if post.pin %}
@@ -182,7 +210,8 @@ layout: default
         {% elsif post.categories contains 'political-trades' %}
           {% assign cat_type = "political" %}
         {% endif %}
-        <div class="post-item pinned-post" data-cat-type="{{ cat_type }}">
+        {% assign word_count = post.content | number_of_words %}
+        <div class="post-item pinned-post" data-cat-type="{{ cat_type }}" data-words="{{ word_count }}" data-tags="{{ post.tags | size }}" data-has-image="{% if post.image %}1{% else %}0{% endif %}" data-date="{{ post.date | date: '%Y%m%d%H%M' }}">
           {% include post-card.html post=post %}
         </div>
       {% endif %}
@@ -197,8 +226,8 @@ layout: default
             {% if prev_date != "" %}
               </div>
             {% endif %}
-            <div class="date-group">
-              <div class="date-group-header">
+            <div class="date-group" data-date="{{ post_date }}">
+              <div class="date-group-header" role="button" tabindex="0" aria-expanded="true">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <rect x="3" y="4" width="18" height="18" rx="2"/>
                   <line x1="16" y1="2" x2="16" y2="6"/>
@@ -206,6 +235,8 @@ layout: default
                   <line x1="3" y1="10" x2="21" y2="10"/>
                 </svg>
                 <span>{{ post_date }}</span>
+                <span class="date-group-count"></span>
+                <svg class="date-group-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
               </div>
             {% assign prev_date = post_date %}
           {% endif %}
@@ -226,7 +257,8 @@ layout: default
           {% elsif post.categories contains 'political-trades' %}
             {% assign cat_type = "political" %}
           {% endif %}
-          <div class="post-item" data-cat-type="{{ cat_type }}">
+          {% assign word_count = post.content | number_of_words %}
+          <div class="post-item" data-cat-type="{{ cat_type }}" data-words="{{ word_count }}" data-tags="{{ post.tags | size }}" data-has-image="{% if post.image %}1{% else %}0{% endif %}" data-date="{{ post.date | date: '%Y%m%d%H%M' }}">
             {% include post-card.html post=post %}
           </div>
         {% endif %}
@@ -235,6 +267,15 @@ layout: default
     {% if prev_date != "" %}
       </div>
     {% endif %}
+  </div>
+
+  <!-- Load More Button -->
+  <div class="posts-load-more" id="load-more-wrapper">
+    <button id="load-more-btn" class="load-more-btn">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+      더보기
+      <span id="load-more-remaining"></span>
+    </button>
   </div>
 </section>
 
@@ -493,38 +534,162 @@ layout: default
     dateEl.textContent = now.toLocaleDateString('ko-KR', options);
   }
 
-  // Tab switching with animation
+  // === Posts Controller ===
+  const POSTS_PER_PAGE = 20;
+  let currentPage = 1;
+  let currentCategory = 'all';
+  let currentSort = 'recent';
+  let currentView = 'card';
+
   const tabs = document.querySelectorAll('.posts-tab');
   const postItems = document.querySelectorAll('.post-item');
   const dateGroups = document.querySelectorAll('.date-group');
+  const container = document.getElementById('posts-container');
+  const loadMoreBtn = document.getElementById('load-more-btn');
+  const loadMoreWrapper = document.getElementById('load-more-wrapper');
+  const loadMoreRemaining = document.getElementById('load-more-remaining');
+  const visibleCountEl = document.getElementById('posts-visible-count');
 
+  function getFilteredItems() {
+    return Array.from(postItems).filter(item => {
+      if (currentCategory === 'all') return true;
+      return item.dataset.catType === currentCategory;
+    });
+  }
+
+  function sortItems(items) {
+    if (currentSort === 'popular') {
+      return items.sort((a, b) => {
+        const pinA = a.classList.contains('pinned-post') ? 1 : 0;
+        const pinB = b.classList.contains('pinned-post') ? 1 : 0;
+        if (pinB !== pinA) return pinB - pinA;
+        const scoreA = (parseInt(a.dataset.words) || 0) + (parseInt(a.dataset.tags) || 0) * 200 + (a.dataset.hasImage === '1' ? 500 : 0);
+        const scoreB = (parseInt(b.dataset.words) || 0) + (parseInt(b.dataset.tags) || 0) * 200 + (b.dataset.hasImage === '1' ? 500 : 0);
+        return scoreB - scoreA;
+      });
+    }
+    return items;
+  }
+
+  function updateVisibility() {
+    const filtered = getFilteredItems();
+    const sorted = sortItems([...filtered]);
+    const maxVisible = currentPage * POSTS_PER_PAGE;
+
+    // Hide all first
+    postItems.forEach(item => { item.style.display = 'none'; item.classList.remove('list-view'); });
+
+    // Show sorted items up to limit
+    sorted.forEach((item, i) => {
+      if (i < maxVisible) {
+        item.style.display = '';
+        if (currentView === 'list') item.classList.add('list-view');
+      }
+    });
+
+    // Date groups visibility
+    dateGroups.forEach(group => {
+      const items = group.querySelectorAll('.post-item');
+      const anyVisible = Array.from(items).some(i => i.style.display !== 'none');
+      group.style.display = anyVisible ? 'flex' : 'none';
+    });
+
+    // Popular mode: hide date group headers (irrelevant when sorted by score)
+    if (currentSort === 'popular') {
+      dateGroups.forEach(g => {
+        const header = g.querySelector('.date-group-header');
+        if (header) header.style.display = 'none';
+      });
+    } else {
+      dateGroups.forEach(g => {
+        const header = g.querySelector('.date-group-header');
+        if (header) header.style.display = '';
+      });
+    }
+
+    // Update count
+    const visibleCount = sorted.filter((_, i) => i < maxVisible).length;
+    const totalCount = filtered.length;
+    if (visibleCountEl) {
+      visibleCountEl.textContent = `${visibleCount} / ${totalCount}건 표시`;
+    }
+
+    // Load more button
+    const remaining = totalCount - maxVisible;
+    if (remaining > 0) {
+      loadMoreWrapper.style.display = '';
+      loadMoreRemaining.textContent = `(${remaining}건 남음)`;
+    } else {
+      loadMoreWrapper.style.display = 'none';
+    }
+
+    // Date group counts
+    dateGroups.forEach(group => {
+      const items = group.querySelectorAll('.post-item');
+      const visCount = Array.from(items).filter(i => i.style.display !== 'none').length;
+      const countEl = group.querySelector('.date-group-count');
+      if (countEl) countEl.textContent = visCount > 0 ? `(${visCount}건)` : '';
+    });
+  }
+
+  // Tab switching
   tabs.forEach(tab => {
     tab.addEventListener('click', () => {
-      const category = tab.dataset.category;
-
-      // Update active tab
+      currentCategory = tab.dataset.category;
+      currentPage = 1;
       tabs.forEach(t => { t.classList.remove('active'); t.setAttribute('aria-selected', 'false'); });
       tab.classList.add('active');
       tab.setAttribute('aria-selected', 'true');
-
-      // Filter posts
-      postItems.forEach(item => {
-        if (category === 'all') {
-          item.style.display = '';
-        } else {
-          const match = item.dataset.catType === category;
-          item.style.display = match ? '' : 'none';
-        }
-      });
-
-      // Hide date group headers if all posts inside are hidden
-      dateGroups.forEach(group => {
-        const items = group.querySelectorAll('.post-item');
-        const anyVisible = Array.from(items).some(i => i.style.display !== 'none');
-        group.style.display = anyVisible ? 'flex' : 'none';
-      });
+      updateVisibility();
     });
   });
+
+  // Sort switching
+  document.querySelectorAll('.sort-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      currentSort = btn.dataset.sort;
+      currentPage = 1;
+      document.querySelectorAll('.sort-btn').forEach(b => { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
+      btn.classList.add('active');
+      btn.setAttribute('aria-pressed', 'true');
+      updateVisibility();
+    });
+  });
+
+  // View toggle
+  document.querySelectorAll('.view-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      currentView = btn.dataset.view;
+      document.querySelectorAll('.view-btn').forEach(b => { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
+      btn.classList.add('active');
+      btn.setAttribute('aria-pressed', 'true');
+      if (container) container.classList.toggle('list-mode', currentView === 'list');
+      updateVisibility();
+    });
+  });
+
+  // Load more
+  if (loadMoreBtn) {
+    loadMoreBtn.addEventListener('click', () => {
+      currentPage++;
+      updateVisibility();
+    });
+  }
+
+  // Date group collapse/expand
+  document.querySelectorAll('.date-group-header').forEach(header => {
+    header.addEventListener('click', () => {
+      const group = header.parentElement;
+      const isCollapsed = group.classList.toggle('collapsed');
+      header.setAttribute('aria-expanded', !isCollapsed);
+    });
+    header.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); header.click(); }
+    });
+  });
+
+  // Initial render
+  updateVisibility();
 
   // Scroll to top button
   const scrollToTopBtn = document.getElementById('scroll-to-top');

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -6964,6 +6964,223 @@ a:focus-visible {
   .skip-to-content {
     border: 2px solid #0969da;
   }
+
+  // Sort & view controls light mode
+  .sort-btn {
+    color: #656d76;
+    &.active { background: #0969da; color: #ffffff; }
+  }
+  .view-btn {
+    color: #656d76;
+    border-color: rgba(208, 215, 222, 0.5);
+    &.active { background: rgba(9, 105, 218, 0.1); color: #0969da; border-color: #0969da; }
+  }
+  .posts-count-bar { color: #656d76; }
+  .load-more-btn {
+    background: #f0f3f6;
+    color: #24292f;
+    border-color: rgba(208, 215, 222, 0.6);
+    &:hover { background: #e1e4e8; }
+  }
+  // List view light mode
+  .posts-tab-content.list-mode .post-card {
+    border-color: rgba(208, 215, 222, 0.4);
+  }
+}
+
+/* ================================
+   POSTS CONTROLS — Sort, View, Pagination
+   ================================ */
+
+.posts-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.posts-sort-view {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.posts-sort {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.sort-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  background: transparent;
+  color: $text-secondary;
+  transition: all 0.2s ease;
+
+  &:hover { color: $text-primary; }
+  &.active {
+    background: rgba($accent-blue, 0.15);
+    color: $accent-blue;
+    font-weight: 600;
+  }
+  svg { flex-shrink: 0; }
+}
+
+.view-toggle {
+  display: flex;
+  gap: 0.25rem;
+  border: 1px solid rgba($border-color, 0.4);
+  border-radius: 8px;
+  padding: 2px;
+}
+
+.view-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 28px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  background: transparent;
+  color: $text-secondary;
+  transition: all 0.2s ease;
+
+  &:hover { color: $text-primary; }
+  &.active {
+    background: rgba($accent-blue, 0.12);
+    color: $accent-blue;
+  }
+}
+
+.posts-count-bar {
+  font-size: 0.78rem;
+  color: $text-secondary;
+  padding: 0.25rem 0;
+}
+
+/* Date group collapse */
+.date-group-header {
+  cursor: pointer;
+  user-select: none;
+}
+
+.date-group-count {
+  font-size: 0.75rem;
+  color: $text-secondary;
+  opacity: 0.7;
+}
+
+.date-group-chevron {
+  margin-left: auto;
+  transition: transform 0.2s ease;
+  opacity: 0.5;
+}
+
+.date-group.collapsed {
+  .post-item { display: none !important; }
+  .date-group-chevron { transform: rotate(-90deg); }
+}
+
+/* Load more button */
+.posts-load-more {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 0;
+}
+
+.load-more-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 2rem;
+  border: 1px solid rgba($border-color, 0.4);
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  background: rgba($bg-card, 0.5);
+  color: $text-primary;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba($accent-blue, 0.1);
+    border-color: $accent-blue;
+    color: $accent-blue;
+    transform: translateY(-1px);
+  }
+
+  span {
+    font-size: 0.75rem;
+    color: $text-secondary;
+  }
+}
+
+/* List view mode */
+.posts-tab-content.list-mode {
+  gap: 0.25rem;
+
+  .date-group { gap: 0.25rem; }
+
+  .post-card {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.6rem 1rem;
+    border-radius: 8px;
+    border-left-width: 3px;
+
+    .post-card-thumb { display: none; }
+
+    .post-card-meta {
+      flex-shrink: 0;
+      min-width: 200px;
+      margin-bottom: 0;
+    }
+
+    h3 {
+      font-size: 0.9rem;
+      margin: 0;
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .post-excerpt,
+    .post-desc-hint { display: none; }
+
+    .post-card-footer {
+      flex-shrink: 0;
+      margin-top: 0;
+      .post-tags { display: none; }
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .posts-sort-view {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .posts-tab-content.list-mode .post-card {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .post-card-meta { min-width: auto; }
+    h3 { white-space: normal; }
+  }
 }
 
 /* ================================


### PR DESCRIPTION
## Summary
홈페이지 최근 포스트 섹션의 사용성을 대폭 개선합니다.

### 새 기능
- **정렬**: 최신순 / 인기순 전환 (콘텐츠 깊이·태그·이미지 유무 기반 점수)
- **뷰 전환**: 카드뷰(기존) / 리스트뷰(컴팩트 한줄) 토글
- **페이지네이션**: 20개씩 표시 + '더보기' 버튼 (남은 건수 표시)
- **날짜 그룹 접기/펼치기**: 클릭으로 토글, 건수 카운트 표시
- **표시 건수**: 'N / M건 표시' 인디케이터

### 개선 효과
- 수백 개 포스트를 한번에 로드하던 문제 해결
- 리스트뷰로 빠르게 내역 스캔 가능
- 인기순으로 중요한 포스트 우선 확인

## Test plan
- [x] Jekyll 빌드 성공 (9.4s)
- [ ] 카드뷰/리스트뷰 전환 확인
- [ ] 최신순/인기순 정렬 확인
- [ ] 더보기 버튼 동작 확인
- [ ] 날짜 그룹 접기/펼치기 확인
- [ ] 모바일 반응형 확인