### PR TITLE
fix: 일일요약 생성 시 pin:true 제거

### DIFF
--- a/scripts/generate_daily_summary.py
+++ b/scripts/generate_daily_summary.py
@@ -2257,7 +2257,6 @@ def main():
 
     content = "\n".join(content_parts)
 
-    # Create post with pin: true
     title = f"일일 뉴스 종합 요약 - {today}"
     slug = "daily-news-summary"
     filename = f"{today}-{slug}.md"
@@ -2291,7 +2290,6 @@ tags: [{", ".join(safe_tags)}]
 keywords: "{keywords}"
 source: "consolidated"
 lang: "ko"{image_line}
-pin: true
 description: "{safe_desc}"
 excerpt: "{counts_str}의 뉴스를 종합 분석한 일일 요약"
 image_alt: "{image_alt}"


### PR DESCRIPTION
## Summary
- generate_daily_summary.py에서 새 포스트 생성 시 pin:true 설정 제거
- 향후 생성되는 일일요약이 최상단에 고정되지 않도록 근본 수정

## Test plan
- [x] Python 컴파일 확인
- [x] scripts/ 내 pin:true 잔여 0건 확인