### PR TITLE
fix: 보안 리포트 description 영문 헤드라인 노출 방지

### DIFF
--- a/scripts/collect_crypto_news.py
+++ b/scripts/collect_crypto_news.py
@@ -535,10 +535,16 @@ def _build_security_description(
     rekt_items: List[Dict[str, Any]],
     google_security_items: List[Dict[str, Any]],
 ) -> str:
-    """보안 포스트의 동적 description_ko를 생성합니다."""
+    """보안 포스트의 동적 description_ko를 생성합니다.
+
+    Rekt 항목은 ``Funds Lost:`` 메타데이터가 있는 실제 해킹 사건일 때만 대표
+    문구로 사용합니다. 메타데이터가 없는 항목(일반 분석/오피니언 아티클 등)은
+    제목을 그대로 description에 노출하면 영문 헤드라인이 한국어 description을
+    오염시켜 검색/UX 품질이 떨어지므로, Google 보안 뉴스 fallback으로 위임합니다.
+    """
     parts: List[str] = []
 
-    # Rekt 사고에서 대표 사건 추출
+    # Rekt 사고: Funds Lost 메타데이터가 있는 실제 해킹만 노출.
     if rekt_items:
         top = rekt_items[0]
         project = top["title"].replace("[Security] ", "")
@@ -551,10 +557,10 @@ def _build_security_description(
                 pass
         if funds:
             parts.append(f"{project} {funds} 피해 발생")
-        else:
-            parts.append(f"{project} 보안 사고 보고")
+        # No else: rekt 항목에 funds 메타데이터가 없으면 일반 기사일 수 있어
+        # 제목(종종 영문)을 그대로 노출하지 않고 Google fallback으로 넘어간다.
 
-    # Google 보안 뉴스 대표 사건
+    # Google 보안 뉴스 대표 사건 — rekt에 실제 사건이 없을 때만 fallback.
     if google_security_items and not parts:
         top_title = get_display_title(google_security_items[0])
         parts.append(smart_truncate(top_title, 60))


### PR DESCRIPTION
## Summary
- Rekt 항목에 Funds Lost 메타데이터가 없는 경우 제목을 description에 그대로 노출하지 않도록 수정
- 영문 헤드라인이 한국어 description을 오염시키는 문제 해결
- Google 보안 뉴스 fallback으로 위임하여 description 품질 유지

## Test plan
- [ ] Funds Lost 메타데이터가 있는 rekt 항목은 기존처럼 피해 금액 표시 확인
- [ ] 메타데이터 없는 rekt 항목은 영문 제목 노출 없이 Google fallback 동작 확인
- [ ] ruff check 통과 확인