### PR TITLE
perf: Chart.js 지연 로딩 + 폰트 비차단 + 차트 접기 토글

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,9 @@
   <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/images/favicon-32.png' | relative_url }}">
   <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
   <link rel="manifest" href="{{ '/manifest.json' | relative_url }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&family=Noto+Serif+KR:wght@600;700;900&family=JetBrains+Mono:wght@400;500&display=swap" media="print" onload="this.media='all'">
   <meta name="theme-color" content="#0a0e14" id="meta-theme-color">
   <style>html{background-color:#0a0e14}html[data-theme="light"]{background-color:#ffffff}</style>
   <!-- Inline: theme flash-prevention must run before first paint to avoid FOUC -->

--- a/_layouts/reports.html
+++ b/_layouts/reports.html
@@ -2,8 +2,9 @@
 layout: default
 ---
 
-<!-- Preconnect for Chart.js CDN -->
+<!-- Preconnect for CDNs -->
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
 
 <!-- JSON-LD structured data -->
 <script type="application/ld+json">
@@ -78,10 +79,15 @@ layout: default
     <div class="highlights-grid" id="highlights-grid"></div>
   </div>
 
-  <!-- Charts Section -->
+  <!-- Charts Section (collapsible) -->
+  <details class="reports-charts-wrapper" open>
+    <summary class="charts-toggle">
+      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>
+      <span data-i18n="reports_charts_toggle">통계 차트</span>
+    </summary>
   <div class="reports-charts">
     <div class="report-chart-card">
-      <h3 class="report-chart-title">카테고리 분포</h3>
+      <h3 class="report-chart-title" data-i18n="reports_category_dist">카테고리 분포</h3>
       <canvas id="category-chart" height="220"></canvas>
     </div>
     <div class="report-chart-card">
@@ -89,6 +95,7 @@ layout: default
       <canvas id="daily-chart" height="220"></canvas>
     </div>
   </div>
+  </details>
 
   <!-- Filter Controls -->
   <div class="report-controls" role="search" aria-label="리포트 필터">
@@ -159,6 +166,27 @@ layout: default
 [{% assign report_limit = 200 %}{% for post in site.posts limit:report_limit %}{% assign cat_slug = post.categories[0] | default: "uncategorized" %}{% assign cat_info = site.data.categories[cat_slug] %}{"u":"{{ post.url | relative_url }}","t":{{ post.title | jsonify }},"c":"{{ cat_slug }}","cn":"{{ cat_info.name | default: cat_slug }}","cc":"{{ cat_info.color | default: 'cat-stock' }}","d":"{{ post.date | date: '%Y-%m-%d' }}","dm":"{{ post.date | date: '%m.%d %H:%M' }}","s":{{ post.description | default: post.excerpt | strip_html | truncate: 80 | jsonify }},"img":"{{ post.image | default: '' }}","tags":[{% for tag in post.tags limit:2 %}{{ tag | jsonify }}{% unless forloop.last %},{% endunless %}{% endfor %}]}{% unless forloop.last %},{% endunless %}{% endfor %}]
 </script>
 
-<!-- Chart.js CDN -->
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
+<!-- Chart.js: lazy loaded when charts section enters viewport -->
+<script>
+(function(){
+  var chartsEl = document.querySelector('.reports-charts');
+  if (!chartsEl) return;
+  var loaded = false;
+  function loadChartJS() {
+    if (loaded) return;
+    loaded = true;
+    var s = document.createElement('script');
+    s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';
+    s.onload = function() { window.dispatchEvent(new Event('chartjs-ready')); };
+    document.head.appendChild(s);
+  }
+  if ('IntersectionObserver' in window) {
+    new IntersectionObserver(function(entries, obs) {
+      if (entries[0].isIntersecting) { loadChartJS(); obs.disconnect(); }
+    }, { rootMargin: '300px' }).observe(chartsEl);
+  } else {
+    loadChartJS();
+  }
+})();
+</script>
 <script src="{{ '/assets/js/reports.js' | relative_url }}" defer></script>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,7 +1,6 @@
 @import "variables";
 
-/* Google Fonts - Korean Editorial */
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&family=Noto+Serif+KR:wght@600;700;900&family=JetBrains+Mono:wght@400;500&display=swap');
+/* Google Fonts loaded via <link> in default.html for performance */
 
 /* Component imports */
 @import "components/layout";

--- a/_sass/components/_reports.scss
+++ b/_sass/components/_reports.scss
@@ -304,6 +304,41 @@
   overflow: hidden;
 }
 
+// ---------- Charts Toggle ----------
+.reports-charts-wrapper {
+  margin-bottom: 1.5rem;
+
+  &[open] .charts-toggle svg {
+    transform: rotate(0);
+  }
+
+  &:not([open]) .charts-toggle svg {
+    transform: rotate(-90deg);
+  }
+}
+
+.charts-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  padding: 0.5rem 0;
+  list-style: none;
+  user-select: none;
+
+  &::-webkit-details-marker { display: none; }
+
+  svg {
+    transition: transform 0.2s;
+    flex-shrink: 0;
+  }
+
+  &:hover { color: var(--accent-blue); }
+}
+
 // ---------- Charts Section ----------
 .reports-charts {
   display: grid;

--- a/assets/js/reports.js
+++ b/assets/js/reports.js
@@ -445,8 +445,7 @@
   if (typeof Chart !== 'undefined') {
     initCharts();
   } else {
-    var chartScript = document.querySelector('script[src*="chart.js"]');
-    if (chartScript) chartScript.addEventListener('load', initCharts);
+    window.addEventListener('chartjs-ready', initCharts);
   }
 
   var themeObserver = new MutationObserver(function(mutations) {


### PR DESCRIPTION
## Summary
- Chart.js IntersectionObserver로 뷰포트 진입 시에만 로딩 (LCP 개선)
- Google Fonts를 CSS `@import`에서 HTML `link media=print onload`로 이동 (비차단 렌더링)
- `preconnect`: googleapis.com, gstatic.com 추가
- 통계 차트 `details/summary` 접기/펼치기 토글 (A/B 테스트 기반)

## Test plan
- [x] 61 E2E tests passed
- [x] Jekyll 빌드 성공 (14초)