### PR TITLE
observability: add dns_cache_snapshot() helper for SSRF DNS cache tuning

### DIFF
--- a/scripts/common/utils.py
+++ b/scripts/common/utils.py
@@ -131,6 +131,33 @@ def _resolve_hostname_ips(hostname: str) -> Optional[tuple]:
         return None
 
 
+def dns_cache_snapshot() -> dict:
+    """Return a point-in-time snapshot of the DNS SSRF guard cache.
+
+    Intended for collector observability: log this dict (or inject into
+    ``log_collection_summary`` extras) at the end of a collection run to
+    track whether ``maxsize`` is saturated.
+
+    Returns a dict with keys:
+    - ``dns_cache_size``: number of entries currently cached (thread-safe read).
+    - ``dns_cache_maxsize``: configured cache capacity.
+    - ``dns_cache_ttl_seconds``: configured entry TTL.
+
+    Tuning guidance based on repeated snapshots:
+    - Sustained ``size < maxsize * 0.2`` over many runs → current sizing may
+      be over-provisioned but the memory cost is negligible; no action needed.
+    - Sustained ``size >= maxsize * 0.8`` → consider raising ``maxsize`` so
+      legitimate upstreams are not churned out within a single collection run.
+    """
+    with _dns_cache_lock:
+        size = len(_dns_cache)
+    return {
+        "dns_cache_size": size,
+        "dns_cache_maxsize": _dns_cache.maxsize,
+        "dns_cache_ttl_seconds": int(_dns_cache.ttl),
+    }
+
+
 def is_private_url_target(url: str) -> bool:
     """Best-effort SSRF guard for URL targets.
 

--- a/tests/test_utils_ssrf.py
+++ b/tests/test_utils_ssrf.py
@@ -330,3 +330,56 @@ class TestMalformedUrls:
 
     def test_just_scheme_blocked(self):
         assert is_private_url_target("http://") is True
+
+
+# ---------------------------------------------------------------------------
+# 11. dns_cache_snapshot observability helper
+# ---------------------------------------------------------------------------
+
+
+class TestDnsCacheSnapshot:
+    """Guardrails for dns_cache_snapshot() used by collector observability."""
+
+    def _clear(self):
+        from common.utils import _dns_cache, _dns_cache_lock
+
+        with _dns_cache_lock:
+            _dns_cache.clear()
+
+    def test_schema_and_defaults(self):
+        from common.utils import dns_cache_snapshot
+
+        self._clear()
+        snap = dns_cache_snapshot()
+        assert set(snap.keys()) == {
+            "dns_cache_size",
+            "dns_cache_maxsize",
+            "dns_cache_ttl_seconds",
+        }
+        assert snap["dns_cache_size"] == 0
+        assert snap["dns_cache_maxsize"] == 256
+        assert snap["dns_cache_ttl_seconds"] == 300
+
+    def test_size_reflects_cache_population(self):
+        from common.utils import dns_cache_snapshot, is_private_url_target
+
+        self._clear()
+        with patch("socket.getaddrinfo", return_value=_fake_getaddrinfo("8.8.8.8")):
+            is_private_url_target("https://example.com/")
+
+        snap = dns_cache_snapshot()
+        assert snap["dns_cache_size"] >= 1
+        assert snap["dns_cache_size"] <= snap["dns_cache_maxsize"]
+
+    def test_types_are_jsonable(self):
+        """Snapshot must be log/JSON friendly — no cachetools internals leak."""
+        import json
+
+        from common.utils import dns_cache_snapshot
+
+        self._clear()
+        snap = dns_cache_snapshot()
+        # json.dumps raises TypeError on non-serializable values
+        json.dumps(snap)
+        for v in snap.values():
+            assert isinstance(v, int)


### PR DESCRIPTION
## Summary
- Adds `dns_cache_snapshot()` in `scripts/common/utils.py` as a minimal, opt-in observability helper for the DNS SSRF guard cache.
- Follow-up to PR #621 which introduced the thread-safe `TTLCache(maxsize=256, ttl=300)` replacing `functools.lru_cache`. We want empirical evidence to tune `maxsize` without guessing.

## Why
The SSRF guard resolves every upstream hostname via `socket.getaddrinfo` (fail-closed). The new TTLCache is bounded at 256 entries; if a collection run exercises >256 distinct hostnames within a 5-minute window, legitimate upstreams can be evicted mid-run and re-resolved repeatedly, wasting DNS calls. Without observability we can't tell whether 256 is over-provisioned or under-provisioned.

## What the helper returns
```python
{
    "dns_cache_size": int,        # current entry count (thread-safe read)
    "dns_cache_maxsize": int,     # configured capacity
    "dns_cache_ttl_seconds": int, # configured TTL
}
```

## Intended usage (opt-in, no collector changes in this PR)
Collectors can inject the snapshot into `log_collection_summary` extras:
```python
from common.utils import dns_cache_snapshot
log_collection_summary(
    logger, collector="crypto_news", ...,
    extras={**dns_cache_snapshot(), "items_after_dedup": len(items)},
)
```

## Tuning rubric (documented in the docstring)
- Sustained `size < maxsize * 0.2` → over-provisioned (harmless, memory is negligible)
- Sustained `size >= maxsize * 0.8` → raise `maxsize` to avoid mid-run eviction

## Scope discipline
- No behavioral changes to `_resolve_hostname_ips` or `is_private_url_target`.
- No collector call-sites touched — opt-in so reviewers can consider adoption pattern separately.
- Hit/miss counters intentionally **not** added: cachetools' `@cached` decorator doesn't expose stats, and replacing it needs a bigger rewrite that isn't justified until size monitoring shows demand.

## Test plan
- [x] `ruff check` clean on both touched files
- [x] 3 new tests in `tests/test_utils_ssrf.py::TestDnsCacheSnapshot` cover schema, population reflection, and JSON-serializability
- [x] `pytest tests/test_utils_ssrf.py tests/test_utils.py` → 107 passed, 0 regressions
- [ ] CI quality + e2e + CodeQL