### PR TITLE
feat: 리포트 대시보드 페이지 추가

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -27,5 +27,7 @@ main:
         url: /market-analysis/
       - title: "블록체인"
         url: /blockchain/
+  - title: "리포트"
+    url: /reports/
   - title: "About"
     url: /about/

--- a/_layouts/reports.html
+++ b/_layouts/reports.html
@@ -1,0 +1,203 @@
+---
+layout: default
+---
+
+<section class="reports-dashboard">
+  <!-- Header -->
+  <div class="reports-header">
+    <div class="reports-header-text">
+      <h1>리포트</h1>
+      <p class="reports-subtitle">일일 뉴스, 시장 분석, 규제 동향 등 전체 리포트</p>
+    </div>
+    <div class="reports-stats">
+      <div class="reports-stat">
+        <span class="reports-stat-value">{{ site.posts | size }}</span>
+        <span class="reports-stat-label">전체 리포트</span>
+      </div>
+      <div class="reports-stat">
+        <span class="reports-stat-value">{{ site.categories | size }}</span>
+        <span class="reports-stat-label">카테고리</span>
+      </div>
+      {% assign today = site.time | date: "%Y-%m-%d" %}
+      {% assign today_count = 0 %}
+      {% for post in site.posts %}
+        {% assign post_date = post.date | date: "%Y-%m-%d" %}
+        {% if post_date == today %}
+          {% assign today_count = today_count | plus: 1 %}
+        {% endif %}
+      {% endfor %}
+      <div class="reports-stat">
+        <span class="reports-stat-value">{{ today_count }}</span>
+        <span class="reports-stat-label">오늘 발행</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Filter Controls -->
+  <div class="report-controls">
+    <div class="report-filters">
+      <button class="filter-btn active" data-filter="all">전체</button>
+      {% for cat_entry in site.data.categories %}
+        {% assign cat_key = cat_entry[0] %}
+        {% assign cat = cat_entry[1] %}
+        {% unless cat_key contains "journal" %}
+        <button class="filter-btn" data-filter="{{ cat_key }}" data-color="{{ cat.color }}">{{ cat.name }}</button>
+        {% endunless %}
+      {% endfor %}
+    </div>
+    <div class="report-search-row">
+      <div class="report-search-wrap">
+        <svg class="report-search-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <input type="text" id="report-search" class="report-search" placeholder="리포트 검색...">
+      </div>
+      <div class="report-date-wrap">
+        <input type="date" id="report-date-from" class="report-date">
+        <span class="report-date-sep">~</span>
+        <input type="date" id="report-date-to" class="report-date">
+      </div>
+      <button id="report-clear" class="report-clear-btn">초기화</button>
+    </div>
+  </div>
+
+  <!-- Reports Grid -->
+  <div class="reports-grid" id="reports-grid">
+    {% for post in site.posts %}
+      {% assign cat_slug = post.categories[0] | default: "uncategorized" %}
+      {% assign cat_info = site.data.categories[cat_slug] %}
+      {% assign cat_name = cat_info.name | default: cat_slug %}
+      {% assign cat_color = cat_info.color | default: "cat-stock" %}
+      <a href="{{ post.url | relative_url }}"
+         class="report-card"
+         data-category="{{ cat_slug }}"
+         data-date="{{ post.date | date: '%Y-%m-%d' }}"
+         data-title="{{ post.title | downcase }}"
+         data-desc="{{ post.description | default: post.excerpt | strip_html | truncate: 200 | downcase }}">
+        <div class="report-card-header">
+          <span class="report-category-badge badge-{{ cat_color }}">{{ cat_name }}</span>
+          <time class="report-date-label" datetime="{{ post.date | date_to_xmlschema }}">
+            {{ post.date | date: "%m.%d %H:%M" }}
+          </time>
+        </div>
+        <h3 class="report-title">{{ post.title }}</h3>
+        <p class="report-summary">
+          {{ post.description | default: post.excerpt | strip_html | truncate: 150 }}
+        </p>
+        {% if post.tags.size > 0 %}
+        <div class="report-tags">
+          {% for tag in post.tags limit:4 %}
+            <span class="report-tag">{{ tag }}</span>
+          {% endfor %}
+        </div>
+        {% endif %}
+        <div class="report-card-footer">
+          <span class="report-read-more">자세히 보기
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+          </span>
+        </div>
+      </a>
+    {% endfor %}
+  </div>
+
+  <!-- Load More -->
+  <div class="reports-load-more" id="reports-load-more">
+    <button id="load-more-btn" class="load-more-btn">더 보기</button>
+    <p class="reports-showing" id="reports-showing"></p>
+  </div>
+</section>
+
+<script>
+(function() {
+  const PAGE_SIZE = 24;
+  let currentPage = 1;
+  let activeFilter = 'all';
+  let searchQuery = '';
+  let dateFrom = '';
+  let dateTo = '';
+
+  const grid = document.getElementById('reports-grid');
+  const cards = Array.from(grid.querySelectorAll('.report-card'));
+  const loadMoreBtn = document.getElementById('load-more-btn');
+  const showingEl = document.getElementById('reports-showing');
+  const searchInput = document.getElementById('report-search');
+  const dateFromInput = document.getElementById('report-date-from');
+  const dateToInput = document.getElementById('report-date-to');
+  const clearBtn = document.getElementById('report-clear');
+  const filterBtns = document.querySelectorAll('.filter-btn');
+
+  function getFiltered() {
+    return cards.filter(function(card) {
+      if (activeFilter !== 'all' && card.dataset.category !== activeFilter) return false;
+      if (searchQuery) {
+        var t = card.dataset.title || '';
+        var d = card.dataset.desc || '';
+        if (t.indexOf(searchQuery) === -1 && d.indexOf(searchQuery) === -1) return false;
+      }
+      if (dateFrom && card.dataset.date < dateFrom) return false;
+      if (dateTo && card.dataset.date > dateTo) return false;
+      return true;
+    });
+  }
+
+  function render() {
+    var filtered = getFiltered();
+    var visible = currentPage * PAGE_SIZE;
+    cards.forEach(function(c) { c.style.display = 'none'; c.classList.remove('report-card-visible'); });
+    filtered.forEach(function(c, i) {
+      if (i < visible) {
+        c.style.display = '';
+        requestAnimationFrame(function() {
+          requestAnimationFrame(function() { c.classList.add('report-card-visible'); });
+        });
+      }
+    });
+    loadMoreBtn.style.display = visible >= filtered.length ? 'none' : '';
+    showingEl.textContent = Math.min(visible, filtered.length) + ' / ' + filtered.length + '건';
+  }
+
+  filterBtns.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      filterBtns.forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      activeFilter = btn.dataset.filter;
+      currentPage = 1;
+      render();
+    });
+  });
+
+  searchInput.addEventListener('input', function() {
+    searchQuery = this.value.toLowerCase().trim();
+    currentPage = 1;
+    render();
+  });
+
+  dateFromInput.addEventListener('change', function() { dateFrom = this.value; currentPage = 1; render(); });
+  dateToInput.addEventListener('change', function() { dateTo = this.value; currentPage = 1; render(); });
+
+  clearBtn.addEventListener('click', function() {
+    searchInput.value = '';
+    dateFromInput.value = '';
+    dateToInput.value = '';
+    searchQuery = ''; dateFrom = ''; dateTo = '';
+    filterBtns.forEach(function(b) { b.classList.remove('active'); });
+    filterBtns[0].classList.add('active');
+    activeFilter = 'all';
+    currentPage = 1;
+    render();
+  });
+
+  loadMoreBtn.addEventListener('click', function() {
+    currentPage++;
+    render();
+  });
+
+  // Keyboard shortcut: / to focus search
+  document.addEventListener('keydown', function(e) {
+    if (e.key === '/' && document.activeElement.tagName !== 'INPUT') {
+      e.preventDefault();
+      searchInput.focus();
+    }
+  });
+
+  render();
+})();
+</script>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -12,4 +12,5 @@
 @import "components/tables";
 @import "components/footer";
 @import "components/journal";
+@import "components/reports";
 @import "components/utilities";

--- a/_sass/components/_reports.scss
+++ b/_sass/components/_reports.scss
@@ -1,0 +1,400 @@
+// ==========================================================
+// Reports Dashboard - Crypto Monitoring Style
+// ==========================================================
+
+.reports-dashboard {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+}
+
+// ---------- Header ----------
+.reports-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}
+
+.reports-header-text {
+  h1 {
+    font-size: 1.75rem;
+    font-weight: 800;
+    color: var(--text-primary);
+    margin: 0 0 0.25rem;
+    letter-spacing: -0.02em;
+  }
+}
+
+.reports-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.reports-stats {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.reports-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.reports-stat-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--accent-blue);
+  font-family: var(--font-mono);
+}
+
+.reports-stat-label {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+// ---------- Filter Controls ----------
+.report-controls {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  backdrop-filter: blur(12px);
+}
+
+.report-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.filter-btn {
+  padding: 0.35rem 0.85rem;
+  border-radius: 20px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: var(--font-sans);
+  white-space: nowrap;
+
+  &:hover {
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+    background: rgba(77, 166, 255, 0.08);
+  }
+
+  &.active {
+    background: var(--accent-blue);
+    color: #fff;
+    border-color: var(--accent-blue);
+  }
+}
+
+.report-search-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.report-search-wrap {
+  flex: 1;
+  min-width: 200px;
+  position: relative;
+}
+
+.report-search-icon {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-secondary);
+  pointer-events: none;
+}
+
+.report-search {
+  width: 100%;
+  padding: 0.5rem 0.75rem 0.5rem 2.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-family: var(--font-sans);
+  outline: none;
+  transition: border-color 0.2s;
+
+  &::placeholder {
+    color: var(--text-secondary);
+    opacity: 0.6;
+  }
+
+  &:focus {
+    border-color: var(--accent-blue);
+    box-shadow: var(--focus-ring);
+  }
+}
+
+.report-date-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.report-date-sep {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.report-date {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  font-family: var(--font-sans);
+  outline: none;
+  width: 140px;
+  transition: border-color 0.2s;
+
+  &:focus {
+    border-color: var(--accent-blue);
+    box-shadow: var(--focus-ring);
+  }
+}
+
+.report-clear-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: var(--accent-red);
+    color: var(--accent-red);
+  }
+}
+
+// ---------- Reports Grid ----------
+.reports-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1rem;
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+// ---------- Report Card ----------
+.report-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.15rem 1.25rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+  opacity: 0;
+  transform: translateY(12px);
+
+  &.report-card-visible {
+    opacity: 1;
+    transform: translateY(0);
+    transition: transform 0.35s ease, border-color 0.25s ease, box-shadow 0.25s ease, opacity 0.35s ease;
+  }
+
+  &:hover {
+    transform: translateY(-3px);
+    border-color: var(--accent-blue);
+    box-shadow: 0 8px 30px rgba(77, 166, 255, 0.12);
+
+    .report-read-more {
+      color: var(--accent-blue);
+      svg { transform: translateX(3px); }
+    }
+  }
+}
+
+.report-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.6rem;
+}
+
+.report-category-badge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+// Badge color variants
+.badge-cat-crypto    { background: rgba($cat-crypto, 0.15);    color: $cat-crypto; }
+.badge-cat-stock     { background: rgba($cat-stock, 0.15);     color: $cat-stock; }
+.badge-cat-journal   { background: rgba($cat-journal, 0.15);   color: $cat-journal; }
+.badge-cat-security  { background: rgba($cat-security, 0.15);  color: $cat-security; }
+.badge-cat-analysis  { background: rgba($cat-analysis, 0.15);  color: $cat-analysis; }
+.badge-cat-regulatory{ background: rgba($cat-regulatory, 0.15);color: $cat-regulatory; }
+.badge-cat-political { background: rgba($cat-political, 0.15); color: $cat-political; }
+.badge-cat-social    { background: rgba($cat-social, 0.15);    color: $cat-social; }
+.badge-cat-worldmonitor { background: rgba($cat-worldmonitor, 0.15); color: $cat-worldmonitor; }
+.badge-cat-blockchain{ background: rgba($cat-blockchain, 0.15);color: $cat-blockchain; }
+.badge-cat-devops    { background: rgba($cat-devops, 0.15);    color: $cat-devops; }
+
+.report-date-label {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
+.report-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.5rem;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.report-summary {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0 0 0.6rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  flex: 1;
+}
+
+.report-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.6rem;
+}
+
+.report-tag {
+  font-size: 0.65rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  background: rgba(77, 166, 255, 0.08);
+  color: var(--text-secondary);
+  border: 1px solid rgba(77, 166, 255, 0.12);
+}
+
+.report-card-footer {
+  margin-top: auto;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.report-read-more {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  transition: color 0.2s;
+
+  svg {
+    transition: transform 0.2s;
+  }
+}
+
+// ---------- Load More ----------
+.reports-load-more {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 2rem;
+}
+
+.load-more-btn {
+  padding: 0.6rem 2rem;
+  border-radius: 8px;
+  border: 1px solid var(--accent-blue);
+  background: transparent;
+  color: var(--accent-blue);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all 0.2s;
+
+  &:hover {
+    background: var(--accent-blue);
+    color: #fff;
+  }
+}
+
+.reports-showing {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+// ---------- Light mode adjustments ----------
+[data-theme="light"] {
+  .report-card {
+    box-shadow: var(--shadow-card, 0 2px 8px rgba(0,0,0,0.06));
+    &:hover {
+      box-shadow: var(--shadow-card-hover, 0 8px 24px rgba(0,0,0,0.1));
+    }
+  }
+
+  .report-controls {
+    box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    .report-card {
+      box-shadow: var(--shadow-card, 0 2px 8px rgba(0,0,0,0.06));
+      &:hover {
+        box-shadow: var(--shadow-card-hover, 0 8px 24px rgba(0,0,0,0.1));
+      }
+    }
+
+    .report-controls {
+      box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+    }
+  }
+}

--- a/pages/reports.md
+++ b/pages/reports.md
@@ -1,0 +1,6 @@
+---
+layout: reports
+title: "리포트"
+description: "일일 뉴스, 시장 분석, 규제 동향 등 전체 리포트를 한눈에 확인하세요."
+permalink: /reports/
+---


### PR DESCRIPTION
## Summary
- crypto 모니터링 대시보드 스타일의 리포트 카드 그리드 UI 구현
- 카테고리 필터 (10개), 텍스트 검색, 날짜 범위 필터링
- 카드별 카테고리 배지, 요약 3줄, 태그, hover lift 효과
- 24건씩 점진적 로딩, 다크/라이트 모드 대응
- 네비게이션 메뉴에 리포트 항목 추가

## Test plan
- [x] Jekyll 빌드 성공 (13초)
- [x] 렌더링 검증: 1236 카드 참조, 11 필터 버튼, 411 배지
- [x] SCSS 컴파일 정상