### PR TITLE
fix: $cat-devops SCSS 변수 복원 (빌드 에러 수정)

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -22,6 +22,7 @@ $cat-political: #dc143c;
 $cat-social: #1da1f2;
 $cat-worldmonitor: #20b2aa;
 $cat-blockchain: #8b5cf6;
+$cat-devops: #4fc3f7;
 
 // Layout
 $container-width: 1100px;


### PR DESCRIPTION
## Summary

- upstream에서 devops 카테고리 페이지 삭제 시 `$cat-devops` 변수도 함께 삭제됨
- 카드 플레이스홀더 CSS (`.cat-bg-devops`)에서 해당 변수를 참조하여 Jekyll 빌드 에러 발생
- `_sass/_variables.scss`에 변수 복원하여 빌드 정상화

## Test plan

- [x] `bundle exec jekyll build` 성공 확인 (10.4초, 에러 없음)

Generated with [Claude Code](https://claude.com/claude-code)