### PR TITLE
feat: URL 기반 중복 감지 전체 수집기 적용

### DIFF
--- a/scripts/collect_geopolitical.py
+++ b/scripts/collect_geopolitical.py
@@ -26,7 +26,7 @@ from common.config import (
     get_verify_ssl,
     setup_logging,
 )
-from common.dedup import DedupEngine
+from common.dedup import DedupEngine, deduplicate_by_url
 from common.enrichment import enrich_items
 from common.markdown_utils import (
     html_reference_details,
@@ -705,6 +705,7 @@ def main() -> None:
     # Enrich Google News items for descriptions
     if google_news_items:
         enrich_items(google_news_items, _GEO_SOURCE_CONTEXT, fetch_url=False)
+        google_news_items = deduplicate_by_url(google_news_items)
 
     # Count total items across sources
     total_items = len(markets) + len(gdelt_articles) + len(google_news_items)

--- a/scripts/collect_political_trades.py
+++ b/scripts/collect_political_trades.py
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from common.collector_metrics import log_collection_summary
 from common.config import REQUEST_TIMEOUT, get_kst_now, get_verify_ssl, setup_logging
-from common.dedup import DedupEngine
+from common.dedup import DedupEngine, deduplicate_by_url
 from common.enrichment import _POLITICAL_SOURCE_CONTEXT, enrich_items
 from common.markdown_utils import (
     html_reference_details,
@@ -252,17 +252,12 @@ def main():
     all_items = congress_items + sec_items + trump_items + korea_items + central_bank_items
     pre_dedup_count = len(all_items)
 
-    # Deduplicate individual items (by title+source AND by URL)
-    unique_items = []
-    seen_links: set[str] = set()
-    for item in all_items:
-        link = item.get("link", "").split("?")[0].rstrip("/")  # normalize URL
-        if link and link in seen_links:
-            continue
-        if not dedup.is_duplicate(item.get("title", ""), item.get("source", ""), today):
-            unique_items.append(item)
-            if link:
-                seen_links.add(link)
+    # Deduplicate individual items (by URL, then by title+source)
+    all_items = deduplicate_by_url(all_items)
+    unique_items = [
+        item for item in all_items
+        if not dedup.is_duplicate(item.get("title", ""), item.get("source", ""), today)
+    ]
 
     total_count = len(unique_items)
     logger.info(

--- a/scripts/collect_worldmonitor_news.py
+++ b/scripts/collect_worldmonitor_news.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from common.collector_metrics import log_collection_summary
 from common.config import REQUEST_TIMEOUT, USER_AGENT, get_kst_now, get_verify_ssl, setup_logging
-from common.dedup import DedupEngine
+from common.dedup import DedupEngine, deduplicate_by_url
 from common.enrichment import _WORLDMONITOR_SOURCE_CONTEXT, enrich_items
 from common.markdown_utils import (
     escape_table_cell,
@@ -680,6 +680,7 @@ def main() -> None:
         return
 
     enrich_items(items, context_map=_WORLDMONITOR_SOURCE_CONTEXT, max_fetch=20)
+    items = deduplicate_by_url(items)
 
     source_counter: Counter = Counter()
     theme_counter: Counter = Counter()

--- a/scripts/tests/test_core_modules.py
+++ b/scripts/tests/test_core_modules.py
@@ -223,6 +223,101 @@ class TestDedupEngineMarkSeen:
             assert engine2.is_duplicate_exact("Persistent title", "src", "2024-01-15") is True
 
 
+class TestDedupEngineUrlDedup:
+    """Tests for URL-based deduplication."""
+
+    def test_url_duplicate_different_source(self, tmp_path):
+        import common.dedup as dedup_mod
+        with patch.object(dedup_mod, "STATE_DIR", str(tmp_path)):
+            from common.dedup import DedupEngine
+            engine = DedupEngine("test_state.json")
+            engine.mark_seen("Article A", "src1", "2024-01-15", url="https://example.com/article")
+            assert engine.is_duplicate("Article A", "src2", "2024-01-15", url="https://example.com/article") is True
+
+    def test_url_duplicate_with_tracking_params(self, tmp_path):
+        import common.dedup as dedup_mod
+        with patch.object(dedup_mod, "STATE_DIR", str(tmp_path)):
+            from common.dedup import DedupEngine
+            engine = DedupEngine("test_state.json")
+            engine.mark_seen("Article", "src1", "2024-01-15", url="https://example.com/art?utm=1")
+            assert engine.is_duplicate("Article", "src2", "2024-01-15", url="https://example.com/art?ref=2") is True
+
+    def test_different_url_not_duplicate(self, tmp_path):
+        import common.dedup as dedup_mod
+        with patch.object(dedup_mod, "STATE_DIR", str(tmp_path)):
+            from common.dedup import DedupEngine
+            engine = DedupEngine("test_state.json")
+            engine.mark_seen("Article", "src1", "2024-01-15", url="https://example.com/art1")
+            assert engine.is_duplicate("Other Article", "src2", "2024-01-15", url="https://example.com/art2") is False
+
+    def test_no_url_falls_back_to_title(self, tmp_path):
+        import common.dedup as dedup_mod
+        with patch.object(dedup_mod, "STATE_DIR", str(tmp_path)):
+            from common.dedup import DedupEngine
+            engine = DedupEngine("test_state.json")
+            engine.mark_seen("Unique Article", "src1", "2024-01-15")
+            assert engine.is_duplicate("Unique Article", "src1", "2024-01-15") is True
+            assert engine.is_duplicate("Different Article", "src1", "2024-01-15") is False
+
+    def test_url_persists_after_save_reload(self, tmp_path):
+        import common.dedup as dedup_mod
+        with patch.object(dedup_mod, "STATE_DIR", str(tmp_path)):
+            from common.dedup import DedupEngine
+            engine = DedupEngine("url_persist.json")
+            engine.mark_seen("Art", "src", "2024-01-15", url="https://example.com/x")
+            engine.save()
+            engine2 = DedupEngine("url_persist.json")
+            assert engine2.is_duplicate("Art", "src2", "2024-01-15", url="https://example.com/x") is True
+
+
+class TestDeduplicateByUrl:
+    """Tests for the deduplicate_by_url utility function."""
+
+    def test_removes_duplicate_urls(self):
+        from common.dedup import deduplicate_by_url
+        items = [
+            {"title": "A", "link": "https://example.com/1"},
+            {"title": "B", "link": "https://example.com/2"},
+            {"title": "A copy", "link": "https://example.com/1"},
+        ]
+        result = deduplicate_by_url(items)
+        assert len(result) == 2
+        assert result[0]["title"] == "A"
+        assert result[1]["title"] == "B"
+
+    def test_keeps_items_without_url(self):
+        from common.dedup import deduplicate_by_url
+        items = [
+            {"title": "A", "link": ""},
+            {"title": "B"},
+            {"title": "C", "link": "https://example.com/1"},
+        ]
+        result = deduplicate_by_url(items)
+        assert len(result) == 3
+
+    def test_normalizes_tracking_params(self):
+        from common.dedup import deduplicate_by_url
+        items = [
+            {"title": "A", "link": "https://example.com/art?utm=1"},
+            {"title": "B", "link": "https://example.com/art?ref=2"},
+        ]
+        result = deduplicate_by_url(items)
+        assert len(result) == 1
+
+    def test_empty_list(self):
+        from common.dedup import deduplicate_by_url
+        assert deduplicate_by_url([]) == []
+
+    def test_custom_url_key(self):
+        from common.dedup import deduplicate_by_url
+        items = [
+            {"title": "A", "url": "https://example.com/1"},
+            {"title": "B", "url": "https://example.com/1"},
+        ]
+        result = deduplicate_by_url(items, url_key="url")
+        assert len(result) == 1
+
+
 # ---------------------------------------------------------------------------
 # post_generator module tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- 나머지 3개 수집기(political_trades, worldmonitor, geopolitical)에 `deduplicate_by_url` 적용
- political_trades의 기존 수동 URL dedup 로직을 공통 유틸리티로 교체
- URL 기반 dedup 테스트 10건 추가 (DedupEngine URL + deduplicate_by_url 유틸리티)

## Test plan
- [x] ruff check 통과 (5개 파일)
- [x] 신규 테스트 10건 통과
- [x] 전체 테스트 1473건 통과 (회귀 없음)
- [ ] 다음 수집 주기에서 "URL dedup removed N items" 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)