### PR TITLE
feat: 검색 디바운스+하이라이트, TOC 사이드바, 상대 시간 배지

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -88,16 +88,20 @@ layout: default
   {% include trading-journal-summary.html %}
   {% endif %}
 
-  <nav class="post-toc" id="post-toc">
-    <div class="toc-header" id="toc-header">
-      <span class="toc-title" data-i18n="toc">목차</span>
-      <svg class="toc-toggle-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
-    </div>
-    <ol class="toc-list" id="toc-list"></ol>
-  </nav>
+  <div class="post-layout-wrapper">
+    <aside class="post-toc-sidebar" id="post-toc-sidebar">
+      <nav class="post-toc post-toc-sticky" id="post-toc">
+        <div class="toc-header" id="toc-header">
+          <span class="toc-title" data-i18n="toc">목차</span>
+          <svg class="toc-toggle-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+        </div>
+        <ol class="toc-list" id="toc-list"></ol>
+      </nav>
+    </aside>
 
-  <div class="post-content prose-content" translate="yes">
-    {{ content }}
+    <div class="post-content prose-content" translate="yes">
+      {{ content }}
+    </div>
   </div>
 
   <section class="post-engagement">

--- a/_layouts/reports.html
+++ b/_layouts/reports.html
@@ -144,6 +144,26 @@ layout: default
     return d.innerHTML;
   }
 
+  function highlightText(html) {
+    if (!searchQuery || searchQuery.length < 2) return html;
+    var escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return html.replace(new RegExp('(' + escaped + ')', 'gi'), '<mark class="search-highlight">$1</mark>');
+  }
+
+  function relativeTime(dateStr) {
+    var now = new Date();
+    var d = new Date(dateStr + 'T00:00:00');
+    var diff = Math.floor((now - d) / (1000 * 60 * 60));
+    if (diff < 1) return '방금 전';
+    if (diff < 24) return diff + '시간 전';
+    var days = Math.floor(diff / 24);
+    if (days === 0) return '오늘';
+    if (days === 1) return '어제';
+    if (days < 7) return days + '일 전';
+    if (days < 30) return Math.floor(days / 7) + '주 전';
+    return Math.floor(days / 30) + '개월 전';
+  }
+
   function buildCard(p) {
     var thumbHtml = '';
     if (p.img) {
@@ -162,9 +182,10 @@ layout: default
       '<div class="report-card-header">' +
       '<span class="report-category-badge" style="background:' + bc[0] + ';color:' + bc[1] + '">' + escapeHtml(p.cn) + '</span>' +
       '<time class="report-date-label">' + escapeHtml(p.dm) + '</time>' +
+      '<span class="report-relative-time">' + relativeTime(p.d) + '</span>' +
       '</div>' +
-      '<h3 class="report-title">' + escapeHtml(p.t) + '</h3>' +
-      '<p class="report-summary">' + escapeHtml(p.s) + '</p>' +
+      '<h3 class="report-title">' + highlightText(escapeHtml(p.t)) + '</h3>' +
+      '<p class="report-summary">' + highlightText(escapeHtml(p.s)) + '</p>' +
       tagsHtml +
       '<div class="report-card-footer">' +
       '<span class="report-read-more">자세히 보기 <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span>' +
@@ -204,10 +225,15 @@ layout: default
     });
   });
 
+  var _searchTimer;
   searchInput.addEventListener('input', function() {
-    searchQuery = this.value.toLowerCase().trim();
-    currentPage = 1;
-    render();
+    var val = this.value.toLowerCase().trim();
+    clearTimeout(_searchTimer);
+    _searchTimer = setTimeout(function() {
+      searchQuery = val;
+      currentPage = 1;
+      render();
+    }, 300);
   });
 
   dateFromInput.addEventListener('change', function() { dateFrom = this.value; currentPage = 1; render(); });

--- a/_sass/components/_reports.scss
+++ b/_sass/components/_reports.scss
@@ -531,6 +531,24 @@
   margin: 0;
 }
 
+// ---------- Search Highlight ----------
+.search-highlight {
+  background: rgba(77, 166, 255, 0.25);
+  color: var(--text-primary);
+  border-radius: 2px;
+  padding: 0 2px;
+}
+
+// ---------- Relative Time Badge ----------
+.report-relative-time {
+  font-size: 0.65rem;
+  color: var(--accent-blue);
+  background: rgba(77, 166, 255, 0.08);
+  padding: 0.1rem 0.4rem;
+  border-radius: 8px;
+  white-space: nowrap;
+}
+
 // ---------- Light mode adjustments ----------
 [data-theme="light"] {
   .report-card {

--- a/_sass/components/_utilities.scss
+++ b/_sass/components/_utilities.scss
@@ -866,6 +866,44 @@ main {
 /* ================================
    TABLE OF CONTENTS (TOC)
    ================================ */
+
+// Post layout wrapper for sidebar TOC
+.post-layout-wrapper {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+
+  @media (max-width: 1024px) {
+    flex-direction: column;
+  }
+
+  > .post-content {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+.post-toc-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  order: -1;
+
+  @media (max-width: 1024px) {
+    width: 100%;
+    order: 0;
+  }
+}
+
+.post-toc-sticky {
+  @media (min-width: 1025px) {
+    position: sticky;
+    top: 5rem;
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+    scrollbar-width: thin;
+  }
+}
+
 .post-toc {
   background: linear-gradient(135deg, rgba($bg-card, 0.4) 0%, rgba($bg-secondary, 0.6) 100%);
   border: 1px solid rgba($border-color, 0.4);


### PR DESCRIPTION
## Summary
- 리포트 검색 300ms 디바운스 + 매칭 텍스트 하이라이트 (mark 태그)
- post.html TOC를 sticky 사이드바로 이동 (데스크톱 1025px+, 모바일은 인라인 폴백)
- 리포트 카드에 상대 시간 배지 표시 (방금 전/N시간 전/어제/N일 전/N주 전)

## Test plan
- [x] Jekyll 빌드 성공 (13초)
- [x] 리포트 페이지 + 포스트 페이지 렌더링 확인