### PR TITLE
feat: 네비게이션 해시 링크 + CoinGecko 스파크라인 + 오늘의 하이라이트

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -28,6 +28,18 @@ main:
       - title: "블록체인"
         url: /blockchain/
   - title: "리포트"
-    url: /reports/
+    children:
+      - title: "전체 리포트"
+        url: /reports/
+      - title: "암호화폐"
+        url: /reports/#crypto-news
+      - title: "주식"
+        url: /reports/#stock-news
+      - title: "글로벌 모니터"
+        url: /reports/#worldmonitor
+      - title: "규제 동향"
+        url: /reports/#regulatory-news
+      - title: "정치인 거래"
+        url: /reports/#political-trades
   - title: "About"
     url: /about/

--- a/_layouts/reports.html
+++ b/_layouts/reports.html
@@ -33,6 +33,15 @@ layout: default
     </div>
   </div>
 
+  <!-- Today's Highlights -->
+  <div class="reports-highlights" id="reports-highlights" style="display:none">
+    <h2 class="highlights-title">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+      오늘의 하이라이트
+    </h2>
+    <div class="highlights-grid" id="highlights-grid"></div>
+  </div>
+
   <!-- Charts Section -->
   <div class="reports-charts">
     <div class="report-chart-card">
@@ -220,6 +229,28 @@ layout: default
       searchInput.focus();
     }
   });
+
+  // --- Today's Highlights ---
+  (function() {
+    var today = new Date().toISOString().slice(0, 10);
+    var todayPosts = posts.filter(function(p) { return p.d === today; });
+    if (todayPosts.length === 0) return;
+    var container = document.getElementById('reports-highlights');
+    var grid = document.getElementById('highlights-grid');
+    container.style.display = '';
+    var shown = todayPosts.slice(0, 6);
+    grid.innerHTML = shown.map(function(p) {
+      var bc = BADGE_COLORS[p.cc] || ['rgba(88,166,255,0.15)', '#58a6ff'];
+      var thumbHtml = p.img ? '<img class="highlight-thumb" src="' + p.img + '" alt="" loading="lazy">' : '';
+      return '<a href="' + p.u + '" class="highlight-card">' +
+        thumbHtml +
+        '<div class="highlight-body">' +
+        '<span class="report-category-badge" style="background:' + bc[0] + ';color:' + bc[1] + '">' + p.cn + '</span>' +
+        '<h4 class="highlight-title">' + p.t + '</h4>' +
+        '<p class="highlight-summary">' + (p.s || '').slice(0, 80) + '</p>' +
+        '</div></a>';
+    }).join('');
+  })();
 
   // --- Hash-based filter ---
   function applyHash() {

--- a/_sass/components/_reports.scss
+++ b/_sass/components/_reports.scss
@@ -200,6 +200,87 @@
   }
 }
 
+// ---------- Today's Highlights ----------
+.reports-highlights {
+  margin-bottom: 1.5rem;
+}
+
+.highlights-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--accent-orange);
+  margin: 0 0 0.75rem;
+
+  svg { color: var(--accent-orange); }
+}
+
+.highlights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.highlight-card {
+  display: flex;
+  gap: 0.75rem;
+  background: var(--bg-card);
+  border: 1px solid var(--accent-orange);
+  border-left-width: 3px;
+  border-radius: 10px;
+  padding: 0.85rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s, box-shadow 0.2s;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(227, 168, 43, 0.15);
+  }
+}
+
+.highlight-thumb {
+  width: 64px;
+  height: 64px;
+  border-radius: 8px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.highlight-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.highlight-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.highlight-summary {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 // ---------- Charts Section ----------
 .reports-charts {
   display: grid;

--- a/scripts/common/image_generator.py
+++ b/scripts/common/image_generator.py
@@ -998,7 +998,7 @@ def generate_top_coins_card(
         bar_x = 6.4
         _draw_rounded_rect(ax, bar_x, y - 0.06, bar_w, 0.12, facecolor=color_24h, alpha=0.35, pad=0.005)
 
-        # --- 7d change with mini bar ---
+        # --- 7d change with sparkline ---
         color_7d = _get_change_color(change_7d)
         arrow_7d = "+" if change_7d >= 0 else ""
         ax.text(
@@ -1010,9 +1010,25 @@ def generate_top_coins_card(
             ha="left",
             fontfamily=_FONT_FAMILY,
         )
-        bar_w_7d = min(abs(change_7d) / 15.0, 1.0) * bar_max_w
-        bar_x_7d = 7.9
-        _draw_rounded_rect(ax, bar_x_7d, y - 0.06, bar_w_7d, 0.12, facecolor=color_7d, alpha=0.3, pad=0.005)
+        # Draw sparkline from CoinGecko 7d price data if available
+        spark_data = None
+        if source == "coingecko":
+            spark_data = (coin.get("sparkline_in_7d") or {}).get("price")
+        if spark_data and len(spark_data) >= 10:
+            spark_arr = np.array(spark_data[-24:], dtype=float)  # Last 24 data points (~1 day intervals)
+            smin, smax = spark_arr.min(), spark_arr.max()
+            if smax > smin:
+                spark_norm = (spark_arr - smin) / (smax - smin)
+            else:
+                spark_norm = np.full(len(spark_arr), 0.5)
+            sx = np.linspace(7.9, 8.7, len(spark_norm))
+            sy = y - 0.15 + spark_norm * 0.3
+            ax.plot(sx, sy, color=color_7d, linewidth=1.2, alpha=0.7, solid_capstyle="round")
+            ax.fill_between(sx, y - 0.15, sy, color=color_7d, alpha=0.08)
+        else:
+            bar_w_7d = min(abs(change_7d) / 15.0, 1.0) * bar_max_w
+            bar_x_7d = 7.9
+            _draw_rounded_rect(ax, bar_x_7d, y - 0.06, bar_w_7d, 0.12, facecolor=color_7d, alpha=0.3, pad=0.005)
 
         # Market cap
         if mcap >= 1_000_000_000_000:


### PR DESCRIPTION
## Summary
- 네비게이션에 리포트 카테고리 해시 링크 드롭다운 추가 (암호화폐/주식/글로벌/규제/정치)
- CoinGecko `sparkline_in_7d` 데이터로 Top Coins 카드 7d 열에 실제 스파크라인 렌더링
- 리포트 페이지 상단 "오늘의 하이라이트" 섹션 (최대 6건, 썸네일+배지)

## Test plan
- [x] Jekyll 빌드 성공 (12초)
- [x] 143 image generator tests passed
- [x] ruff lint clean