### PR TITLE
feat: 카드/리스트 뷰 전환 + 최근 본 리포트 + RSS 피드

### DIFF
--- a/_layouts/reports.html
+++ b/_layouts/reports.html
@@ -7,7 +7,11 @@ layout: default
   <div class="reports-header">
     <div class="reports-header-text">
       <h1>리포트</h1>
-      <p class="reports-subtitle">일일 뉴스, 시장 분석, 규제 동향 등 전체 리포트</p>
+      <p class="reports-subtitle">일일 뉴스, 시장 분석, 규제 동향 등 전체 리포트
+        <a href="{{ '/reports-feed.xml' | relative_url }}" class="rss-link" title="RSS 피드">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20C5 20 4 19 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/></svg>
+        </a>
+      </p>
     </div>
     <div class="reports-stats">
       <div class="reports-stat">
@@ -81,7 +85,24 @@ layout: default
         <input type="date" id="report-date-to" class="report-date">
       </div>
       <button id="report-clear" class="report-clear-btn">초기화</button>
+      <div class="report-view-toggle" role="group" aria-label="뷰 전환">
+        <button class="report-view-btn active" data-view="grid" aria-label="카드뷰">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+        </button>
+        <button class="report-view-btn" data-view="list" aria-label="리스트뷰">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+        </button>
+      </div>
     </div>
+  </div>
+
+  <!-- Recently Viewed -->
+  <div class="reports-recent" id="reports-recent" style="display:none">
+    <h3 class="recent-title">
+      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+      최근 본 리포트
+    </h3>
+    <div class="recent-list" id="recent-list"></div>
   </div>
 
   <!-- Reports Grid (JS-rendered) -->
@@ -321,6 +342,52 @@ layout: default
   });
 
   updateBookmarkBadge();
+
+  // --- View toggle ---
+  var currentView = 'grid';
+  var viewBtns = document.querySelectorAll('.report-view-btn');
+  viewBtns.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      viewBtns.forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      currentView = btn.dataset.view;
+      grid.classList.toggle('reports-list-view', currentView === 'list');
+    });
+  });
+
+  // --- Recently viewed ---
+  var recentHistory = JSON.parse(localStorage.getItem('report-recent') || '[]');
+  function renderRecent() {
+    if (!recentHistory.length) return;
+    var container = document.getElementById('reports-recent');
+    var list = document.getElementById('recent-list');
+    var recentPosts = recentHistory.slice(0, 5).map(function(url) {
+      return posts.find(function(p) { return p.u === url; });
+    }).filter(Boolean);
+    if (!recentPosts.length) return;
+    container.style.display = '';
+    list.innerHTML = recentPosts.map(function(p) {
+      var bc = BADGE_COLORS[p.cc] || ['rgba(88,166,255,0.15)','#58a6ff'];
+      return '<a href="' + p.u + '" class="recent-item">' +
+        '<span class="report-category-badge" style="background:' + bc[0] + ';color:' + bc[1] + '">' + p.cn + '</span>' +
+        '<span class="recent-item-title">' + escapeHtml(p.t) + '</span>' +
+        '<span class="report-relative-time">' + relativeTime(p.d) + '</span></a>';
+    }).join('');
+  }
+  // Track clicks for history
+  grid.addEventListener('click', function(e) {
+    var card = e.target.closest('.report-card');
+    if (card && !e.target.closest('.report-bookmark')) {
+      var url = card.getAttribute('href');
+      if (url) {
+        recentHistory = recentHistory.filter(function(u) { return u !== url; });
+        recentHistory.unshift(url);
+        recentHistory = recentHistory.slice(0, 20);
+        localStorage.setItem('report-recent', JSON.stringify(recentHistory));
+      }
+    }
+  });
+  renderRecent();
 
   // --- Bookmark click delegation ---
   grid.addEventListener('click', function(e) {

--- a/_sass/components/_reports.scss
+++ b/_sass/components/_reports.scss
@@ -38,6 +38,15 @@
   color: var(--text-secondary);
   font-size: 0.9rem;
   margin: 0;
+
+  .rss-link {
+    color: var(--accent-orange);
+    margin-left: 0.4rem;
+    vertical-align: middle;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+    &:hover { opacity: 1; }
+  }
 }
 
 .reports-stats {
@@ -529,6 +538,97 @@
   font-size: 0.75rem;
   color: var(--text-secondary);
   margin: 0;
+}
+
+// ---------- View Toggle ----------
+.report-view-toggle {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+.report-view-btn {
+  padding: 0.4rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover { color: var(--accent-blue); border-color: var(--accent-blue); }
+  &.active { background: var(--accent-blue); color: #fff; border-color: var(--accent-blue); }
+}
+
+// ---------- List View ----------
+.reports-list-view {
+  grid-template-columns: 1fr !important;
+
+  .report-card {
+    flex-direction: row;
+    align-items: center;
+
+    .report-card-thumb {
+      width: 80px;
+      height: 60px;
+      flex-shrink: 0;
+      border-radius: 8px;
+    }
+
+    .report-card-body { padding: 0.6rem 1rem; }
+    .report-title { -webkit-line-clamp: 1; font-size: 0.9rem; }
+    .report-summary { -webkit-line-clamp: 1; }
+    .report-tags { display: none; }
+    .report-card-footer { display: none; }
+  }
+}
+
+// ---------- Recently Viewed ----------
+.reports-recent {
+  margin-bottom: 1.25rem;
+}
+
+.recent-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0 0 0.5rem;
+}
+
+.recent-list {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scrollbar-width: thin;
+}
+
+.recent-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: border-color 0.2s;
+
+  &:hover { border-color: var(--accent-blue); }
+}
+
+.recent-item-title {
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 // ---------- Keyboard Focus ----------

--- a/reports-feed.xml
+++ b/reports-feed.xml
@@ -1,0 +1,26 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Investing Dragon - 리포트</title>
+    <description>암호화폐·주식 뉴스 자동 수집 및 시장 분석 리포트</description>
+    <link>{{ site.url }}/reports/</link>
+    <atom:link href="{{ site.url }}/reports-feed.xml" rel="self" type="application/rss+xml"/>
+    <language>ko</language>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    {% for post in site.posts limit:30 %}
+    {% assign cat_slug = post.categories[0] | default: "uncategorized" %}
+    {% assign cat_info = site.data.categories[cat_slug] %}
+    <item>
+      <title>{{ post.title | xml_escape }}</title>
+      <link>{{ post.url | absolute_url }}</link>
+      <guid isPermaLink="true">{{ post.url | absolute_url }}</guid>
+      <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+      <category>{{ cat_info.name | default: cat_slug | xml_escape }}</category>
+      <description>{{ post.description | default: post.excerpt | strip_html | truncate: 200 | xml_escape }}</description>
+    </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- 카드 그리드 / 리스트 뷰 토글 (리스트: 1열, 썸네일 축소, 제목 1줄 표시)
- localStorage 기반 최근 본 리포트 이력 (최대 20건 저장, 상위 5건 가로 스크롤)
- `/reports-feed.xml` 전용 RSS 피드 (최근 30건, 카테고리 포함)
- RSS 아이콘 링크를 리포트 헤더 서브타이틀에 추가

## Test plan
- [x] Jekyll 빌드 성공 (12초)
- [x] RSS 피드 21KB 정상 생성, XML 구조 확인
- [x] 7개 기능 키워드 렌더링 확인