### PR TITLE
feat: PWA manifest 강화 + 스켈레톤 로딩 + 카테고리별 description

### DIFF
--- a/_layouts/reports.html
+++ b/_layouts/reports.html
@@ -81,7 +81,14 @@ layout: default
   </div>
 
   <!-- Reports Grid (JS-rendered) -->
-  <div class="reports-grid" id="reports-grid"></div>
+  <div class="reports-grid" id="reports-grid">
+    <div class="skeleton-card"></div>
+    <div class="skeleton-card"></div>
+    <div class="skeleton-card"></div>
+    <div class="skeleton-card"></div>
+    <div class="skeleton-card"></div>
+    <div class="skeleton-card"></div>
+  </div>
 
   <!-- Load More -->
   <div class="reports-load-more" id="reports-load-more">

--- a/_sass/components/_reports.scss
+++ b/_sass/components/_reports.scss
@@ -462,6 +462,42 @@
   }
 }
 
+// ---------- Skeleton Loading ----------
+.skeleton-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.15rem 1.25rem;
+  min-height: 180px;
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    display: block;
+    height: 14px;
+    width: 60px;
+    background: var(--border-color);
+    border-radius: 10px;
+    margin-bottom: 0.75rem;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(77,166,255,0.04), transparent);
+    animation: shimmer 1.8s infinite;
+  }
+}
+
+@keyframes shimmer {
+  100% { left: 100%; }
+}
+
 // ---------- Load More ----------
 .reports-load-more {
   display: flex;

--- a/manifest.json
+++ b/manifest.json
@@ -4,18 +4,52 @@
   "description": "암호화폐·주식 뉴스 자동 수집 및 시장 분석",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#0d1117",
-  "theme_color": "#0d1117",
+  "background_color": "#0a0e14",
+  "theme_color": "#0a0e14",
+  "orientation": "portrait-primary",
   "icons": [
+    {
+      "src": "/assets/images/favicon-32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/images/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    },
     {
       "src": "/assets/images/favicon-192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "/assets/images/favicon-512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
-  ]
+  ],
+  "shortcuts": [
+    {
+      "name": "리포트",
+      "short_name": "리포트",
+      "url": "/reports/",
+      "icons": [{"src": "/assets/images/favicon-192.png", "sizes": "192x192"}]
+    },
+    {
+      "name": "암호화폐 뉴스",
+      "short_name": "크립토",
+      "url": "/reports/#crypto-news",
+      "icons": [{"src": "/assets/images/favicon-192.png", "sizes": "192x192"}]
+    },
+    {
+      "name": "주식 뉴스",
+      "short_name": "주식",
+      "url": "/reports/#stock-news",
+      "icons": [{"src": "/assets/images/favicon-192.png", "sizes": "192x192"}]
+    }
+  ],
+  "categories": ["finance", "news"]
 }

--- a/scripts/common/post_generator.py
+++ b/scripts/common/post_generator.py
@@ -421,8 +421,44 @@ _CATEGORY_KO: dict[str, str] = {
 }
 
 
+_CATEGORY_DESC_TEMPLATES: dict[str, list[str]] = {
+    "crypto-news": [
+        "{title} - 비트코인, 이더리움 등 암호화폐 시장 핵심 동향.{tags}",
+        "오늘의 암호화폐 브리핑: {title}. 시세 변동과 온체인 데이터를 분석합니다.{tags}",
+        "{title}. 크립토 시장 심리와 자금 흐름을 점검합니다.{tags}",
+    ],
+    "stock-news": [
+        "{title} - 미국·한국 주식 시장 동향과 섹터별 분석.{tags}",
+        "오늘의 주식 시장: {title}. 주요 지수와 종목 흐름을 정리합니다.{tags}",
+        "{title}. 매크로 지표와 기업 실적이 시장에 미치는 영향을 살펴봅니다.{tags}",
+    ],
+    "regulatory-news": [
+        "{title} - 글로벌 금융 규제 및 정책 변화 추적.{tags}",
+        "규제 동향 브리핑: {title}. 각국 규제 기관의 최신 결정을 분석합니다.{tags}",
+        "{title}. 규제 환경 변화가 시장에 미칠 영향을 점검합니다.{tags}",
+    ],
+    "worldmonitor": [
+        "{title} - 지정학적 리스크와 글로벌 이슈 모니터링.{tags}",
+        "글로벌 브리핑: {title}. 국제 정세가 금융 시장에 미치는 영향을 분석합니다.{tags}",
+        "{title}. 지정학적 변수와 매크로 리스크를 점검합니다.{tags}",
+    ],
+    "political-trades": [
+        "{title} - 미국 의회 내부자 거래와 정책 동향 추적.{tags}",
+        "정치인 거래 리포트: {title}. 입법 동향과 의원 포트폴리오를 분석합니다.{tags}",
+    ],
+    "social-media": [
+        "{title} - 소셜 미디어 트렌드와 커뮤니티 반응 분석.{tags}",
+        "소셜 브리핑: {title}. 시장 심리와 커뮤니티 동향을 정리합니다.{tags}",
+    ],
+}
+
+
 def _build_fallback_description(title: str, category: str, tags: Optional[List[str]] = None) -> str:
-    """Build a fallback SEO description from title and category when content extraction fails."""
+    """Build a fallback SEO description from title and category.
+
+    Uses category-specific templates for better SEO diversity,
+    falling back to generic templates when no match exists.
+    """
     cat_ko = _CATEGORY_KO.get(category, category)
     tag_str = ""
     if tags and len(tags) >= 2:
@@ -430,6 +466,15 @@ def _build_fallback_description(title: str, category: str, tags: Optional[List[s
 
     # Clean title for description use
     clean_title = re.sub(r"[*_`~]", "", title).strip()
+
+    # Try category-specific template first
+    cat_templates = _CATEGORY_DESC_TEMPLATES.get(category)
+    if cat_templates:
+        seed = hash((datetime.now(UTC).date().isoformat(), title))
+        template = cat_templates[seed % len(cat_templates)]
+        desc = template.format(title=clean_title, tags=tag_str)
+        return smart_truncate(desc, 160)
+
     templates = [
         f"{clean_title} - 최신 {cat_ko} 뉴스와 분석을 확인하세요.{tag_str}",
         f"{cat_ko} 분야 핵심 동향: {clean_title}.{tag_str}",


### PR DESCRIPTION
## Summary
- `manifest.json`: maskable 아이콘, PWA shortcuts (리포트/크립토/주식), categories 추가
- 리포트 카드 스켈레톤 shimmer 애니메이션 (6개 placeholder, JS 렌더 후 교체)
- 6개 카테고리별 맞춤 SEO description 템플릿 (crypto/stock/regulatory/worldmonitor/political/social)

## Test plan
- [x] 86 post_generator tests passed
- [x] ruff lint clean
- [x] Jekyll 빌드 성공 (13초)