### PR TITLE
fix: _custom.scss lighten() 경고 완전 제거

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -63,7 +63,7 @@ a {
   transition: all 0.3s ease;
 
   &:hover {
-    color: lighten($accent-blue, 10%);
+    color: #80c0ff;
     text-decoration: none;
   }
 }
@@ -1432,11 +1432,11 @@ a {
       transition: width 0.5s ease;
     }
 
-    .bar-fill-blue { background: linear-gradient(90deg, $accent-blue, lighten($accent-blue, 10%)); }
+    .bar-fill-blue { background: linear-gradient(90deg, $accent-blue, #80c0ff); }
     .bar-fill-orange { background: linear-gradient(90deg, #f7931a, #ffb347); }
-    .bar-fill-purple { background: linear-gradient(90deg, $accent-purple, lighten($accent-purple, 10%)); }
-    .bar-fill-green { background: linear-gradient(90deg, $accent-green, lighten($accent-green, 10%)); }
-    .bar-fill-red { background: linear-gradient(90deg, $accent-red, lighten($accent-red, 10%)); }
+    .bar-fill-purple { background: linear-gradient(90deg, $accent-purple, #d4a8ff); }
+    .bar-fill-green { background: linear-gradient(90deg, $accent-green, #5ee878); }
+    .bar-fill-red { background: linear-gradient(90deg, $accent-red, #fa7d77); }
 
     .theme-count {
       min-width: 80px;


### PR DESCRIPTION
## Summary
- `_custom.scss` 내 나머지 `lighten()` 호출 5건을 계산된 hex 값으로 대체
- Sass 3.0 deprecation 경고 완전 해소 (minima 테마 내부 제외)

## Test plan
- [x] `bundle exec jekyll build` 성공, `_custom.scss` 관련 경고 0건

Generated with [Claude Code](https://claude.com/claude-code)