### PR TITLE
fix: SCSS lighten() 함수를 리터럴 색상값으로 대체

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -4178,7 +4178,7 @@ html {
   border: 2px solid $bg-primary;
 
   &:hover {
-  background: linear-gradient(180deg, lighten($accent-blue, 5%), lighten($accent-purple, 5%));
+  background: linear-gradient(180deg, #6db8ff, #cc9aff);
   }
 }
 
@@ -4371,7 +4371,7 @@ html {
     transition: background 0.3s ease;
 
     &:hover {
-  background: linear-gradient(90deg, lighten($accent-blue, 5%), lighten($accent-purple, 5%));
+  background: linear-gradient(90deg, #6db8ff, #cc9aff);
     }
   }
 }
@@ -4583,7 +4583,7 @@ html {
 
   &:hover {
     gap: 0.75rem;
-    color: lighten($accent-blue, 10%);
+    color: #80c0ff;
   }
 }
 


### PR DESCRIPTION
## Summary
- Sass 2.0 deprecation 경고 해결: `lighten()` 호출 3건을 계산된 hex 값으로 대체

## Test plan
- [x] `bundle exec jekyll build` 성공

Generated with [Claude Code](https://claude.com/claude-code)