### PR TITLE
feat: 번역 교정 CI 자동화 + 무한 스크롤 + 히트맵 스파크라인

### DIFF
--- a/_layouts/reports.html
+++ b/_layouts/reports.html
@@ -223,6 +223,21 @@ layout: default
     render();
   });
 
+  // Infinite scroll with IntersectionObserver
+  if ('IntersectionObserver' in window) {
+    var sentinel = document.createElement('div');
+    sentinel.id = 'scroll-sentinel';
+    sentinel.style.height = '1px';
+    document.getElementById('reports-load-more').appendChild(sentinel);
+    var observer = new IntersectionObserver(function(entries) {
+      if (entries[0].isIntersecting && loadMoreBtn.style.display !== 'none') {
+        currentPage++;
+        render();
+      }
+    }, { rootMargin: '200px' });
+    observer.observe(sentinel);
+  }
+
   document.addEventListener('keydown', function(e) {
     if (e.key === '/' && document.activeElement.tagName !== 'INPUT') {
       e.preventDefault();

--- a/scripts/common/image_generator.py
+++ b/scripts/common/image_generator.py
@@ -1496,18 +1496,39 @@ def generate_market_heatmap(
         # Change -- with sign prefix instead of arrow for clarity
         change_color = _get_change_color(change)
         sign = "+" if change >= 0 else ""
-        ax.text(
-            x + cell_w / 2,
-            y + cell_h * 0.18,
-            f"{sign}{change:.2f}%",
-            ha="center",
-            va="center",
-            transform=ax.transAxes,
-            fontsize=12,
-            fontweight="bold",
-            color=change_color,
-            fontfamily=_FONT_FAMILY,
-        )
+
+        # Sparkline overlay if available
+        spark_data = None
+        if source == "coingecko":
+            spark_data = (coin.get("sparkline_in_7d") or {}).get("price")
+        if spark_data and len(spark_data) >= 10:
+            spark_arr = np.array(spark_data[-48:], dtype=float)
+            smin, smax = spark_arr.min(), spark_arr.max()
+            if smax > smin:
+                spark_norm = (spark_arr - smin) / (smax - smin)
+            else:
+                spark_norm = np.full(len(spark_arr), 0.5)
+            sx = np.linspace(x + 0.01, x + cell_w - 0.01, len(spark_norm))
+            sy_base = y + cell_h * 0.02
+            sy = sy_base + spark_norm * (cell_h * 0.28)
+            ax.plot(sx, sy, color=change_color, linewidth=0.8, alpha=0.5, transform=ax.transAxes, solid_capstyle="round")
+            ax.fill_between(sx, sy_base, sy, color=change_color, alpha=0.06, transform=ax.transAxes)
+            # Change text above sparkline
+            ax.text(
+                x + cell_w / 2,
+                y + cell_h * 0.35,
+                f"{sign}{change:.2f}%",
+                ha="center", va="center", transform=ax.transAxes,
+                fontsize=12, fontweight="bold", color=change_color, fontfamily=_FONT_FAMILY,
+            )
+        else:
+            ax.text(
+                x + cell_w / 2,
+                y + cell_h * 0.18,
+                f"{sign}{change:.2f}%",
+                ha="center", va="center", transform=ax.transAxes,
+                fontsize=12, fontweight="bold", color=change_color, fontfamily=_FONT_FAMILY,
+            )
 
     # Color scale legend at bottom
     legend_y = 0.03

--- a/scripts/improve_existing_posts.py
+++ b/scripts/improve_existing_posts.py
@@ -531,9 +531,20 @@ def remove_duplicate_articles_in_themes(body: str) -> tuple[str, bool]:
 def fix_translation_artifacts(body: str) -> tuple[str, bool]:
     """Fix known machine translation artifacts in post body.
 
-    Applies particle corrections, name fixes, and awkward phrasing cleanup.
+    Applies _MISTRANSLATION_FIXES from post_generator, particle corrections,
+    name fixes, and awkward phrasing cleanup.
     """
     original = body
+
+    # Apply centralized mistranslation dictionary first
+    try:
+        from common.post_generator import _MISTRANSLATION_FIXES
+
+        for wrong, correct in _MISTRANSLATION_FIXES.items():
+            body = body.replace(wrong, correct)
+    except ImportError:
+        pass
+
     fixes = [
         # Particle corrections (names without 받침)
         ("트럼프은 ", "트럼프는 "),


### PR DESCRIPTION
## Summary
- `improve_existing_posts.py`에 `_MISTRANSLATION_FIXES` 사전 통합으로 CI 수집 시 자동 번역 교정
- 리포트 페이지 IntersectionObserver 기반 무한 스크롤 (더 보기 버튼 유지 + 자동 로딩)
- Market Heatmap 각 코인 셀에 7일 스파크라인 오버레이 + fill 렌더링

## Test plan
- [x] 143 image generator tests passed
- [x] ruff lint clean
- [x] Jekyll 빌드 성공 (13초)