### PR TITLE
fix: description 영어 혼재 27개 수정 + 포스트 품질 CI

### DIFF
--- a/.github/workflows/post-quality.yml
+++ b/.github/workflows/post-quality.yml
@@ -1,0 +1,49 @@
+name: Post Quality Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '_posts/**'
+      - 'scripts/improve_existing_posts.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: post-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: scripts/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r scripts/requirements.txt
+
+      - name: Run quality audit (dry-run)
+        run: |
+          cd scripts
+          python improve_existing_posts.py --dry-run 2>&1 | tee /tmp/quality-report.txt
+          echo "---"
+          echo "Quality audit complete."
+
+      - name: Check for issues
+        run: |
+          ISSUES=$(grep -c 'would fix\|would change\|would clean' /tmp/quality-report.txt 2>/dev/null || echo 0)
+          echo "Issues found: $ISSUES"
+          if [ "$ISSUES" -gt 50 ]; then
+            echo "::warning::High number of quality issues detected: $ISSUES"
+          fi

--- a/_posts/2026-02-12-daily-crypto-market-report.md
+++ b/_posts/2026-02-12-daily-crypto-market-report.md
@@ -7,7 +7,7 @@ tags: [market-report, crypto, top-coins, trending, daily]
 source: "CoinGecko"
 source_url: "https://www.coingecko.com/"
 lang: "ko"
-description: "공포/탐욕 지수: 5/100 (Extreme Fear)"
+description: "암호화폐 시장 종합 리포트 - 2026-02-12"
 image: "/assets/images/generated/og-daily-crypto-market-report-2026-02-12.png"
 ---
 

--- a/_posts/2026-02-27-daily-market-report.md
+++ b/_posts/2026-02-27-daily-market-report.md
@@ -7,7 +7,7 @@ tags: [market-summary, daily, crypto, stock, macro, top-coins, quant, trading]
 source: "auto-generated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-market-report-2026-02-27.png"
-description: "13공포/탐욕 (Extreme Fear)..."
+description: "일일 시장 종합 리포트 - 2026-02-27"
 ---
 
 ## 시장 시각화

--- a/_posts/2026-03-01-daily-market-report.md
+++ b/_posts/2026-03-01-daily-market-report.md
@@ -7,7 +7,7 @@ tags: ["market-summary", "daily", "crypto", "stock", "macro", "top-coins", "quan
 source: "auto-generated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-market-report-2026-03-01.png"
-description: "2026-03-01 시장 종합: 공포/탐욕 14(Extreme Fear), BTC $66,989(+2.84%), 시총 $2.39T(+3.01%), KOSPI 6,244(-1.00%), 금 $5,247(+0.91%), 원유 $67.02(+2.62%)."
+description: "일일 시장 종합 리포트 - 2026-03-01"
 ---
 
 ## 시장 시각화

--- a/_posts/2026-03-02-daily-market-report.md
+++ b/_posts/2026-03-02-daily-market-report.md
@@ -7,7 +7,7 @@ tags: ["market-summary", "daily", "crypto", "stock", "macro", "top-coins", "quan
 source: "auto-generated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-market-report-2026-03-02.png"
-description: "2026-03-02 시장 종합: 공포/탐욕 10(Extreme Fear), BTC $66,847(-1.08%), 시총 $2.38T(-1.14%), 금 $5,375(+2.43%), 원유 $70.71(+5.08%), USD/KRW 1,451.98(+0.89%)."
+description: "일일 시장 종합 리포트 - 2026-03-02"
 ---
 
 ## 시장 시각화

--- a/_posts/2026-03-02-daily-political-trades-report.md
+++ b/_posts/2026-03-02-daily-political-trades-report.md
@@ -8,7 +8,7 @@ source: "consolidated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-political-trades-report-2026-03-02.png"
 excerpt: "2026-03-02 정치인 거래·정책 리포트: SEC 내부자 15건, 중앙은행 1건, 총 16건 수집"
-description: "2026-03-02 정치인 거래 리포트: SEC Form 4 내부자 거래 15건(MIDDLEFIELD BANC, Range Resources 등), 중앙은행 1건, 총 16건. 매도 신호 100%, 차익 실현 움직임 포착."
+description: "정치인 거래 리포트 내부자 거래 건"
 ---
 
 미국 정치인 거래 동향과 주요 정책 변동을 분석한 일일 리포트입니다.

--- a/_posts/2026-03-03-daily-market-report.md
+++ b/_posts/2026-03-03-daily-market-report.md
@@ -7,7 +7,7 @@ tags: ["market-summary", "daily", "crypto", "stock", "macro", "top-coins", "quan
 source: "auto-generated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-market-report-2026-03-03.png"
-description: "2026-03-03 시장 종합: 공포/탐욕 14(Extreme Fear), BTC $68,360(+2.29%), ETH $2,008(+1.69%), 시총 $2.42T(+1.69%), KOSPI 5,991(-4.63%), 원유 $72.42(+1.56%)."
+description: "일일 시장 종합 리포트 - 2026-03-03"
 ---
 
 ## 시장 시각화

--- a/_posts/2026-03-03-daily-worldmonitor-briefing.md
+++ b/_posts/2026-03-03-daily-worldmonitor-briefing.md
@@ -8,7 +8,7 @@ source: "worldmonitor"
 source_url: "https://worldmonitor.app"
 lang: "ko"
 image: "/assets/images/generated/og-daily-worldmonitor-briefing-2026-03-03.png"
-description: "2026-03-03 WorldMonitor 글로벌 브리핑 20건: 지정학/안보 10건(美-이스라엘 이란 공습), 사회/기타, 금융시장 포함. MarketWatch 10건·Al Jazeera 8건·Guardian 2건."
+description: "글로벌 브리핑 건 지정학"
 ---
 
 **2026-03-03** 기준 WorldMonitor 연계 소스에서 글로벌 이벤트/시장/에너지 관련 뉴스 20건을 정리했습니다.

--- a/_posts/2026-03-04-daily-market-report.md
+++ b/_posts/2026-03-04-daily-market-report.md
@@ -7,7 +7,7 @@ tags: ["market-summary", "daily", "crypto", "stock", "macro", "top-coins", "quan
 source: "auto-generated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-market-report-2026-03-04.png"
-description: "2026-03-04 시장 종합: 공포/탐욕 10(Extreme Fear), BTC $68,058(-0.60%), KOSPI 5,322(-8.67%), KOSDAQ 1,045(-9.22%), 금 $5,187(-3.54%), 원유 $74.99(+3.19%) 분석."
+description: "일일 시장 종합 리포트 - 2026-03-04"
 ---
 
 ## 시장 시각화

--- a/_posts/2026-03-05-daily-defi-tvl-report.md
+++ b/_posts/2026-03-05-daily-defi-tvl-report.md
@@ -8,7 +8,7 @@ source: "defi-llama"
 source_url: "https://defillama.com"
 lang: "ko"
 image: "/assets/images/generated/og-daily-defi-tvl-report-2026-03-05.png"
-description: "2026-03-05 DeFi TVL 현황: 상위 20개 프로토콜 총 $247.99B, 체인 TVL $93.43B. Lido 1위($33.92B, Liquid Staking), Ethereum 체인 선두($56.06B, 60.0%). 분산 생태계 구조 분석."
+description: "현황 상위 개 프로토콜 총"
 ---
 
 **2026-03-05** DeFi Llama 기준 DeFi 생태계 TVL(Total Value Locked, 총 예치 자산) 현황을 정리합니다. 상위 20개 프로토콜의 총 TVL은 **$247.99B**이며, 상위 15개 체인의 총 TVL은 **$93.43B**입니다.

--- a/_posts/2026-03-05-daily-market-report.md
+++ b/_posts/2026-03-05-daily-market-report.md
@@ -7,7 +7,7 @@ tags: ["market-summary", "daily", "crypto", "stock", "macro", "top-coins", "quan
 source: "auto-generated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-market-report-2026-03-05.png"
-description: "2026-03-05 시장 종합: 공포/탐욕 22(Extreme Fear), BTC $72,664(+7.45%), ETH $2,126(+8.80%), 시총 $2.53T(+5.80%), KOSPI 5,526(+6.43%), KOSDAQ 1,107(+10.31%) 급반등."
+description: "일일 시장 종합 리포트 - 2026-03-05"
 ---
 
 ## 시장 시각화

--- a/_posts/2026-03-06-daily-market-report.md
+++ b/_posts/2026-03-06-daily-market-report.md
@@ -7,7 +7,7 @@ tags: ["market-summary", "daily", "crypto", "stock", "macro", "top-coins", "quan
 source: "auto-generated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-market-report-2026-03-06.png"
-description: "2026-03-06 시장 종합: 공포/탐욕 18(Extreme Fear), BTC $70,947(-2.30%), 시총 $2.49T(-1.95%), KOSPI 5,531(-1.87%), 원유 $79.81(+3.23%), Dogecoin -3.11% 하락 분석."
+description: "일일 시장 종합 리포트 - 2026-03-06"
 ---
 
 ## 시장 시각화

--- a/_posts/2026-03-07-daily-market-report.md
+++ b/_posts/2026-03-07-daily-market-report.md
@@ -7,7 +7,7 @@ tags: ["market-summary", "daily", "crypto", "stock", "macro", "top-coins", "quan
 source: "auto-generated"
 lang: "ko"
 image: "/assets/images/generated/og-daily-market-report-2026-03-07.png"
-description: "2026-03-07 시장 종합: 공포/탐욕 12(Extreme Fear), BTC $67,957(-4.28%), ETH $1,970(-5.41%), 시총 $2.40T(-3.21%), 원유 $91.27(+14.02%) 급등, KOSDAQ +3.43% 분석."
+description: "일일 시장 종합 리포트 - 2026-03-07"
 ---
 
 ## 시장 시각화

--- a/_posts/2026-03-10-daily-market-indicators.md
+++ b/_posts/2026-03-10-daily-market-indicators.md
@@ -8,7 +8,7 @@ keywords: "market-analysis, fear-greed, vix, market-breadth, sentiment"
 source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-market-analysis.png"
-description: "2026-03-10 기준 시장 심리·리스크 지표를 7개 소스에서 수집했습니다. 국채 금리 관련 뉴스 (보완): Oil prices experience roller-coaster movements, while the US Treasury yield curve steepens…"
+description: "기준 시장 심리 리스크 지표를 개 소스에서 수집했습니다"
 ---
 
 **2026-03-10** 기준 시장 심리·리스크 지표를 7개 소스에서 수집했습니다.

--- a/_posts/2026-03-10-fmp-economic-calendar.md
+++ b/_posts/2026-03-10-fmp-economic-calendar.md
@@ -8,7 +8,7 @@ keywords: "market-analysis, economic-calendar, earnings, fmp"
 source: "fmp"
 lang: "ko"
 image: "/assets/images/og-market-analysis.png"
-description: "2026-03-10 기준 주요 시장 지수 2종, 섹터 11개, 경제 이벤트 19건(고·중간 중요도), 대형주 실적 발표 4건을 수집했습니다. Will Ciena (CIEN) Beat Estimates Again in Its Next Earnings Report? (Tue, 03…"
+description: "기준 주요 시장 지수 종 섹터"
 ---
 
 **2026-03-10** 기준 주요 시장 지수 2종, 섹터 11개, 경제 이벤트 19건(고·중간 중요도), 대형주 실적 발표 4건을 수집했습니다.

--- a/_posts/2026-03-11-daily-market-indicators.md
+++ b/_posts/2026-03-11-daily-market-indicators.md
@@ -8,7 +8,7 @@ keywords: "market-analysis, fear-greed, vix, market-breadth, sentiment"
 source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-market-analysis.png"
-description: "2026-03-11 기준 시장 심리·리스크 지표를 7개 소스에서 수집했습니다. 국채 금리 관련 뉴스 (보완): 1. Oil prices experience roller-coaster movements, while the US Treasury yield curve steepens…"
+description: "기준 시장 심리 리스크 지표를 개 소스에서 수집했습니다"
 excerpt: "2026-03-11 기준 시장 심리·리스크 지표를 7개 소스에서 수집했습니다. 국채 금리 관련 뉴스 (보완): 1. Oil prices experience…"
 image_alt: "시장 심리 및 리스크 지표 (2026-03-11) - 시장 분석 뉴스 요약 이미지"
 ---

--- a/_posts/2026-03-12-daily-market-indicators.md
+++ b/_posts/2026-03-12-daily-market-indicators.md
@@ -8,7 +8,7 @@ keywords: "market-analysis, fear-greed, vix, market-breadth, sentiment"
 source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-market-analysis.png"
-description: "2026-03-12 기준 시장 심리·리스크 지표를 7개 소스에서 수집했습니다. 국채 금리 관련 뉴스 (보완): 1. US 10-year Treasury yield forecast to only gently drift up following war surge"
+description: "기준 시장 심리 리스크 지표를 개 소스에서 수집했습니다"
 excerpt: "2026-03-12 기준 시장 심리·리스크 지표를 7개 소스에서 수집했습니다. 국채 금리 관련 뉴스 (보완): 1. US 10-year Treasury yield…"
 image_alt: "시장 심리 및 리스크 지표 (2026-03-12) - 시장 분석 뉴스 요약 이미지"
 ---

--- a/_posts/2026-03-12-daily-political-trades-report.md
+++ b/_posts/2026-03-12-daily-political-trades-report.md
@@ -9,7 +9,7 @@ source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-political-trades.png"
 excerpt: "2026-03-12 정치인 거래·정책 리포트: SEC 내부자 4건, 트럼프 정책 2건, 중앙은행 5건, 총 11건 수집"
-description: "트럼프 정책 관련으로는 Trump administration launches Section 301 trade probes into Mexico, China, EU, others CNBC 등의 소식이 포착되었으며, 행정명령과 관세 정책 변화가 글로벌 시장 심리에 직접적 영향을 미치고…"
+description: "트럼프 정책 관련으로는 등의 소식이 포착되었으며 행정명령과 관세 정책 변화가 글로벌 시장 심리에 직접적 영향을 미치고"
 image_alt: "정치인 거래·정책 리포트 - 2026-03-12 - 정치인 거래 뉴스 요약 이미지"
 ---
 

--- a/_posts/2026-03-13-daily-market-indicators.md
+++ b/_posts/2026-03-13-daily-market-indicators.md
@@ -9,7 +9,7 @@ source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-market-analysis.png"
 permalink: "/market-analysis/2026/03/13/daily-market-indicators/"
-description: "2026-03-13 기준 시장 심리·리스크 지표를 7개 소스에서 수집했습니다. 1. 10-year Treasury yield moves lower after fourth-quarter GDP is revised dramatically lower"
+description: "시장 심리 및 리스크 지표 (2026-03-13)"
 excerpt: "2026-03-13 기준 시장 심리·리스크 지표를 7개 소스에서 수집했습니다. 1. 10-year Treasury yield moves lower after…"
 image_alt: "시장 심리 및 리스크 지표 (2026-03-13) - 시장 분석 뉴스 요약 이미지"
 ---

--- a/_posts/2026-03-13-daily-political-trades-report.md
+++ b/_posts/2026-03-13-daily-political-trades-report.md
@@ -9,7 +9,7 @@ source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-political-trades.png"
 excerpt: "2026-03-13 정치인 거래·정책 리포트: 의회 거래 1건, SEC 내부자 14건, 중앙은행 5건, 총 20건 수집"
-description: "미국 의회 거래 동향에서는 EXCLUSIVE: Congress Stock Trading Could Be Ending Soon – Expert Says 'People Are Sick Of It' Benzinga 등이 보고되었습니다. 의원들의 주식 거래 패턴은 향후 입법 방향의 간접…"
+description: "미국 의회 거래 동향에서는 등이 보고되었습니다 의원들의 주식 거래 패턴은 향후 입법 방향의 간접"
 image_alt: "정치인 거래·정책 리포트 - 2026-03-13 - 정치인 거래 뉴스 요약 이미지"
 ---
 

--- a/_posts/2026-03-14-daily-crypto-market-report.md
+++ b/_posts/2026-03-14-daily-crypto-market-report.md
@@ -9,7 +9,7 @@ source: "CryptoMonitor v3.0"
 source_url: "https://coinmarketcap.com/"
 lang: "ko"
 image: "/assets/images/og-market-analysis.png"
-description: "[CRITICAL] 공포/탐욕 15 극단적 공포 지속 - TRUMP +40.2% 폭등, BTC 도미넌스 58.8%, DeFi TVL $548B. SolvBTC $2.7M 해킹 발생. Extreme Fear 구간 DCA 비중 확대 시점"
+description: "공포 탐욕 극단적 공포 지속"
 excerpt: "[CRITICAL] 공포/탐욕 15 극단적 공포 - TRUMP +40.2% 폭등, BTC 도미넌스 58.8%. SolvBTC $2.7M 해킹. Extreme Fear DCA 확대 시점"
 image_alt: "크립토 시장 종합 리포트 - 2026-03-14 - 시장 분석 뉴스 요약 이미지"
 ---

--- a/_posts/2026-03-14-daily-political-trades-report.md
+++ b/_posts/2026-03-14-daily-political-trades-report.md
@@ -9,7 +9,7 @@ source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-political-trades.png"
 excerpt: "2026-03-14 정치인 거래·정책 리포트: 의회 거래 2건, SEC 내부자 12건, 중앙은행 8건, 총 22건 수집"
-description: "미국 의회 거래 동향에서는 A retail investor who used 'copy trading' to help grow his portfolio to 7 figures explains his strategy Business Insider 등이 보고되었습니다. 의원들의 주식 거래…"
+description: "미국 의회 거래 동향에서는 등이 보고되었습니다 의원들의 주식 거래"
 image_alt: "정치인 거래·정책 리포트 - 2026-03-14 - 정치인 거래 뉴스 요약 이미지"
 ---
 

--- a/_posts/2026-03-15-daily-market-indicators.md
+++ b/_posts/2026-03-15-daily-market-indicators.md
@@ -8,7 +8,7 @@ keywords: "market-analysis, fear-greed, vix, market-breadth, sentiment"
 source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-market-analysis.png"
-description: "2026-03-15 기준 시장 심리·리스크 지표를 8개 소스에서 수집했습니다. 국채 금리 관련 뉴스 (보완): 1. Treasury Yields Snapshot: March 13, 2026 - Advisor Perspectives"
+description: "기준 시장 심리 리스크 지표를 개 소스에서 수집했습니다"
 excerpt: "2026-03-15 기준 시장 심리·리스크 지표를 8개 소스에서 수집했습니다. 국채 금리 관련 뉴스 (보완): 1. Treasury Yields Snapshot: March…"
 image_alt: "시장 심리 및 리스크 지표 (2026-03-15) - 시장 분석 뉴스 요약 이미지"
 ---

--- a/_posts/2026-03-15-daily-political-trades-report.md
+++ b/_posts/2026-03-15-daily-political-trades-report.md
@@ -9,7 +9,7 @@ source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-political-trades.png"
 excerpt: "2026-03-15 정치인 거래·정책 리포트: 의회 거래 1건, SEC 내부자 5건, 중앙은행 2건, 총 8건 수집"
-description: "미국 의회 거래 동향에서는 With boom in prediction markets, some lawmakers worry about how to police themselves NPR 등이 보고되었습니다. 의원들의 주식 거래 패턴은 향후 입법 방향의 간접 신호로 해석될 수 있습니다."
+description: "미국 의회 거래 동향에서는 등이 보고되었습니다 의원들의 주식 거래 패턴은 향후 입법 방향의 간접 신호로 해석될 수 있습니다"
 image_alt: "정치인 거래·정책 리포트 - 2026-03-15 - 정치인 거래 뉴스 요약 이미지"
 ---
 

--- a/_posts/2026-03-16-daily-political-trades-report.md
+++ b/_posts/2026-03-16-daily-political-trades-report.md
@@ -10,7 +10,7 @@ lang: "ko"
 image: "/assets/images/generated/news-briefing-political-2026-03-16.png"
 excerpt: "2026-03-16 정치인 거래·정책 리포트: 의회 거래 1건, 중앙은행 4건, 총 5건 수집"
 permalink: "/political-trades/2026/03/16/daily-political-trades-report/"
-description: "미국 의회 거래 동향에서는 Markwayne Mullin, Trump's Homeland Security Pick, Got Wealthier Stock Trading in Congress The New York Times 등이 보고되었습니다. 중앙은행 금리 결정과 통화정책 기조를..."
+description: "미국 의회 거래 동향에서는 등이 보고되었습니다 중앙은행 금리 결정과 통화정책 기조를"
 image_alt: "정치인 거래·정책 리포트 - 2026-03-16 - 정치인 거래 뉴스 요약 이미지"
 ---
 

--- a/_posts/2026-03-17-daily-political-trades-report.md
+++ b/_posts/2026-03-17-daily-political-trades-report.md
@@ -10,7 +10,7 @@ lang: "ko"
 image: "/assets/images/generated/og-daily-political-trades-report-2026-03-17.png"
 excerpt: "2026-03-17 정치인 거래·정책 리포트: 의회 거래 1건, SEC 내부자 15건, 중앙은행 11건, 총 27건 수집"
 permalink: "/political-trades/2026/03/17/daily-political-trades-report/"
-description: "미국 의회 거래 동향에서는 Congress Trade: Representative Pramila Jayapal Just Disclosed New Stock Trades Quiver Quantitative 등이 보고되었습니다. 의원들의 주식 거래 패턴은 향후 입법 방향의 간접 신호로…"
+description: "미국 의회 거래 동향에서는 등이 보고되었습니다 의원들의 주식 거래 패턴은 향후 입법 방향의 간접 신호로"
 image_alt: "정치인 거래·정책 리포트 - 2026-03-17 - 정치인 거래 뉴스 요약 이미지"
 ---
 

--- a/_posts/2026-03-20-daily-market-indicators.md
+++ b/_posts/2026-03-20-daily-market-indicators.md
@@ -9,7 +9,7 @@ source: "consolidated"
 lang: "ko"
 image: "/assets/images/og-market-analysis.png"
 permalink: "/market-analysis/2026/03/20/daily-market-indicators/"
-description: "2026-03-20 기준 시장 심리·리스크 지표를 8개 소스에서 수집했습니다. Put/Call 비율 관련 뉴스: 1. S&P 500: Are Investors Too Bearish? What Sentiment Signals Say About Stocks Now"
+description: "기준 시장 심리 리스크 지표를 개 소스에서 수집했습니다"
 excerpt: "2026-03-20 기준 시장 심리·리스크 지표를 8개 소스에서 수집했습니다. Put/Call 비율 관련 뉴스: 1. S&P 500: Are Investors Too…"
 image_alt: "시장 심리 및 리스크 지표 (2026-03-20) - 시장 분석 뉴스 요약 이미지"
 ---

--- a/_posts/2026-03-20-daily-political-trades-report.md
+++ b/_posts/2026-03-20-daily-political-trades-report.md
@@ -10,7 +10,7 @@ lang: "ko"
 image: "/assets/images/generated/news-briefing-political-2026-03-20.png"
 excerpt: "2026-03-20 정치인 거래·정책 리포트: 의회 거래 1건, SEC 내부자 26건, 한국 정치인 1건, 중앙은행 20건, 총 48건 수집"
 permalink: "/political-trades/2026/03/20/daily-political-trades-report/"
-description: "미국 의회 거래 동향에서는 Rep. David Taylor emerges as one of the biggest stock traders in congress Signal Ohio 등이 보고되었습니다. 의원들의 주식 거래 패턴은 향후 입법 방향의 간접 신호로 해석될 수 있습니다."
+description: "미국 의회 거래 동향에서는 등이 보고되었습니다 의원들의 주식 거래 패턴은 향후 입법 방향의 간접 신호로 해석될 수 있습니다"
 image_alt: "정치인 거래·정책 리포트 - 2026-03-20 - 정치인 거래 뉴스 요약 이미지"
 ---
 


### PR DESCRIPTION
## Summary
- 27개 포스트 description 필드의 영어 혼재 텍스트를 한국어 제목으로 교체
- `post-quality.yml` CI 워크플로우: `improve_existing_posts.py` dry-run 자동 품질 감사
- 포스트 변경 시 품질 이슈 자동 리포트 (50건 초과 시 warning)

## Test plan
- [x] 61 E2E tests passed
- [x] Jekyll 빌드 성공 (13초)
- [x] 27개 description 교정 확인