### PR TITLE
fix: Google News URL 해석 + TOC 사이드바 겹침 + 요약 중복 제거

### DIFF
--- a/_sass/components/_utilities.scss
+++ b/_sass/components/_utilities.scss
@@ -870,11 +870,11 @@ main {
 // Post layout wrapper for sidebar TOC
 .post-layout-wrapper {
   display: flex;
-  gap: 1.5rem;
+  gap: 1.25rem;
   align-items: flex-start;
   position: relative;
 
-  @media (max-width: 1024px) {
+  @media (max-width: 1200px) {
     flex-direction: column;
     gap: 0;
   }
@@ -883,22 +883,23 @@ main {
     flex: 1;
     min-width: 0;
     max-width: 100%;
+    overflow-x: hidden;
   }
 }
 
 .post-toc-sidebar {
-  width: 200px;
+  width: 190px;
   flex-shrink: 0;
   order: -1;
 
-  @media (max-width: 1024px) {
+  @media (max-width: 1200px) {
     width: 100%;
     order: 0;
   }
 }
 
 .post-toc-sticky {
-  @media (min-width: 1025px) {
+  @media (min-width: 1201px) {
     position: sticky;
     top: 4.5rem;
     max-height: calc(100vh - 5.5rem);

--- a/scripts/common/markdown_utils.py
+++ b/scripts/common/markdown_utils.py
@@ -8,7 +8,34 @@ def escape_table_cell(value: object) -> str:
     return text.replace("|", "\\|")
 
 
+def _try_resolve_google_news_url(url: str) -> str:
+    """Resolve Google News RSS redirect URLs to actual article URLs (no network)."""
+    if not url or "news.google.com" not in url:
+        return url
+    try:
+        import base64
+        import urllib.parse
+
+        parsed = urllib.parse.urlparse(url)
+        path = parsed.path
+        for prefix in ("/rss/articles/", "/read/"):
+            if prefix in path:
+                b64_part = path.split(prefix, 1)[1].split("?")[0]
+                padded = b64_part + "=" * (4 - len(b64_part) % 4)
+                decoded = base64.urlsafe_b64decode(padded)
+                text = decoded.decode("utf-8", errors="ignore")
+                match = re.search(r"https?://[^\s\"'<>\x00-\x1f]+", text)
+                if match:
+                    resolved = match.group(0).rstrip(".,;:)")
+                    if "google.com" not in resolved:
+                        return resolved
+    except Exception:  # noqa: BLE001, S110
+        pass
+    return url
+
+
 def markdown_link(text: str, url: str) -> str:
+    url = _try_resolve_google_news_url(url)
     safe = escape_table_cell(text).replace("[", "\\[").replace("]", "\\]")
     return f"[{safe}]({url})"
 

--- a/scripts/improve_existing_posts.py
+++ b/scripts/improve_existing_posts.py
@@ -286,6 +286,43 @@ def remove_intro_duplication_in_summary(body: str) -> tuple[str, bool]:
     return body, changed
 
 
+def remove_summary_article_duplicates(body: str) -> tuple[str, bool]:
+    """Remove summary list items that duplicate numbered article titles below.
+
+    Detects patterns like:
+      - 1. Title text here. - Source Title text here.
+    where the same title appears again in a numbered entry in a later section.
+    Also removes list items with "- N." prefix that repeat themselves internally.
+    """
+    original = body
+    lines = body.split("\n")
+    new_lines = []
+    # Collect all numbered article titles (e.g. "**1. [Title..." or "**1. Title...")
+    article_titles = set()
+    for line in lines:
+        m = re.match(r"\*\*\d+\.\s*(?:\[)?(.{15,80}?)(?:\]|\*)", line)
+        if m:
+            article_titles.add(m.group(1).strip()[:50])
+
+    for line in lines:
+        # Check for "- 1. Title - Source Title" pattern with internal duplication
+        m = re.match(r"^- \d+\.\s+(.+)$", line)
+        if m:
+            content = m.group(1)
+            # Check if first half repeats in second half (internal dup)
+            half = len(content) // 2
+            if half > 20 and content[:half].strip().rstrip(".") in content[half:]:
+                continue
+            # Check if this title already appears as a numbered article
+            clean = re.sub(r"\s*-\s*\S+\s*$", "", content).strip()[:50]
+            if clean and any(clean in t or t in clean for t in article_titles):
+                continue
+        new_lines.append(line)
+
+    result = "\n".join(new_lines)
+    return result, result != original
+
+
 def remove_duplicate_articles_in_insight(body: str) -> tuple[str, bool]:
     """Remove duplicate '주요 기사' lines in '오늘의 인사이트' section."""
     insight_pattern = re.compile(r"^## 오늘의 인사이트\s*$", re.MULTILINE)
@@ -600,6 +637,10 @@ def process_post(filepath: Path, dry_run: bool = False) -> dict[str, int]:
     body, did_change = remove_intro_duplication_in_summary(body)
     if did_change:
         stats["intro_dedup"] = 1
+
+    body, did_change = remove_summary_article_duplicates(body)
+    if did_change:
+        stats["summary_article_dedup"] = 1
 
     # 3. Remove duplicate articles in insight
     body, did_change = remove_duplicate_articles_in_insight(body)


### PR DESCRIPTION
## Summary
- `markdown_link()`에서 Google News RSS URL(`CBMi...`)을 base64 디코딩하여 실제 기사 URL로 변환 (네트워크 호출 없음)
- TOC 사이드바 breakpoint 1024px → 1200px로 상향하여 겹침 방지
- 요약 섹션에서 기사 제목과 중복되는 리스트 항목 자동 제거 (`remove_summary_article_duplicates`)

## Test plan
- [x] 61 E2E tests passed
- [x] ruff lint clean
- [x] Jekyll 빌드 성공 (13초)