### PR TITLE
fix: CSP에 Google Fonts 도메인 허용 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://translate.googleapis.com; font-src 'self' data:;" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://translate.googleapis.com; font-src 'self' data: https://fonts.gstatic.com;" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## Summary
- `style-src`에 `https://fonts.googleapis.com` 추가
- `font-src`에 `https://fonts.gstatic.com` 추가
- 브라우저 콘솔 CSP 위반 오류 해결

## Test plan
- [x] `bundle exec jekyll build` 성공
- [x] vercel.json CSP 헤더 변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)