### PR TITLE
feat: TOC 사이드바 개선 + 즐겨찾기 + 하이라이트 라이트모드

### DIFF
--- a/_layouts/reports.html
+++ b/_layouts/reports.html
@@ -58,6 +58,10 @@ layout: default
   <div class="report-controls">
     <div class="report-filters">
       <button class="filter-btn active" data-filter="all">전체</button>
+      <button class="filter-btn" data-filter="_bookmarks" data-color="cat-bookmark">
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" stroke="none"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+        즐겨찾기
+      </button>
       {% for cat_entry in site.data.categories %}
         {% assign cat_key = cat_entry[0] %}
         {% assign cat = cat_entry[1] %}
@@ -150,6 +154,15 @@ layout: default
     return html.replace(new RegExp('(' + escaped + ')', 'gi'), '<mark class="search-highlight">$1</mark>');
   }
 
+  // --- Bookmarks ---
+  var bookmarks = JSON.parse(localStorage.getItem('report-bookmarks') || '{}');
+  function isBookmarked(url) { return !!bookmarks[url]; }
+  function toggleBookmark(url, btn) {
+    if (bookmarks[url]) { delete bookmarks[url]; btn.classList.remove('bookmarked'); }
+    else { bookmarks[url] = 1; btn.classList.add('bookmarked'); }
+    localStorage.setItem('report-bookmarks', JSON.stringify(bookmarks));
+  }
+
   function relativeTime(dateStr) {
     var now = new Date();
     var d = new Date(dateStr + 'T00:00:00');
@@ -176,7 +189,9 @@ layout: default
       }).join('') + '</div>';
     }
     var bc = BADGE_COLORS[p.cc] || ['rgba(88,166,255,0.15)', '#58a6ff'];
+    var bmClass = isBookmarked(p.u) ? ' bookmarked' : '';
     return '<a href="' + escapeHtml(p.u) + '" class="report-card report-card-visible">' +
+      '<button class="report-bookmark' + bmClass + '" data-url="' + escapeHtml(p.u) + '" title="즐겨찾기"><svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" stroke="none"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg></button>' +
       thumbHtml +
       '<div class="report-card-body">' +
       '<div class="report-card-header">' +
@@ -194,7 +209,8 @@ layout: default
 
   function getFiltered() {
     return posts.filter(function(p) {
-      if (activeFilter !== 'all' && p.c !== activeFilter) return false;
+      if (activeFilter === '_bookmarks' && !isBookmarked(p.u)) return false;
+      if (activeFilter !== 'all' && activeFilter !== '_bookmarks' && p.c !== activeFilter) return false;
       if (searchQuery) {
         var t = p.t.toLowerCase();
         var s = (p.s || '').toLowerCase();
@@ -275,6 +291,17 @@ layout: default
     if (e.key === '/' && document.activeElement.tagName !== 'INPUT') {
       e.preventDefault();
       searchInput.focus();
+    }
+  });
+
+  // --- Bookmark click delegation ---
+  grid.addEventListener('click', function(e) {
+    var btn = e.target.closest('.report-bookmark');
+    if (btn) {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleBookmark(btn.dataset.url, btn);
+      if (activeFilter === '_bookmarks') render();
     }
   });
 

--- a/_sass/components/_reports.scss
+++ b/_sass/components/_reports.scss
@@ -533,10 +533,33 @@
 
 // ---------- Search Highlight ----------
 .search-highlight {
-  background: rgba(77, 166, 255, 0.25);
+  background: var(--highlight-bg, rgba(77, 166, 255, 0.25));
   color: var(--text-primary);
   border-radius: 2px;
   padding: 0 2px;
+}
+
+// ---------- Bookmark Button ----------
+.report-bookmark {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  color: var(--text-secondary);
+  opacity: 0;
+  transition: opacity 0.2s, color 0.2s, transform 0.15s;
+  z-index: 1;
+
+  &:hover { color: var(--accent-orange); transform: scale(1.15); }
+  &.bookmarked { color: var(--accent-orange); opacity: 1; }
+}
+
+.report-card {
+  position: relative;
+  &:hover .report-bookmark { opacity: 1; }
 }
 
 // ---------- Relative Time Badge ----------
@@ -551,6 +574,8 @@
 
 // ---------- Light mode adjustments ----------
 [data-theme="light"] {
+  --highlight-bg: rgba(9, 105, 218, 0.15);
+
   .report-card {
     box-shadow: var(--shadow-card, 0 2px 8px rgba(0,0,0,0.06));
     &:hover {
@@ -560,6 +585,10 @@
 
   .report-controls {
     box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  }
+
+  .search-highlight {
+    background: rgba(9, 105, 218, 0.18);
   }
 }
 

--- a/_sass/components/_utilities.scss
+++ b/_sass/components/_utilities.scss
@@ -870,21 +870,24 @@ main {
 // Post layout wrapper for sidebar TOC
 .post-layout-wrapper {
   display: flex;
-  gap: 2rem;
+  gap: 1.5rem;
   align-items: flex-start;
+  position: relative;
 
   @media (max-width: 1024px) {
     flex-direction: column;
+    gap: 0;
   }
 
   > .post-content {
     flex: 1;
     min-width: 0;
+    max-width: 100%;
   }
 }
 
 .post-toc-sidebar {
-  width: 220px;
+  width: 200px;
   flex-shrink: 0;
   order: -1;
 
@@ -897,10 +900,18 @@ main {
 .post-toc-sticky {
   @media (min-width: 1025px) {
     position: sticky;
-    top: 5rem;
-    max-height: calc(100vh - 6rem);
+    top: 4.5rem;
+    max-height: calc(100vh - 5.5rem);
     overflow-y: auto;
     scrollbar-width: thin;
+
+    &::-webkit-scrollbar {
+      width: 3px;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: rgba($accent-blue, 0.3);
+      border-radius: 3px;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- TOC 사이드바: 200px 폭, 커스텀 스크롤바, top 간격 최적화
- localStorage 기반 즐겨찾기: 카드 북마크 버튼 + 즐겨찾기 필터 탭
- 라이트 모드 검색 하이라이트 `--highlight-bg` CSS 변수화 (대비 개선)
- 북마크 클릭 이벤트 위임으로 카드 링크와 충돌 방지

## Test plan
- [x] Jekyll 빌드 성공 (13초)
- [x] 10개 기능 키워드 렌더링 확인