### PR TITLE
refactor: Sass deprecation 제거, enrichment 리팩토링, 수집기 테스트 추가

### DIFF
--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -1,0 +1,44 @@
+@charset "utf-8";
+
+// Define defaults for each variable.
+
+$base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$base-font-size:   16px !default;
+$base-font-weight: 400 !default;
+$small-font-size:  $base-font-size * 0.875 !default;
+$base-line-height: 1.5 !default;
+
+$spacing-unit:     30px !default;
+
+$text-color:       #111 !default;
+$background-color: #fdfdfd !default;
+$brand-color:      #2a7ae2 !default;
+
+$grey-color:       #828282 !default;
+$grey-color-light: #e8e8e8 !default; // was lighten($grey-color, 40%)
+$grey-color-dark:  #424242 !default; // was darken($grey-color, 25%)
+
+$table-text-align: left !default;
+
+// Width of the content area
+$content-width:    800px !default;
+
+$on-palm:          600px !default;
+$on-laptop:        800px !default;
+
+@mixin media-query($device) {
+  @media screen and (max-width: $device) {
+    @content;
+  }
+}
+
+@mixin relative-font-size($ratio) {
+  font-size: $base-font-size * $ratio;
+}
+
+// Import partials.
+@import
+  "minima/base",
+  "minima/layout",
+  "minima/syntax-highlighting"
+;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -1,0 +1,256 @@
+@use "sass:color";
+
+/**
+ * Reset some basic elements
+ */
+body, h1, h2, h3, h4, h5, h6,
+p, blockquote, pre, hr,
+dl, dd, ol, ul, figure {
+  margin: 0;
+  padding: 0;
+}
+
+
+
+/**
+ * Basic styling
+ */
+body {
+  font: $base-font-weight #{$base-font-size}/#{$base-line-height} $base-font-family;
+  color: $text-color;
+  background-color: $background-color;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-feature-settings: "kern" 1;
+     -moz-font-feature-settings: "kern" 1;
+       -o-font-feature-settings: "kern" 1;
+          font-feature-settings: "kern" 1;
+  font-kerning: normal;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+
+
+/**
+ * Set `margin-bottom` to maintain vertical rhythm
+ */
+h1, h2, h3, h4, h5, h6,
+p, blockquote, pre,
+ul, ol, dl, figure,
+%vertical-rhythm {
+  margin-bottom: $spacing-unit * 0.5;
+}
+
+
+
+/**
+ * `main` element
+ */
+main {
+  display: block; /* Default value of `display` of `main` element is 'inline' in IE 11. */
+}
+
+
+
+/**
+ * Images
+ */
+img {
+  max-width: 100%;
+  vertical-align: middle;
+}
+
+
+
+/**
+ * Figures
+ */
+figure > img {
+  display: block;
+}
+
+figcaption {
+  font-size: $small-font-size;
+}
+
+
+
+/**
+ * Lists
+ */
+ul, ol {
+  margin-left: $spacing-unit;
+}
+
+li {
+  > ul,
+  > ol {
+    margin-bottom: 0;
+  }
+}
+
+
+
+/**
+ * Headings
+ */
+h1, h2, h3, h4, h5, h6 {
+  font-weight: $base-font-weight;
+}
+
+
+
+/**
+ * Links
+ */
+a {
+  color: $brand-color;
+  text-decoration: none;
+
+  &:visited {
+    color: color.adjust($brand-color, $lightness: -15%);
+  }
+
+  &:hover {
+    color: $text-color;
+    text-decoration: underline;
+  }
+
+  .social-media-list &:hover {
+    text-decoration: none;
+
+    .username {
+      text-decoration: underline;
+    }
+  }
+}
+
+
+/**
+ * Blockquotes
+ */
+blockquote {
+  color: $grey-color;
+  border-left: 4px solid $grey-color-light;
+  padding-left: $spacing-unit * 0.5;
+  @include relative-font-size(1.125);
+  letter-spacing: -1px;
+  font-style: italic;
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+}
+
+
+
+/**
+ * Code formatting
+ */
+pre,
+code {
+  @include relative-font-size(0.9375);
+  border: 1px solid $grey-color-light;
+  border-radius: 3px;
+  background-color: #eef;
+}
+
+code {
+  padding: 1px 5px;
+}
+
+pre {
+  padding: 8px 12px;
+  overflow-x: auto;
+
+  > code {
+    border: 0;
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+
+
+/**
+ * Wrapper
+ */
+.wrapper {
+  max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit} * 2));
+  max-width:         calc(#{$content-width} - (#{$spacing-unit} * 2));
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: $spacing-unit;
+  padding-left: $spacing-unit;
+  @extend %clearfix;
+
+  @include media-query($on-laptop) {
+    max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit}));
+    max-width:         calc(#{$content-width} - (#{$spacing-unit}));
+    padding-right: $spacing-unit * 0.5;
+    padding-left: $spacing-unit * 0.5;
+  }
+}
+
+
+
+/**
+ * Clearfix
+ */
+%clearfix:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+
+
+/**
+ * Icons
+ */
+
+.svg-icon {
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+    fill: #{$grey-color};
+    padding-right: 5px;
+    vertical-align: text-top;
+}
+
+.social-media-list {
+  li + li {
+    padding-top: 5px;
+  }
+}
+
+
+
+/**
+ * Tables
+ */
+table {
+  margin-bottom: $spacing-unit;
+  width: 100%;
+  text-align: $table-text-align;
+  color: color.adjust($text-color, $lightness: 18%);
+  border-collapse: collapse;
+  border: 1px solid $grey-color-light;
+  tr {
+    &:nth-child(even) {
+      background-color: color.adjust($grey-color-light, $lightness: 6%);
+    }
+  }
+  th, td {
+    padding: ($spacing-unit * 0.3333333333) ($spacing-unit * 0.5);
+  }
+  th {
+    background-color: color.adjust($grey-color-light, $lightness: 3%);
+    border: 1px solid color.adjust($grey-color-light, $lightness: -4%);
+    border-bottom-color: color.adjust($grey-color-light, $lightness: -12%);
+  }
+  td {
+    border: 1px solid $grey-color-light;
+  }
+}

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -1,0 +1,255 @@
+/**
+ * Site header
+ */
+.site-header {
+  border-top: 5px solid $grey-color-dark;
+  border-bottom: 1px solid $grey-color-light;
+  min-height: $spacing-unit * 1.865;
+
+  // Positioning context for the mobile navigation icon
+  position: relative;
+}
+
+.site-title {
+  @include relative-font-size(1.625);
+  font-weight: 300;
+  line-height: $base-line-height * $base-font-size * 2.25;
+  letter-spacing: -1px;
+  margin-bottom: 0;
+  float: left;
+
+  &,
+  &:visited {
+    color: $grey-color-dark;
+  }
+}
+
+.site-nav {
+  float: right;
+  line-height: $base-line-height * $base-font-size * 2.25;
+
+  .nav-trigger {
+      display: none;
+  }
+
+  .menu-icon {
+    display: none;
+  }
+
+  .page-link {
+    color: $text-color;
+    line-height: $base-line-height;
+
+    // Gaps between nav items, but not on the last one
+    &:not(:last-child) {
+      margin-right: 20px;
+    }
+  }
+
+  @include media-query($on-palm) {
+    position: absolute;
+    top: 9px;
+    right: $spacing-unit * 0.5;
+    background-color: $background-color;
+    border: 1px solid $grey-color-light;
+    border-radius: 5px;
+    text-align: right;
+
+    label[for="nav-trigger"] {
+      display: block;
+      float: right;
+      width: 36px;
+      height: 36px;
+      z-index: 2;
+      cursor: pointer;
+    }
+
+    .menu-icon {
+      display: block;
+      float: right;
+      width: 36px;
+      height: 26px;
+      line-height: 0;
+      padding-top: 10px;
+      text-align: center;
+
+      > svg {
+        fill: $grey-color-dark;
+      }
+    }
+
+    input ~ .trigger {
+      clear: both;
+      display: none;
+    }
+
+    input:checked ~ .trigger {
+      display: block;
+      padding-bottom: 5px;
+    }
+
+    .page-link {
+      display: block;
+      margin-left: 20px;
+      padding: 5px 10px;
+
+      &:not(:last-child) {
+        margin-right: 0;
+      }
+    }
+  }
+}
+
+
+
+/**
+ * Site footer
+ */
+.site-footer {
+  border-top: 1px solid $grey-color-light;
+  padding: $spacing-unit 0;
+}
+
+.footer-heading {
+  @include relative-font-size(1.125);
+  margin-bottom: $spacing-unit * 0.5;
+}
+
+.contact-list,
+.social-media-list {
+  list-style: none;
+  margin-left: 0;
+}
+
+.footer-col-wrapper {
+  @include relative-font-size(0.9375);
+  color: $grey-color;
+  margin-left: -$spacing-unit * 0.5;
+  @extend %clearfix;
+}
+
+.footer-col {
+  float: left;
+  margin-bottom: $spacing-unit * 0.5;
+  padding-left: $spacing-unit * 0.5;
+}
+
+.footer-col-1 {
+  width: -webkit-calc(35% - (#{$spacing-unit} / 2));
+  width:         calc(35% - (#{$spacing-unit} / 2));
+}
+
+.footer-col-2 {
+  width: -webkit-calc(20% - (#{$spacing-unit} / 2));
+  width:         calc(20% - (#{$spacing-unit} / 2));
+}
+
+.footer-col-3 {
+  width: -webkit-calc(45% - (#{$spacing-unit} / 2));
+  width:         calc(45% - (#{$spacing-unit} / 2));
+}
+
+@include media-query($on-laptop) {
+  .footer-col-1,
+  .footer-col-2 {
+    width: -webkit-calc(50% - (#{$spacing-unit} / 2));
+    width:         calc(50% - (#{$spacing-unit} / 2));
+  }
+
+  .footer-col-3 {
+    width: -webkit-calc(100% - (#{$spacing-unit} / 2));
+    width:         calc(100% - (#{$spacing-unit} / 2));
+  }
+}
+
+@include media-query($on-palm) {
+  .footer-col {
+    float: none;
+    width: -webkit-calc(100% - (#{$spacing-unit} / 2));
+    width:         calc(100% - (#{$spacing-unit} / 2));
+  }
+}
+
+
+
+/**
+ * Page content
+ */
+.page-content {
+  padding: $spacing-unit 0;
+  flex: 1;
+}
+
+.page-heading {
+  @include relative-font-size(2);
+}
+
+.post-list-heading {
+  @include relative-font-size(1.75);
+}
+
+.post-list {
+  margin-left: 0;
+  list-style: none;
+
+  > li {
+    margin-bottom: $spacing-unit;
+  }
+}
+
+.post-meta {
+  font-size: $small-font-size;
+  color: $grey-color;
+}
+
+.post-link {
+  display: block;
+  @include relative-font-size(1.5);
+}
+
+
+
+/**
+ * Posts
+ */
+.post-header {
+  margin-bottom: $spacing-unit;
+}
+
+.post-title {
+  @include relative-font-size(2.625);
+  letter-spacing: -1px;
+  line-height: 1;
+
+  @include media-query($on-laptop) {
+    @include relative-font-size(2.25);
+  }
+}
+
+.post-content {
+  margin-bottom: $spacing-unit;
+
+  h2 {
+    @include relative-font-size(2);
+
+    @include media-query($on-laptop) {
+      @include relative-font-size(1.75);
+    }
+  }
+
+  h3 {
+    @include relative-font-size(1.625);
+
+    @include media-query($on-laptop) {
+      @include relative-font-size(1.375);
+    }
+  }
+
+  h4 {
+    @include relative-font-size(1.25);
+
+    @include media-query($on-laptop) {
+      @include relative-font-size(1.125);
+    }
+  }
+}

--- a/_sass/minima/_syntax-highlighting.scss
+++ b/_sass/minima/_syntax-highlighting.scss
@@ -1,0 +1,71 @@
+/**
+ * Syntax highlighting styles
+ */
+.highlight {
+  background: #fff;
+  @extend %vertical-rhythm;
+
+  .highlighter-rouge & {
+    background: #eef;
+  }
+
+  .c     { color: #998; font-style: italic } // Comment
+  .err   { color: #a61717; background-color: #e3d2d2 } // Error
+  .k     { font-weight: bold } // Keyword
+  .o     { font-weight: bold } // Operator
+  .cm    { color: #998; font-style: italic } // Comment.Multiline
+  .cp    { color: #999; font-weight: bold } // Comment.Preproc
+  .c1    { color: #998; font-style: italic } // Comment.Single
+  .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
+  .gd    { color: #000; background-color: #fdd } // Generic.Deleted
+  .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
+  .ge    { font-style: italic } // Generic.Emph
+  .gr    { color: #a00 } // Generic.Error
+  .gh    { color: #999 } // Generic.Heading
+  .gi    { color: #000; background-color: #dfd } // Generic.Inserted
+  .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
+  .go    { color: #888 } // Generic.Output
+  .gp    { color: #555 } // Generic.Prompt
+  .gs    { font-weight: bold } // Generic.Strong
+  .gu    { color: #aaa } // Generic.Subheading
+  .gt    { color: #a00 } // Generic.Traceback
+  .kc    { font-weight: bold } // Keyword.Constant
+  .kd    { font-weight: bold } // Keyword.Declaration
+  .kp    { font-weight: bold } // Keyword.Pseudo
+  .kr    { font-weight: bold } // Keyword.Reserved
+  .kt    { color: #458; font-weight: bold } // Keyword.Type
+  .m     { color: #099 } // Literal.Number
+  .s     { color: #d14 } // Literal.String
+  .na    { color: #008080 } // Name.Attribute
+  .nb    { color: #0086B3 } // Name.Builtin
+  .nc    { color: #458; font-weight: bold } // Name.Class
+  .no    { color: #008080 } // Name.Constant
+  .ni    { color: #800080 } // Name.Entity
+  .ne    { color: #900; font-weight: bold } // Name.Exception
+  .nf    { color: #900; font-weight: bold } // Name.Function
+  .nn    { color: #555 } // Name.Namespace
+  .nt    { color: #000080 } // Name.Tag
+  .nv    { color: #008080 } // Name.Variable
+  .ow    { font-weight: bold } // Operator.Word
+  .w     { color: #bbb } // Text.Whitespace
+  .mf    { color: #099 } // Literal.Number.Float
+  .mh    { color: #099 } // Literal.Number.Hex
+  .mi    { color: #099 } // Literal.Number.Integer
+  .mo    { color: #099 } // Literal.Number.Oct
+  .sb    { color: #d14 } // Literal.String.Backtick
+  .sc    { color: #d14 } // Literal.String.Char
+  .sd    { color: #d14 } // Literal.String.Doc
+  .s2    { color: #d14 } // Literal.String.Double
+  .se    { color: #d14 } // Literal.String.Escape
+  .sh    { color: #d14 } // Literal.String.Heredoc
+  .si    { color: #d14 } // Literal.String.Interpol
+  .sx    { color: #d14 } // Literal.String.Other
+  .sr    { color: #009926 } // Literal.String.Regex
+  .s1    { color: #d14 } // Literal.String.Single
+  .ss    { color: #990073 } // Literal.String.Symbol
+  .bp    { color: #999 } // Name.Builtin.Pseudo
+  .vc    { color: #008080 } // Name.Variable.Class
+  .vg    { color: #008080 } // Name.Variable.Global
+  .vi    { color: #008080 } // Name.Variable.Instance
+  .il    { color: #099 } // Literal.Number.Integer.Long
+}

--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -619,288 +619,99 @@ def _get_source_label(source: str, context_map: Dict[str, str]) -> str:
     return context_map.get(source, source)
 
 
-def _extract_title_entities(title: str) -> list:
-    """Extract meaningful entities (names, tickers, numbers) from title."""
-    entities = []
-    # Tickers and crypto symbols (e.g., BTC, ETH, AAPL)
-    tickers = re.findall(r"\b[A-Z]{2,5}\b", title)
-    # Price/percentage values (e.g., $90K, 5.3%, $100B)
-    values = re.findall(r"\$[\d,.]+[KkMmBbTt]?|\d+(?:\.\d+)?%", title)
-    # Korean entities (2+ chars)
-    kr_entities = re.findall(r"[가-힣]{2,}", title)
-    # Proper nouns (capitalized words, not common English)
-    _COMMON = {
-        "The",
-        "And",
-        "For",
-        "With",
-        "Has",
-        "Are",
-        "Its",
-        "But",
-        "How",
-        "Why",
-        "What",
-        "New",
-        "All",
-        "Can",
-        "Now",
-        "Get",
-        "Set",
-        "May",
-        "Not",
-        "Other",
-        "Others",
-        "Another",
-        "Being",
-        "Having",
-        "Doing",
-        "Becomes",
-        "Become",
-        "Getting",
-        "Going",
-        "Coming",
-        "Making",
-        "Says",
-        "Said",
-        "Warns",
-        "Faces",
-        "Shows",
-        "Finds",
-        "Takes",
-        "Gives",
-        "Looks",
-        "Tells",
-        "Seems",
-        "Turns",
-        "Leads",
-        "Holds",
-        "Spikes",
-        "Spike",
-        "Surges",
-        "Surge",
-        "Drops",
-        "Drop",
-        "Falls",
-        "First",
-        "Last",
-        "Next",
-        "After",
-        "Before",
-        "During",
-        "Under",
-        "Over",
-        "About",
-        "Every",
-        "Where",
-        "Which",
-        "While",
-        "Their",
-        "These",
-        "Those",
-        "Could",
-        "Would",
-        "Should",
-        "Might",
-        "Still",
-        "Just",
-        "Also",
-        "More",
-        "Most",
-        "Some",
-        "Much",
-        "Many",
-        "Each",
-        "Only",
-        "Even",
-        "Very",
-        "Here",
-        "There",
-        "Then",
-        "Than",
-        "Into",
-        "From",
-        "This",
-        "That",
-        "Been",
-        "Were",
-        "Will",
-        "Your",
-        "They",
-        "Them",
-        "Such",
-        "Like",
-        "Near",
-        "Amid",
-        "Ahead",
-        "Along",
-        "Among",
-        "Above",
-        "Below",
-        "Behind",
-        "Between",
-        "Through",
-        "Against",
-        "Within",
-        "Without",
-        "Across",
-        "Inside",
-        "Global",
-        "World",
-        "Major",
-        "Latest",
-        "Breaking",
-        "Live",
-        "Watch",
-        "Alert",
-        "Update",
-        "Report",
-        "Check",
-        "Shares",
-        "Stock",
-        "Stocks",
-        "Market",
-        "Markets",
-        "Price",
-        "Prices",
-        "Trade",
-        "Trades",
-        "Trading",
-        "Company",
-        "Companies",
-        "Industry",
-        "Million",
-        "Billion",
-        "Trillion",
-        "Today",
-        "Yesterday",
-        "Tomorrow",
-        "Year",
-        "Week",
-        "Month",
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-        "Sunday",
-        "Better",
-        "Bigger",
-        "Lower",
-        "Higher",
-        "Early",
-        "Late",
-        "Huge",
-        "Massive",
-        "Record",
-        "Rising",
-        "Falling",
-        "Since",
-        "Until",
-        "Whether",
-        "Biggest",
-        "Worst",
-        "Best",
-        "Headed",
-        "Heads",
-        "Keep",
-        "Keeps",
-        "Stayed",
-        "Stays",
-        "Stay",
-        "Worse",
-        "Linked",
-        "Issues",
-        "Issue",
-        "Based",
-        "Using",
-        "Asked",
-        "Asking",
-        "Called",
-        "Calls",
-        "Named",
-        "Known",
-        "Seen",
-        "Taken",
-        "Given",
-        "Several",
-        "Certain",
-        "Entire",
-        "Recent",
-        "Little",
-        "Large",
-        "Small",
-        "Long",
-        "Short",
-        "Full",
-        "Half",
-        "Wants",
-        "Needs",
-        "Tries",
-        "Three",
-        "Four",
-        "Five",
-    }
-    _NOISE_TICKERS = {
-        "CEO",
-        "IPO",
-        "SEC",
-        "FED",
-        "GDP",
-        "CPI",
-        "ETF",
-        "AI",
-        "US",
-        "UK",
-        "EU",
-        "USD",
-        "FOR",
-        "THE",
-        "ARE",
-        "HAS",
-        "NOT",
-        "BUT",
-        "ALL",
-        "CAN",
-        "NOW",
-        "HOW",
-        "NEW",
-        "CBS",
-        "FBI",
-        "GOP",
-        "DHS",
-        "RFK",
-        "ITS",
-        "WAS",
-        "HIS",
-        "HER",
-        "WHO",
-        "MAY",
-        "BIG",
-        "TOP",
-        "TWO",
-        "OUR",
-        "SAY",
-        "ANY",
-        "FEW",
-        "RED",
-    }
-    tickers = [t for t in tickers if t not in _NOISE_TICKERS]
-    proper = [w for w in re.findall(r"\b[A-Z][a-z]{2,}\b", title) if w not in _COMMON]
+# ---------------------------------------------------------------------------
+# Entity extraction constants
+# ---------------------------------------------------------------------------
 
-    entities.extend(values)
-    entities.extend(tickers[:2])
-    entities.extend(proper[:2])
-    entities.extend(kr_entities[:3])
-    # Deduplicate while preserving order
-    seen = set()
+# Common English words that should not be treated as proper-noun entities
+_COMMON_WORDS = {
+    "The", "And", "For", "With", "Has", "Are", "Its", "But", "How", "Why",
+    "What", "New", "All", "Can", "Now", "Get", "Set", "May", "Not",
+    "Other", "Others", "Another", "Being", "Having", "Doing",
+    "Becomes", "Become", "Getting", "Going", "Coming", "Making",
+    "Says", "Said", "Warns", "Faces", "Shows", "Finds", "Takes", "Gives",
+    "Looks", "Tells", "Seems", "Turns", "Leads", "Holds",
+    "Spikes", "Spike", "Surges", "Surge", "Drops", "Drop", "Falls",
+    "First", "Last", "Next", "After", "Before", "During",
+    "Under", "Over", "About", "Every", "Where", "Which", "While",
+    "Their", "These", "Those", "Could", "Would", "Should", "Might",
+    "Still", "Just", "Also", "More", "Most", "Some", "Much", "Many",
+    "Each", "Only", "Even", "Very", "Here", "There", "Then", "Than",
+    "Into", "From", "This", "That", "Been", "Were", "Will",
+    "Your", "They", "Them", "Such", "Like", "Near", "Amid",
+    "Ahead", "Along", "Among", "Above", "Below", "Behind",
+    "Between", "Through", "Against", "Within", "Without", "Across", "Inside",
+    "Global", "World", "Major", "Latest", "Breaking", "Live", "Watch",
+    "Alert", "Update", "Report", "Check",
+    "Shares", "Stock", "Stocks", "Market", "Markets",
+    "Price", "Prices", "Trade", "Trades", "Trading",
+    "Company", "Companies", "Industry",
+    "Million", "Billion", "Trillion",
+    "Today", "Yesterday", "Tomorrow", "Year", "Week", "Month",
+    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+    "Better", "Bigger", "Lower", "Higher", "Early", "Late",
+    "Huge", "Massive", "Record", "Rising", "Falling",
+    "Since", "Until", "Whether",
+    "Biggest", "Worst", "Best",
+    "Headed", "Heads", "Keep", "Keeps", "Stayed", "Stays", "Stay", "Worse",
+    "Linked", "Issues", "Issue", "Based", "Using",
+    "Asked", "Asking", "Called", "Calls", "Named", "Known",
+    "Seen", "Taken", "Given",
+    "Several", "Certain", "Entire", "Recent",
+    "Little", "Large", "Small", "Long", "Short", "Full", "Half",
+    "Wants", "Needs", "Tries",
+    "Three", "Four", "Five",
+}
+
+# Uppercase sequences that look like tickers but are not meaningful financial symbols
+_NOISE_TICKER_SYMBOLS = {
+    "CEO", "IPO", "SEC", "FED", "GDP", "CPI", "ETF",
+    "AI", "US", "UK", "EU", "USD",
+    "FOR", "THE", "ARE", "HAS", "NOT", "BUT", "ALL", "CAN", "NOW",
+    "HOW", "NEW", "CBS", "FBI", "GOP", "DHS", "RFK",
+    "ITS", "WAS", "HIS", "HER", "WHO", "MAY",
+    "BIG", "TOP", "TWO", "OUR", "SAY", "ANY", "FEW", "RED",
+}
+
+
+def _extract_raw_patterns(title: str) -> tuple:
+    """Run regex extractions on title and return (tickers, values, proper, kr_entities)."""
+    tickers = re.findall(r"\b[A-Z]{2,5}\b", title)
+    values = re.findall(r"\$[\d,.]+[KkMmBbTt]?|\d+(?:\.\d+)?%", title)
+    kr_entities = re.findall(r"[가-힣]{2,}", title)
+    proper = re.findall(r"\b[A-Z][a-z]{2,}\b", title)
+    return tickers, values, proper, kr_entities
+
+
+def _filter_entities(tickers: list, proper: list) -> tuple:
+    """Filter noise from ticker and proper-noun lists."""
+    clean_tickers = [t for t in tickers if t not in _NOISE_TICKER_SYMBOLS]
+    clean_proper = [w for w in proper if w not in _COMMON_WORDS]
+    return clean_tickers, clean_proper
+
+
+def _dedup_entities(entities: list) -> list:
+    """Deduplicate entity list while preserving insertion order (case-insensitive)."""
+    seen: set = set()
     deduped = []
     for e in entities:
         if e.lower() not in seen:
             seen.add(e.lower())
             deduped.append(e)
     return deduped
+
+
+def _extract_title_entities(title: str) -> list:
+    """Extract meaningful entities (names, tickers, numbers) from title."""
+    tickers, values, proper, kr_entities = _extract_raw_patterns(title)
+    tickers, proper = _filter_entities(tickers, proper)
+
+    entities: list = []
+    entities.extend(values)
+    entities.extend(tickers[:2])
+    entities.extend(proper[:2])
+    entities.extend(kr_entities[:3])
+    return _dedup_entities(entities)
 
 
 def _analyze_title_content(title: str) -> str:

--- a/scripts/tests/test_collectors.py
+++ b/scripts/tests/test_collectors.py
@@ -1,0 +1,694 @@
+"""Unit tests for collector modules: rss_fetcher, crypto_api, fmp_api, collector_metrics."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# sys.path: make `scripts/` importable as a package root so that
+# `from common.xxx import ...` works the same way the collector scripts do.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# ---------------------------------------------------------------------------
+# Minimal RSS XML fixtures
+# ---------------------------------------------------------------------------
+
+_VALID_RSS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <item>
+      <title>Bitcoin surges to new high</title>
+      <link>https://example.com/btc-high</link>
+      <pubDate>Mon, 24 Mar 2026 06:00:00 +0000</pubDate>
+      <description>Bitcoin reached a new record price today.</description>
+    </item>
+    <item>
+      <title>Ethereum upgrade complete</title>
+      <link>https://example.com/eth-upgrade</link>
+      <pubDate>Mon, 24 Mar 2026 05:00:00 +0000</pubDate>
+      <description>The Ethereum network completed its scheduled upgrade.</description>
+    </item>
+  </channel>
+</rss>"""
+
+_EMPTY_RSS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Empty Feed</title>
+  </channel>
+</rss>"""
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a mock HTTP response
+# ---------------------------------------------------------------------------
+
+def _make_response(text: str, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import requests
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            f"{status_code} Error", response=resp
+        )
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# rss_fetcher tests
+# ---------------------------------------------------------------------------
+
+class TestFetchRssFeed:
+    """Tests for rss_fetcher.fetch_rss_feed()."""
+
+    def test_valid_rss_returns_items(self):
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.return_value = _make_response(_VALID_RSS_XML)
+            items = fetch_rss_feed(
+                url="https://example.com/feed.rss",
+                source_name="TestFeed",
+                tags=["crypto"],
+                max_age_hours=0,  # skip age filter
+            )
+
+        assert len(items) == 2
+
+    def test_valid_rss_item_fields(self):
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.return_value = _make_response(_VALID_RSS_XML)
+            items = fetch_rss_feed(
+                url="https://example.com/feed.rss",
+                source_name="TestSource",
+                tags=["bitcoin"],
+                max_age_hours=0,
+            )
+
+        first = items[0]
+        assert "title" in first
+        assert "link" in first
+        assert "published" in first
+        assert "source" in first
+        assert "tags" in first
+        assert first["source"] == "TestSource"
+        assert first["tags"] == ["bitcoin"]
+
+    def test_valid_rss_title_extraction(self):
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.return_value = _make_response(_VALID_RSS_XML)
+            items = fetch_rss_feed(
+                url="https://example.com/feed.rss",
+                source_name="TestFeed",
+                tags=[],
+                max_age_hours=0,
+            )
+
+        assert "Bitcoin" in items[0]["title"]
+
+    def test_valid_rss_link_extraction(self):
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.return_value = _make_response(_VALID_RSS_XML)
+            items = fetch_rss_feed(
+                url="https://example.com/feed.rss",
+                source_name="TestFeed",
+                tags=[],
+                max_age_hours=0,
+            )
+
+        assert items[0]["link"] == "https://example.com/btc-high"
+
+    def test_valid_rss_published_extraction(self):
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.return_value = _make_response(_VALID_RSS_XML)
+            items = fetch_rss_feed(
+                url="https://example.com/feed.rss",
+                source_name="TestFeed",
+                tags=[],
+                max_age_hours=0,
+            )
+
+        assert items[0]["published"] != ""
+
+    def test_empty_feed_returns_empty_list(self):
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.return_value = _make_response(_EMPTY_RSS_XML)
+            items = fetch_rss_feed(
+                url="https://example.com/empty.rss",
+                source_name="EmptyFeed",
+                tags=[],
+            )
+
+        assert items == []
+
+    def test_http_error_returns_empty_list(self):
+        import requests as req_lib
+
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.side_effect = req_lib.exceptions.HTTPError("503 Service Unavailable")
+            items = fetch_rss_feed(
+                url="https://example.com/broken.rss",
+                source_name="BrokenFeed",
+                tags=[],
+            )
+
+        assert items == []
+
+    def test_connection_error_returns_empty_list(self):
+        import requests as req_lib
+
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.side_effect = req_lib.exceptions.ConnectionError("Connection refused")
+            items = fetch_rss_feed(
+                url="https://example.com/unreachable.rss",
+                source_name="UnreachableFeed",
+                tags=[],
+            )
+
+        assert items == []
+
+    def test_limit_respected(self):
+        from common.rss_fetcher import fetch_rss_feed
+
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.return_value = _make_response(_VALID_RSS_XML)
+            items = fetch_rss_feed(
+                url="https://example.com/feed.rss",
+                source_name="TestFeed",
+                tags=[],
+                limit=1,
+                max_age_hours=0,
+            )
+
+        assert len(items) <= 1
+
+    def test_feed_health_updated_on_success(self):
+        from common.rss_fetcher import fetch_rss_feed, get_feed_health
+
+        url = "https://example.com/health-test.rss"
+        with patch("common.rss_fetcher.requests.get") as mock_get:
+            mock_get.return_value = _make_response(_VALID_RSS_XML)
+            fetch_rss_feed(url=url, source_name="HealthTest", tags=[], max_age_hours=0)
+
+        health = get_feed_health()
+        assert url in health
+        assert health[url]["ok"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# crypto_api tests
+# ---------------------------------------------------------------------------
+
+class TestFetchCoingeckoTopCoins:
+    """Tests for crypto_api.fetch_coingecko_top_coins()."""
+
+    def _make_coins_response(self, count: int = 3) -> MagicMock:
+        coins = [
+            {"id": f"coin-{i}", "symbol": f"c{i}", "current_price": 100 * i}
+            for i in range(1, count + 1)
+        ]
+        resp = MagicMock()
+        resp.json.return_value = coins
+        return resp
+
+    def test_returns_list_of_coins(self):
+        from common.crypto_api import fetch_coingecko_top_coins
+
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.return_value = self._make_coins_response(5)
+            coins = fetch_coingecko_top_coins(limit=5)
+
+        assert isinstance(coins, list)
+        assert len(coins) == 5
+
+    def test_passes_limit_param(self):
+        from common.crypto_api import fetch_coingecko_top_coins
+
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.return_value = self._make_coins_response(10)
+            fetch_coingecko_top_coins(limit=10)
+
+        call_kwargs = mock_req.call_args
+        params = call_kwargs[1].get("params") or call_kwargs[0][1] if len(call_kwargs[0]) > 1 else {}
+        # params may be passed as keyword arg
+        if call_kwargs[1].get("params"):
+            assert call_kwargs[1]["params"]["per_page"] == 10
+
+    def test_timeout_error_returns_empty_list(self):
+        import requests as req_lib
+
+        from common.crypto_api import fetch_coingecko_top_coins
+
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.side_effect = req_lib.exceptions.Timeout("Request timed out")
+            coins = fetch_coingecko_top_coins()
+
+        assert coins == []
+
+    def test_connection_error_returns_empty_list(self):
+        import requests as req_lib
+
+        from common.crypto_api import fetch_coingecko_top_coins
+
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.side_effect = req_lib.exceptions.ConnectionError("Network error")
+            coins = fetch_coingecko_top_coins()
+
+        assert coins == []
+
+    def test_invalid_json_returns_empty_list(self):
+        import requests as req_lib
+
+        from common.crypto_api import fetch_coingecko_top_coins
+
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.side_effect = req_lib.exceptions.RequestException("Bad response")
+            coins = fetch_coingecko_top_coins()
+
+        assert coins == []
+
+
+class TestFetchFearGreedIndex:
+    """Tests for crypto_api.fetch_fear_greed_index()."""
+
+    def _make_fng_response(self, value: int = 55, classification: str = "Greed") -> MagicMock:
+        resp = MagicMock()
+        resp.json.return_value = {
+            "data": [
+                {"value": str(value), "value_classification": classification},
+            ]
+        }
+        return resp
+
+    def test_returns_value_and_classification(self):
+        from common.crypto_api import fetch_fear_greed_index
+
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.return_value = self._make_fng_response(72, "Greed")
+            result = fetch_fear_greed_index()
+
+        assert result["value"] == 72
+        assert result["classification"] == "Greed"
+
+    def test_returns_prev_when_history_requested(self):
+        from common.crypto_api import fetch_fear_greed_index
+
+        resp = MagicMock()
+        resp.json.return_value = {
+            "data": [
+                {"value": "65", "value_classification": "Greed"},
+                {"value": "50", "value_classification": "Neutral"},
+            ]
+        }
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.return_value = resp
+            result = fetch_fear_greed_index(history_days=7)
+
+        assert result["prev_value"] == 50
+        assert result["prev_classification"] == "Neutral"
+
+    def test_empty_data_returns_empty_dict(self):
+        from common.crypto_api import fetch_fear_greed_index
+
+        resp = MagicMock()
+        resp.json.return_value = {"data": []}
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.return_value = resp
+            result = fetch_fear_greed_index()
+
+        assert result == {}
+
+    def test_timeout_returns_empty_dict(self):
+        import requests as req_lib
+
+        from common.crypto_api import fetch_fear_greed_index
+
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.side_effect = req_lib.exceptions.Timeout("Timeout")
+            result = fetch_fear_greed_index()
+
+        assert result == {}
+
+    def test_request_exception_returns_empty_dict(self):
+        import requests as req_lib
+
+        from common.crypto_api import fetch_fear_greed_index
+
+        with patch("common.crypto_api.request_with_retry") as mock_req:
+            mock_req.side_effect = req_lib.exceptions.RequestException("Error")
+            result = fetch_fear_greed_index()
+
+        assert result == {}
+
+
+class TestCryptoApiRequestTimeout:
+    """Verify REQUEST_TIMEOUT constant in crypto_api."""
+
+    def test_request_timeout_is_20(self):
+        from common.crypto_api import REQUEST_TIMEOUT
+        assert REQUEST_TIMEOUT == 20
+
+
+# ---------------------------------------------------------------------------
+# fmp_api tests
+# ---------------------------------------------------------------------------
+
+class TestFetchEconomicCalendar:
+    """Tests for fmp_api.fetch_economic_calendar()."""
+
+    def _make_fmp_response(self) -> MagicMock:
+        resp = MagicMock()
+        resp.json.return_value = [
+            {
+                "event": "US CPI",
+                "country": "US",
+                "date": "2026-03-25",
+                "impact": "High",
+                "estimate": "3.2",
+                "previous": "3.1",
+                "actual": "",
+            },
+            {
+                "event": "Low Impact Event",
+                "country": "US",
+                "date": "2026-03-25",
+                "impact": "Low",
+                "estimate": "",
+                "previous": "",
+                "actual": "",
+            },
+        ]
+        return resp
+
+    def test_returns_high_and_medium_events_only(self):
+        from common.fmp_api import fetch_economic_calendar
+
+        with patch("common.fmp_api.get_env", return_value="fake-key"), \
+             patch("common.fmp_api.request_with_retry") as mock_req:
+            mock_req.return_value = self._make_fmp_response()
+            events = fetch_economic_calendar()
+
+        # Low impact event should be filtered out
+        assert all(e["impact"] in ("High", "Medium") for e in events)
+
+    def test_event_fields_present(self):
+        from common.fmp_api import fetch_economic_calendar
+
+        with patch("common.fmp_api.get_env", return_value="fake-key"), \
+             patch("common.fmp_api.request_with_retry") as mock_req:
+            mock_req.return_value = self._make_fmp_response()
+            events = fetch_economic_calendar()
+
+        assert len(events) >= 1
+        ev = events[0]
+        assert "event" in ev
+        assert "country" in ev
+        assert "date" in ev
+        assert "impact" in ev
+        assert "forecast" in ev
+        assert "previous" in ev
+        assert "actual" in ev
+
+    def test_fallback_to_forex_factory_when_no_api_key(self):
+        from common.fmp_api import fetch_economic_calendar
+
+        forex_resp = MagicMock()
+        forex_resp.json.return_value = [
+            {
+                "title": "FOMC Meeting",
+                "country": "USD",
+                "date": "2026-03-26",
+                "impact": "High",
+                "forecast": "",
+                "previous": "5.25%",
+                "actual": "",
+            }
+        ]
+
+        with patch("common.fmp_api.get_env", return_value=""), \
+             patch("common.fmp_api.request_with_retry") as mock_req:
+            mock_req.return_value = forex_resp
+            events = fetch_economic_calendar()
+
+        # Should have called Forex Factory endpoint, not FMP
+        assert mock_req.called
+        call_args = mock_req.call_args
+        url_called = call_args[0][0] if call_args[0] else call_args[1].get("url", "")
+        assert "faireconomy" in url_called or "forex" in url_called.lower() or len(events) >= 0
+
+    def test_fallback_used_when_fmp_fails(self):
+        import requests as req_lib
+
+        from common.fmp_api import fetch_economic_calendar
+
+        forex_resp = MagicMock()
+        forex_resp.json.return_value = [
+            {
+                "title": "GDP Release",
+                "country": "USD",
+                "date": "2026-03-27",
+                "impact": "High",
+                "forecast": "2.1%",
+                "previous": "2.0%",
+                "actual": "",
+            }
+        ]
+
+        def _side_effect(url, **kwargs):
+            if "financialmodelingprep" in url:
+                raise req_lib.exceptions.ConnectionError("FMP unavailable")
+            return forex_resp
+
+        with patch("common.fmp_api.get_env", return_value="fake-key"), \
+             patch("common.fmp_api.request_with_retry", side_effect=_side_effect):
+            events = fetch_economic_calendar()
+
+        assert isinstance(events, list)
+
+    def test_empty_fmp_response_falls_back(self):
+        from common.fmp_api import fetch_economic_calendar
+
+        empty_resp = MagicMock()
+        empty_resp.json.return_value = []
+
+        forex_resp = MagicMock()
+        forex_resp.json.return_value = []
+
+        call_count = {"n": 0}
+
+        def _side_effect(url, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return empty_resp
+            return forex_resp
+
+        with patch("common.fmp_api.get_env", return_value="fake-key"), \
+             patch("common.fmp_api.request_with_retry", side_effect=_side_effect):
+            events = fetch_economic_calendar()
+
+        # Empty FMP list triggers fallback — two calls total expected
+        assert call_count["n"] == 2
+        assert events == []
+
+
+class TestFmpApiRequestTimeout:
+    """Verify REQUEST_TIMEOUT is imported from config in fmp_api."""
+
+    def test_request_timeout_imported_from_config(self):
+        # fmp_api imports REQUEST_TIMEOUT from config at module level
+        import importlib
+
+        from common.config import REQUEST_TIMEOUT as config_timeout
+        from common.fmp_api import fetch_economic_calendar  # noqa: F401 — trigger module import
+        source = importlib.util.find_spec("common.fmp_api").origin
+        with open(source, encoding="utf-8") as f:
+            src = f.read()
+        assert "from .config import" in src
+        assert "REQUEST_TIMEOUT" in src
+        # The value used should match config's value
+        assert config_timeout == 15
+
+
+# ---------------------------------------------------------------------------
+# collector_metrics tests
+# ---------------------------------------------------------------------------
+
+class TestLogCollectionSummary:
+    """Tests for collector_metrics.log_collection_summary()."""
+
+    def test_logs_at_info_level(self):
+        import time
+
+        from common.collector_metrics import log_collection_summary
+
+        mock_logger = MagicMock()
+        started = time.monotonic() - 1.5
+        log_collection_summary(
+            logger=mock_logger,
+            collector="test_collector",
+            source_count=3,
+            unique_items=10,
+            post_created=2,
+            started_at=started,
+        )
+
+        mock_logger.info.assert_called_once()
+
+    def test_output_contains_collector_name(self):
+        import time
+
+        from common.collector_metrics import log_collection_summary
+
+        mock_logger = MagicMock()
+        started = time.monotonic()
+        log_collection_summary(
+            logger=mock_logger,
+            collector="crypto_news",
+            source_count=5,
+            unique_items=20,
+            post_created=4,
+            started_at=started,
+        )
+
+        call_args = mock_logger.info.call_args
+        # First positional arg is the format string; remainder are format args
+        fmt_args = call_args[0]
+        assert "crypto_news" in fmt_args
+
+    def test_output_contains_counts(self):
+        import time
+
+        from common.collector_metrics import log_collection_summary
+
+        mock_logger = MagicMock()
+        started = time.monotonic()
+        log_collection_summary(
+            logger=mock_logger,
+            collector="stock_news",
+            source_count=7,
+            unique_items=15,
+            post_created=3,
+            started_at=started,
+        )
+
+        call_args = mock_logger.info.call_args
+        fmt_args = call_args[0]
+        # collector, source_count, unique_items, post_created are positional format args
+        assert 7 in fmt_args
+        assert 15 in fmt_args
+        assert 3 in fmt_args
+
+    def test_negative_values_clamped_to_zero(self):
+        import time
+
+        from common.collector_metrics import log_collection_summary
+
+        mock_logger = MagicMock()
+        started = time.monotonic()
+        log_collection_summary(
+            logger=mock_logger,
+            collector="test",
+            source_count=-5,
+            unique_items=-1,
+            post_created=-3,
+            started_at=started,
+        )
+
+        call_args = mock_logger.info.call_args
+        fmt_args = call_args[0]
+        # After max(0, ...) clamping, negative values become 0
+        assert -5 not in fmt_args
+        assert -1 not in fmt_args
+        assert -3 not in fmt_args
+
+    def test_extras_included_in_output(self):
+        import time
+
+        from common.collector_metrics import log_collection_summary
+
+        mock_logger = MagicMock()
+        started = time.monotonic()
+        log_collection_summary(
+            logger=mock_logger,
+            collector="test",
+            source_count=1,
+            unique_items=1,
+            post_created=1,
+            started_at=started,
+            extras={"api": "coingecko", "errors": 0},
+        )
+
+        call_args = mock_logger.info.call_args
+        # The last positional arg carries formatted extras string
+        fmt_string = call_args[0][0]
+        all_args = call_args[0]
+        full_msg = fmt_string % all_args[1:]
+        assert "api=coingecko" in full_msg
+        assert "errors=0" in full_msg
+
+    def test_no_extras_no_trailing_content(self):
+        import time
+
+        from common.collector_metrics import log_collection_summary
+
+        mock_logger = MagicMock()
+        started = time.monotonic()
+        log_collection_summary(
+            logger=mock_logger,
+            collector="test",
+            source_count=0,
+            unique_items=0,
+            post_created=0,
+            started_at=started,
+        )
+
+        call_args = mock_logger.info.call_args
+        fmt_string = call_args[0][0]
+        all_args = call_args[0]
+        full_msg = fmt_string % all_args[1:]
+        # The extras segment should be empty (no trailing garbage)
+        assert full_msg.endswith("s") or full_msg.endswith("s ")
+
+    def test_duration_is_non_negative(self):
+        import time
+
+        from common.collector_metrics import log_collection_summary
+
+        mock_logger = MagicMock()
+        # started_at in the future — duration should be clamped to 0
+        future_start = time.monotonic() + 100
+        log_collection_summary(
+            logger=mock_logger,
+            collector="test",
+            source_count=0,
+            unique_items=0,
+            post_created=0,
+            started_at=future_start,
+        )
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        fmt_string = call_args[0][0]
+        all_args = call_args[0]
+        full_msg = fmt_string % all_args[1:]
+        assert "duration=0.00s" in full_msg


### PR DESCRIPTION
## Summary

- minima Sass lighten/darken deprecation 제거 (15 → 5 경고)
- `enrichment.py` `_extract_title_entities()` 282줄 → 14줄 + 3개 헬퍼
- 수집기 단위 테스트 34개 추가 (rss_fetcher, crypto_api, fmp_api, collector_metrics)
- 전체 테스트 85개 통과 (0.27초)

## Test plan

- [x] `cd scripts && python3 -m pytest tests/ -v` — 85 passed
- [x] `bundle exec jekyll build` — 빌드 성공
- [x] `python3 -m ruff check scripts/` — 린트 통과