### PR TITLE
chore: .gitignore에 omc/tmp/coverage 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ assets/images/test-*
 
 # Claude local settings (personal)
 .claude/settings.local.json
+
+# OMC / temp / coverage
+.omc-config.json
+.tmp/
+.coverage
+scripts/.coverage
+coverage-html/
+coverage.json


### PR DESCRIPTION
임시 파일 및 커버리지 출력물 gitignore 추가