### PR TITLE
test: 생성기 테스트 커버리지 개선 (daily 44%, market 55%)

### DIFF
--- a/tests/test_generate_daily_summary.py
+++ b/tests/test_generate_daily_summary.py
@@ -373,3 +373,824 @@ class TestRenderGeneratedImage:
         # Function checks relative to script location — result varies by env
         result = gds._render_generated_image("test.png", "alt")
         assert result is None or isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# summarize_security_post
+# ---------------------------------------------------------------------------
+
+class TestSummarizeSecurityPost:
+    def _make_post(self, content: str, title: str = "보안 리포트") -> dict:
+        return {"frontmatter": {"title": title}, "content": content}
+
+    def test_basic_type_and_title(self):
+        post = self._make_post("## 보안 사고 현황\n| 프로젝트 | 피해 | 유형 |\n|---|---|---|\n| DeFi | $1M | 해킹 |")
+        result = gds.summarize_security_post(post)
+        assert result["type"] == "security"
+        assert result["title"] == "보안 리포트"
+
+    def test_incident_rows_extracted(self):
+        content = "## 보안 사고 현황\n| H1 | H2 | H3 |\n|---|---|---|\n| A | B | C |\n| D | E | F |"
+        post = self._make_post(content)
+        result = gds.summarize_security_post(post)
+        assert isinstance(result["incidents"], list)
+        assert len(result["incidents"]) == 2
+
+    def test_empty_content(self):
+        post = self._make_post("")
+        result = gds.summarize_security_post(post)
+        assert result["type"] == "security"
+        assert result["count"] == 0
+        assert result["incidents"] == []
+
+
+# ---------------------------------------------------------------------------
+# summarize_regulatory_post
+# ---------------------------------------------------------------------------
+
+class TestSummarizeRegulatoryPost:
+    def _make_post(self, content: str, title: str = "규제 동향") -> dict:
+        return {"frontmatter": {"title": title}, "content": content}
+
+    def test_basic(self):
+        post = self._make_post("## 핵심 요약\n- SEC 조사 착수\n오늘 5건의 뉴스가 수집되었습니다.")
+        result = gds.summarize_regulatory_post(post)
+        assert result["type"] == "regulatory"
+        assert result["count"] == 5
+
+    def test_empty(self):
+        post = self._make_post("")
+        result = gds.summarize_regulatory_post(post)
+        assert result["type"] == "regulatory"
+        assert result["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# summarize_social_post
+# ---------------------------------------------------------------------------
+
+class TestSummarizeSocialPost:
+    def _make_post(self, content: str, title: str = "소셜 미디어") -> dict:
+        return {"frontmatter": {"title": title}, "content": content}
+
+    def test_basic(self):
+        post = self._make_post("## 핵심 요약\n- 비트코인 트위터 급증\n총 10건을 수집했습니다.")
+        result = gds.summarize_social_post(post)
+        assert result["type"] == "social"
+        assert result["title"] == "소셜 미디어"
+
+    def test_highlights_captured(self):
+        post = self._make_post("## 핵심 요약\n- 항목1\n- 항목2\n오늘 7건의 뉴스가 수집되었습니다.")
+        result = gds.summarize_social_post(post)
+        assert len(result["highlights"]) >= 1
+        assert result["count"] == 7
+
+
+# ---------------------------------------------------------------------------
+# summarize_market_post
+# ---------------------------------------------------------------------------
+
+class TestSummarizeMarketPost:
+    def _make_post(self, content: str, title: str = "시장 종합 리포트") -> dict:
+        return {"frontmatter": {"title": title}, "content": content}
+
+    def test_basic_type(self):
+        post = self._make_post("## 오늘의 핵심\n- 코스피 상승\n## 한눈에 보기\n- 요약1")
+        result = gds.summarize_market_post(post)
+        assert result["type"] == "market"
+
+    def test_highlights_from_section(self):
+        post = self._make_post("## 오늘의 핵심\n- 코스피 +1.5%\n- 나스닥 -0.3%")
+        result = gds.summarize_market_post(post)
+        assert any("코스피" in h for h in result["highlights"])
+
+    def test_exec_summary_from_section(self):
+        post = self._make_post("## 한눈에 보기\n- 핵심 요약1\n- 핵심 요약2")
+        result = gds.summarize_market_post(post)
+        assert len(result["exec_summary"]) == 2
+
+    def test_indicator_rows_extracted(self):
+        content = (
+            "## 매크로 경제 지표\n"
+            "| 지표 | 현재 | 변동 |\n"
+            "|---|---|---|\n"
+            "| CPI | 3.2% | +0.1% |\n"
+        )
+        post = self._make_post(content)
+        result = gds.summarize_market_post(post)
+        assert len(result["indicator_rows"]) == 1
+
+    def test_empty_content(self):
+        post = self._make_post("")
+        result = gds.summarize_market_post(post)
+        assert result["type"] == "market"
+        assert result["highlights"] == []
+        assert result["indicator_rows"] == []
+
+
+# ---------------------------------------------------------------------------
+# summarize_worldmonitor_post
+# ---------------------------------------------------------------------------
+
+class TestSummarizeWorldmonitorPost:
+    def _make_post(self, content: str, title: str = "월드모니터 브리핑") -> dict:
+        return {"frontmatter": {"title": title}, "content": content}
+
+    def test_basic_type(self):
+        post = self._make_post("## 핵심 요약\n- 글로벌 이슈1\n수집 건수: **20건**")
+        result = gds.summarize_worldmonitor_post(post)
+        assert result["type"] == "worldmonitor"
+
+    def test_count_from_special_pattern(self):
+        # "수집 건수: **N건**" pattern used in worldmonitor posts
+        content = "수집 건수: **42건**"
+        post = self._make_post(content)
+        result = gds.summarize_worldmonitor_post(post)
+        assert result["count"] == 42
+
+    def test_count_from_standard_pattern(self):
+        content = "오늘 15건의 뉴스가 수집되었습니다."
+        post = self._make_post(content)
+        result = gds.summarize_worldmonitor_post(post)
+        assert result["count"] == 15
+
+    def test_strips_theme_distribution_html(self):
+        content = (
+            "## 핵심\n- 항목1\n"
+            '<div class="theme-distribution">테마블록</div>'
+        )
+        post = self._make_post(content)
+        result = gds.summarize_worldmonitor_post(post)
+        assert "theme-distribution" not in result["content"]
+
+    def test_empty(self):
+        post = self._make_post("")
+        result = gds.summarize_worldmonitor_post(post)
+        assert result["type"] == "worldmonitor"
+        assert result["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# summarize_political_post
+# ---------------------------------------------------------------------------
+
+class TestSummarizePoliticalPost:
+    def _make_post(self, content: str, title: str = "정치인 거래") -> dict:
+        return {"frontmatter": {"title": title}, "content": content}
+
+    def test_basic(self):
+        post = self._make_post("## 핵심 요약\n- 펠로시 매수\n오늘 8건의 뉴스가 수집되었습니다.")
+        result = gds.summarize_political_post(post)
+        assert result["type"] == "political"
+        assert result["count"] == 8
+
+    def test_fallback_to_news_summary_section(self):
+        content = "## 전체 뉴스 요약\n- 트럼프 에너지 정책\n총 3건을 수집했습니다."
+        post = self._make_post(content)
+        result = gds.summarize_political_post(post)
+        assert len(result["key_summary"]) >= 1
+
+    def test_fallback_to_bold_lines(self):
+        content = "## 전체 뉴스 요약\n**트레이더**: 매수 신호\n**분석**: 상승 예상"
+        post = self._make_post(content)
+        result = gds.summarize_political_post(post)
+        # _extract_bold_lines falls back when bullet points absent
+        assert isinstance(result["key_summary"], list)
+
+    def test_highlights_from_policy_section(self):
+        content = "## 정책 영향 분석\n- 에너지 정책 변화\n- 금융 규제 완화"
+        post = self._make_post(content)
+        result = gds.summarize_political_post(post)
+        assert len(result["highlights"]) >= 1
+
+    def test_empty(self):
+        post = self._make_post("")
+        result = gds.summarize_political_post(post)
+        assert result["type"] == "political"
+        assert result["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _extract_bold_lines
+# ---------------------------------------------------------------------------
+
+class TestExtractBoldLines:
+    def test_extracts_bold_colon_lines(self):
+        content = "## 섹션\n**제목**: 내용\n**다른 제목**: 다른 내용"
+        result = gds._extract_bold_lines(content, "섹션")
+        assert len(result) == 2
+        assert all(line.startswith("- **") for line in result)
+
+    def test_max_items_respected(self):
+        lines = "\n".join(f"**항목{i}**: 내용{i}" for i in range(10))
+        content = f"## 섹션\n{lines}"
+        result = gds._extract_bold_lines(content, "섹션", max_items=3)
+        assert len(result) == 3
+
+    def test_no_section_returns_empty(self):
+        result = gds._extract_bold_lines("## 다른 섹션\n**항목**: 내용", "없는 섹션")
+        assert result == []
+
+    def test_plain_lines_ignored(self):
+        content = "## 섹션\n일반 텍스트 줄\n**굵은 제목**: 내용"
+        result = gds._extract_bold_lines(content, "섹션")
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# _analyze_sentiment
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeSentiment:
+    def _make_summary(self, content: str) -> dict:
+        return {"type": "crypto", "content": content, "count": 1}
+
+    def test_positive_dominant(self):
+        content = "- [비트코인 급등으로 신고가 돌파](http://example.com)\n- [이더리움 강세 지속](http://example.com)"
+        result = gds._analyze_sentiment([self._make_summary(content)])
+        assert result["positive"] > 0
+        assert result["ratio"] > 50
+
+    def test_negative_dominant(self):
+        content = "- [비트코인 폭락 급락 해킹 사고](http://example.com)\n- [거래소 파산 위기](http://example.com)"
+        result = gds._analyze_sentiment([self._make_summary(content)])
+        assert result["negative"] > 0
+
+    def test_empty_summaries_returns_neutral(self):
+        result = gds._analyze_sentiment([])
+        assert result["tone"] == "중립"
+        assert result["ratio"] == 50
+
+    def test_none_summaries_skipped(self):
+        result = gds._analyze_sentiment([None, None])
+        assert result["tone"] == "중립"
+
+    def test_tone_labels(self):
+        # Force high positive ratio via many positive keywords
+        pos_content = " ".join(
+            f"[{kw} 뉴스 헤드라인](http://example.com)"
+            for kw in ["상승", "급등", "반등", "돌파", "신고가", "강세", "호재", "승인"]
+        )
+        result = gds._analyze_sentiment([self._make_summary(pos_content)])
+        assert result["tone"] in ("긍정 우세", "혼조", "부정 우세", "경계", "중립")
+
+    def test_ratio_bounds(self):
+        result = gds._analyze_sentiment([self._make_summary("**비트코인 급등**")])
+        assert 0 <= result["ratio"] <= 100
+
+    def test_pos_examples_collected(self):
+        content = "**비트코인이 오늘 크게 급등했습니다 (상승세)**"
+        result = gds._analyze_sentiment([self._make_summary(content)])
+        assert isinstance(result["pos_examples"], list)
+
+
+# ---------------------------------------------------------------------------
+# _extract_key_figures
+# ---------------------------------------------------------------------------
+
+class TestExtractKeyFigures:
+    def test_kospi_with_percent(self):
+        content = "KOSPI 2500.00(+1.23%)"
+        result = gds._extract_key_figures(content)
+        assert any("KOSPI" in f for f in result)
+
+    def test_btc_price_with_currency(self):
+        content = "비트코인 83,200 달러 수준을 유지했습니다."
+        result = gds._extract_key_figures(content)
+        assert any("비트코인" in f or "달러" in f for f in result)
+
+    def test_yoy_percentage(self):
+        content = "전일 대비 +2.3% 상승"
+        result = gds._extract_key_figures(content)
+        assert any("전일" in f for f in result)
+
+    def test_empty_content_returns_empty(self):
+        assert gds._extract_key_figures("") == []
+
+    def test_max_five_results(self):
+        lines = [
+            "KOSPI 2500.00(+1.0%)",
+            "KOSDAQ 800.00(-0.5%)",
+            "S&P 4500.00(+0.3%)",
+            "나스닥 15000.00(-0.2%)",
+            "다우 35000.00(+0.1%)",
+            "BTC 83000.00(+5.0%)",
+        ]
+        content = "\n".join(lines)
+        result = gds._extract_key_figures(content)
+        assert len(result) <= 5
+
+    def test_dedup_same_figure(self):
+        content = "KOSPI 2500.00(+1.0%) KOSPI 2500.00(+1.0%)"
+        result = gds._extract_key_figures(content)
+        # Should not contain duplicate
+        assert len(result) == len(set(result))
+
+
+# ---------------------------------------------------------------------------
+# _topic_hits
+# ---------------------------------------------------------------------------
+
+class TestTopicHits:
+    def test_returns_empty_for_none(self):
+        result = gds._topic_hits(None)
+        assert result == {}
+
+    def test_detects_interest_rate_topic(self):
+        summary = {
+            "title": "연준 금리 인상 결정",
+            "content": "연준이 금리를 인상했습니다.",
+            "highlights": [],
+            "key_summary": [],
+        }
+        hits = gds._topic_hits(summary)
+        assert hits.get("금리/유동성", 0) > 0
+
+    def test_detects_regulation_topic(self):
+        summary = {
+            "title": "SEC ETF 승인",
+            "content": "SEC가 비트코인 ETF를 승인했습니다.",
+            "highlights": [],
+            "key_summary": [],
+        }
+        hits = gds._topic_hits(summary)
+        assert hits.get("정책/규제", 0) > 0
+
+    def test_returns_dict_with_all_topics(self):
+        summary = {"title": "", "content": "", "highlights": [], "key_summary": []}
+        hits = gds._topic_hits(summary)
+        assert isinstance(hits, dict)
+        assert len(hits) > 0
+
+    def test_multiple_keyword_hits_add_up(self):
+        content = "금리 금리 금리 연준 연준"
+        summary = {"title": "", "content": content, "highlights": [], "key_summary": []}
+        hits = gds._topic_hits(summary)
+        assert hits.get("금리/유동성", 0) >= 5
+
+
+# ---------------------------------------------------------------------------
+# _find_shared_topics_across_categories
+# ---------------------------------------------------------------------------
+
+class TestFindSharedTopicsAcrossCategories:
+    def test_returns_list(self):
+        result = gds._find_shared_topics_across_categories([])
+        assert isinstance(result, list)
+
+    def test_finds_cross_cutting_topic(self):
+        crypto_s = {
+            "type": "crypto",
+            "content": "연준 금리 인상이 비트코인에 영향을 미쳤습니다.",
+            "highlights": [],
+        }
+        stock_s = {
+            "type": "stock",
+            "content": "연준 금리 결정으로 주식 시장이 하락했습니다.",
+            "highlights": [],
+        }
+        result = gds._find_shared_topics_across_categories([crypto_s, stock_s])
+        # 금리/유동성 should appear in both crypto and stock content
+        topic_names = [t[0] for t in result]
+        assert "금리/유동성" in topic_names
+
+    def test_no_cross_topic_when_unrelated(self):
+        crypto_s = {"type": "crypto", "content": "비트코인 가격 변동.", "highlights": []}
+        result = gds._find_shared_topics_across_categories([crypto_s])
+        # Single summary — cannot have 2+ categories, so no cross topics
+        assert all(t[1] >= 2 for t in result)
+
+    def test_sorted_by_category_count_desc(self):
+        # Generate summaries mentioning many topics across multiple categories
+        s1 = {"type": "crypto", "content": "금리 연준 환율 달러 해킹 exploit 규제 sec", "highlights": []}
+        s2 = {"type": "stock", "content": "금리 연준 환율 달러 해킹 exploit 규제 sec", "highlights": []}
+        s3 = {"type": "regulatory", "content": "금리 연준 규제 sec", "highlights": []}
+        result = gds._find_shared_topics_across_categories([s1, s2, s3])
+        if len(result) >= 2:
+            assert result[0][1] >= result[1][1]
+
+
+# ---------------------------------------------------------------------------
+# _best_non_noise_title
+# ---------------------------------------------------------------------------
+
+class TestBestNonNoiseTitle:
+    def test_returns_first_valid(self):
+        titles = ["DEF14A", "Bitcoin ETF approval clears regulatory hurdle today"]
+        result = gds._best_non_noise_title(titles)
+        assert "ETF" in result or "Bitcoin" in result.lower() or "비트" in result
+
+    def test_returns_empty_when_all_noise(self):
+        titles = ["BTC", "DEF14A", "가격 알림: BTC/USDT"]
+        result = gds._best_non_noise_title(titles)
+        assert result == ""
+
+    def test_skips_short_titles(self):
+        titles = ["짧음", "이것도 짧아서 스킵됨"]
+        result = gds._best_non_noise_title(titles)
+        # Both are <=15 chars in Korean so should be skipped
+        assert isinstance(result, str)
+
+    def test_empty_list(self):
+        assert gds._best_non_noise_title([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# _summary_keywords_for_korean
+# ---------------------------------------------------------------------------
+
+class TestSummaryKeywordsForKorean:
+    def test_known_keyword_mapped(self):
+        result = gds._summary_keywords_for_korean(["sec"])
+        assert result == "SEC"
+
+    def test_multiple_keywords_joined(self):
+        result = gds._summary_keywords_for_korean(["fed", "etf"])
+        assert "연준" in result
+        assert "ETF" in result
+
+    def test_dedup(self):
+        result = gds._summary_keywords_for_korean(["sec", "sec", "sec"])
+        assert result.count("SEC") == 1
+
+    def test_empty_list(self):
+        assert gds._summary_keywords_for_korean([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# _to_theme_payload
+# ---------------------------------------------------------------------------
+
+class TestToThemePayload:
+    def test_empty_summaries_returns_empty(self):
+        result = gds._to_theme_payload({})
+        assert isinstance(result, list)
+
+    def test_returns_at_most_five(self):
+        s = {
+            "type": "crypto",
+            "title": "금리 환율 규제 해킹 실적 기술 지정학",
+            "content": "금리 연준 환율 달러 규제 sec 해킹 exploit 실적 cpi 기술 tvl 전쟁",
+            "highlights": [],
+            "key_summary": [],
+        }
+        result = gds._to_theme_payload({"crypto": s})
+        assert len(result) <= 5
+
+    def test_payload_has_required_keys(self):
+        s = {
+            "type": "crypto",
+            "title": "연준 금리",
+            "content": "연준 금리 인상",
+            "highlights": [],
+            "key_summary": [],
+        }
+        result = gds._to_theme_payload({"crypto": s})
+        if result:
+            item = result[0]
+            assert "name" in item
+            assert "count" in item
+            assert "keywords" in item
+
+    def test_zero_score_topics_excluded(self):
+        s = {"type": "crypto", "title": "", "content": "", "highlights": [], "key_summary": []}
+        result = gds._to_theme_payload({"crypto": s})
+        assert all(item["count"] > 0 for item in result)
+
+
+# ---------------------------------------------------------------------------
+# _extract_category_data_points
+# ---------------------------------------------------------------------------
+
+class TestExtractCategoryDataPoints:
+    def test_none_returns_empty_structure(self):
+        result = gds._extract_category_data_points(None)
+        assert result["titles"] == []
+        assert result["figures"] == []
+        assert result["count"] == 0
+
+    def test_extracts_titles_from_links(self):
+        summary = {
+            "content": "[Bitcoin ETF approval by SEC confirmed today](https://example.com) news",
+            "count": 5,
+            "themes": [],
+        }
+        result = gds._extract_category_data_points(summary)
+        assert len(result["titles"]) >= 1
+
+    def test_skips_image_links(self):
+        summary = {
+            "content": "![alt text](assets/images/generated/test.png)",
+            "count": 1,
+            "themes": [],
+        }
+        result = gds._extract_category_data_points(summary)
+        assert result["titles"] == []
+
+    def test_skips_noise_titles(self):
+        summary = {
+            "content": "[가격 알림: BTC/USDT](https://example.com)",
+            "count": 1,
+            "themes": [],
+        }
+        result = gds._extract_category_data_points(summary)
+        assert result["titles"] == []
+
+    def test_theme_names_extracted(self):
+        # content must be non-empty to pass the early-return guard
+        summary = {
+            "content": "테마 내용이 있습니다.",
+            "count": 10,
+            "themes": [("규제", 5), ("기술", 3)],
+        }
+        result = gds._extract_category_data_points(summary)
+        assert result["theme_names"] == ["규제", "기술"]
+
+    def test_count_passed_through(self):
+        # content must be non-empty to pass the early-return guard
+        summary = {"content": "내용 있음.", "count": 42, "themes": []}
+        result = gds._extract_category_data_points(summary)
+        assert result["count"] == 42
+
+
+# ---------------------------------------------------------------------------
+# _collect_all_news_items
+# ---------------------------------------------------------------------------
+
+class TestCollectAllNewsItems:
+    def test_empty_summaries_returns_empty(self):
+        assert gds._collect_all_news_items([]) == []
+
+    def test_none_summaries_skipped(self):
+        assert gds._collect_all_news_items([None, None]) == []
+
+    def test_extracts_markdown_links(self):
+        s = {
+            "type": "crypto",
+            "content": "- [Bitcoin surges amid ETF approval news](https://example.com/btc)",
+        }
+        items = gds._collect_all_news_items([s])
+        assert any("Bitcoin" in item["title"] or "ETF" in item["title"] for item in items)
+
+    def test_deduplication_by_url(self):
+        content = (
+            "- [Bitcoin ETF approved by regulators today](https://example.com/btc)\n"
+            "- [Bitcoin ETF approved by regulators today](https://example.com/btc)"
+        )
+        s = {"type": "crypto", "content": content}
+        items = gds._collect_all_news_items([s])
+        # Same URL should appear only once
+        urls = [i["link"] for i in items if i.get("link") == "https://example.com/btc"]
+        assert len(urls) <= 1
+
+    def test_deduplication_across_summaries(self):
+        content = "- [Bitcoin ETF approved by SEC today confirmed](https://example.com/btc)"
+        s1 = {"type": "crypto", "content": content}
+        s2 = {"type": "stock", "content": content}
+        items = gds._collect_all_news_items([s1, s2])
+        urls = [i["link"] for i in items if i.get("link") == "https://example.com/btc"]
+        assert len(urls) == 1
+
+    def test_short_titles_filtered(self):
+        s = {"type": "crypto", "content": "- [Short](https://example.com)"}
+        items = gds._collect_all_news_items([s])
+        assert all(len(i.get("title", "")) >= 10 for i in items)
+
+    def test_html_anchor_links_extracted(self):
+        s = {
+            "type": "stock",
+            "content": '<a href="https://example.com/news">Tesla earnings beat expectations</a>',
+        }
+        items = gds._collect_all_news_items([s])
+        assert any("Tesla" in item.get("title", "") for item in items)
+
+
+# ---------------------------------------------------------------------------
+# _build_snapshot_table
+# ---------------------------------------------------------------------------
+
+class TestBuildSnapshotTable:
+    def _make_summary(self, stype: str, count: int, highlights=None, market_data=None) -> dict:
+        return {
+            "type": stype,
+            "count": count,
+            "highlights": highlights or [],
+            "key_summary": highlights or [],
+            "market_data": market_data or [],
+            "content": "",
+        }
+
+    def test_returns_list_with_table(self):
+        result = gds._build_snapshot_table(None, None, None, None, None, None)
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_all_none_shows_data_unavailable(self):
+        result = gds._build_snapshot_table(None, None, None, None, None, None)
+        combined = "\n".join(result)
+        assert "데이터 없음" in combined
+
+    def test_with_crypto_summary(self):
+        crypto = self._make_summary("crypto", 30, highlights=["- 비트코인 급등 오늘 큰 상승세"])
+        result = gds._build_snapshot_table(crypto, None, None, None, None, None)
+        combined = "\n".join(result)
+        assert "30" in combined
+
+    def test_zero_count_shows_no_data(self):
+        crypto = self._make_summary("crypto", 0)
+        result = gds._build_snapshot_table(crypto, None, None, None, None, None)
+        combined = "\n".join(result)
+        assert "데이터 없음" in combined
+
+    def test_market_data_used_as_top_signal(self):
+        stock = self._make_summary("stock", 10, market_data=["KOSPI 2500 상승"])
+        result = gds._build_snapshot_table(None, stock, None, None, None, None)
+        combined = "\n".join(result)
+        assert "KOSPI" in combined
+
+    def test_theme_name_as_fallback_signal(self):
+        crypto = {
+            "type": "crypto",
+            "count": 5,
+            "highlights": [],
+            "key_summary": [],
+            "market_data": [],
+            "content": "",
+            "themes": [("규제", 3)],
+        }
+        result = gds._build_snapshot_table(crypto, None, None, None, None, None)
+        combined = "\n".join(result)
+        assert "규제" in combined
+
+
+# ---------------------------------------------------------------------------
+# _resolve_frontmatter_image
+# ---------------------------------------------------------------------------
+
+class TestResolveFrontmatterImage:
+    def test_returns_provided_image(self):
+        result = gds._resolve_frontmatter_image("2024-01-01", "/assets/images/test.png")
+        assert result == "/assets/images/test.png"
+
+    def test_returns_empty_when_no_file_exists(self):
+        # No actual files exist for a fake date
+        result = gds._resolve_frontmatter_image("9999-99-99", None)
+        assert result == ""
+
+    def test_briefing_image_none_and_no_candidates(self):
+        result = gds._resolve_frontmatter_image("1900-01-01", None)
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# _build_overview_section
+# ---------------------------------------------------------------------------
+
+class TestBuildOverviewSection:
+    def _make_summary_map(self, crypto_count=0, stock_count=0):
+        summaries = {}
+        if crypto_count:
+            summaries["crypto"] = {
+                "type": "crypto", "count": crypto_count,
+                "highlights": [], "key_summary": [], "content": "",
+            }
+        if stock_count:
+            summaries["stock"] = {
+                "type": "stock", "count": stock_count,
+                "highlights": [], "key_summary": [], "market_data": [], "content": "",
+            }
+        summaries.setdefault("crypto", None)
+        summaries.setdefault("stock", None)
+        summaries.setdefault("regulatory", None)
+        summaries.setdefault("social", None)
+        summaries.setdefault("worldmonitor", None)
+        summaries.setdefault("political", None)
+        return summaries
+
+    def _base_sentiment(self, ratio=50):
+        return {
+            "tone": "중립",
+            "positive": ratio,
+            "negative": 100 - ratio,
+            "ratio": ratio,
+            "pos_examples": [],
+            "neg_examples": [],
+        }
+
+    def test_returns_list(self):
+        result = gds._build_overview_section(
+            0, {"P0": [], "P1": [], "P2": []}, [],
+            self._make_summary_map(), None, "뉴스", self._base_sentiment()
+        )
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_counts_str_in_output(self):
+        result = gds._build_overview_section(
+            50, {"P0": [], "P1": [], "P2": []}, [],
+            self._make_summary_map(crypto_count=30, stock_count=20),
+            None, "암호화폐 30건, 주식 20건", self._base_sentiment()
+        )
+        combined = "\n".join(result)
+        assert "암호화폐 30건, 주식 20건" in combined
+
+    def test_risk_level_높음_when_many_p0(self):
+        priority_items = {"P0": [{"title": f"긴급{i}"} for i in range(5)], "P1": [], "P2": []}
+        result = gds._build_overview_section(
+            10, priority_items, [],
+            self._make_summary_map(), None, "뉴스", self._base_sentiment(ratio=20)
+        )
+        combined = "\n".join(result)
+        assert "높음" in combined
+
+    def test_risk_level_안정_when_no_p0(self):
+        result = gds._build_overview_section(
+            10, {"P0": [], "P1": [], "P2": []}, [],
+            self._make_summary_map(), None, "뉴스", self._base_sentiment(ratio=60)
+        )
+        combined = "\n".join(result)
+        assert "안정" in combined
+
+    def test_theme_narrative_when_multiple_themes(self):
+        themes = [
+            {"name": "금리/유동성", "emoji": "💰", "count": 20, "keywords": ["금리", "연준"]},
+            {"name": "환율/달러", "emoji": "💱", "count": 15, "keywords": ["환율", "달러"]},
+            {"name": "정책/규제", "emoji": "📋", "count": 10, "keywords": ["sec", "etf"]},
+        ]
+        result = gds._build_overview_section(
+            100, {"P0": [], "P1": [], "P2": []}, themes,
+            self._make_summary_map(crypto_count=60, stock_count=40),
+            None, "암호화폐 60건, 주식 40건", self._base_sentiment()
+        )
+        combined = "\n".join(result)
+        assert "3가지 흐름" in combined
+
+    def test_p0_p1_signal_line_present(self):
+        priority_items = {
+            "P0": [{"title": "긴급 해킹 사고 발생"}],
+            "P1": [{"title": "ETF 승인"}],
+            "P2": [],
+        }
+        result = gds._build_overview_section(
+            10, priority_items, [],
+            self._make_summary_map(), None, "뉴스", self._base_sentiment()
+        )
+        combined = "\n".join(result)
+        assert "핵심 신호" in combined
+
+
+# ---------------------------------------------------------------------------
+# _relation_rows
+# ---------------------------------------------------------------------------
+
+class TestRelationRows:
+    def _make_summary(self, content: str) -> dict:
+        return {
+            "title": "",
+            "content": content,
+            "highlights": [],
+            "key_summary": [],
+            "themes": [],
+            "count": 1,
+        }
+
+    def test_returns_list(self):
+        result = gds._relation_rows({"crypto": None, "stock": None})
+        assert isinstance(result, list)
+
+    def test_low_score_when_no_shared_topics(self):
+        s_map = {
+            "crypto": self._make_summary("비트코인 가격 변동"),
+            "stock": self._make_summary("삼성전자 실적 발표"),
+        }
+        rows = gds._relation_rows(s_map)
+        # At least one row should exist for crypto↔stock pair
+        assert len(rows) >= 1
+
+    def test_high_score_when_many_shared_topics(self):
+        shared_content = (
+            "금리 연준 fed fomc 금리인상 "
+            "환율 달러 dxy usd/krw "
+            "규제 sec etf 법안 정책 "
+            "해킹 exploit 파산 청산 "
+            "실적 cpi pce gdp "
+        )
+        s_map = {
+            "crypto": self._make_summary(shared_content),
+            "stock": self._make_summary(shared_content),
+        }
+        rows = gds._relation_rows(s_map)
+        crypto_stock = next(
+            (r for r in rows if "암호화폐" in r[0] and "주식" in r[1]), None
+        )
+        assert crypto_stock is not None
+        assert crypto_stock[2] > 0
+
+    def test_tuple_structure(self):
+        s_map = {
+            "crypto": self._make_summary("금리 연준"),
+            "stock": self._make_summary("금리 연준"),
+        }
+        rows = gds._relation_rows(s_map)
+        for row in rows:
+            assert len(row) == 4  # (left_name, right_name, score, note)

--- a/tests/test_generate_market_summary.py
+++ b/tests/test_generate_market_summary.py
@@ -322,3 +322,674 @@ class TestStablecoinSymbols:
 
     def test_btc_not_in_set(self):
         assert "btc" not in gms.STABLECOIN_SYMBOLS
+
+
+# ---------------------------------------------------------------------------
+# format_us_market
+# ---------------------------------------------------------------------------
+
+class TestFormatUsMarket:
+    def test_empty_data_returns_fallback(self):
+        result = gms.format_us_market({})
+        assert "가져올 수 없습니다" in result
+        assert "S&P 500" in result
+
+    def test_formats_single_symbol(self):
+        data = {
+            "SPY": {
+                "name": "S&P 500 ETF",
+                "price": "500.00",
+                "change": "+5.00",
+                "change_pct": "+1.01%",
+                "volume": "100000",
+            }
+        }
+        result = gms.format_us_market(data)
+        assert "S&P 500 ETF" in result
+        assert "500.00" in result
+        assert "+1.01%" in result
+
+    def test_formats_multiple_symbols(self):
+        data = {
+            "SPY": {
+                "name": "S&P 500 ETF",
+                "price": "500.00",
+                "change": "+5.00",
+                "change_pct": "+1.01%",
+                "volume": "100000",
+            },
+            "QQQ": {
+                "name": "NASDAQ 100 ETF",
+                "price": "420.00",
+                "change": "-2.00",
+                "change_pct": "-0.47%",
+                "volume": "80000",
+            },
+        }
+        result = gms.format_us_market(data)
+        assert "S&P 500 ETF" in result
+        assert "NASDAQ 100 ETF" in result
+
+    def test_includes_volume_column(self):
+        data = {
+            "SPY": {
+                "name": "S&P 500 ETF",
+                "price": "500.00",
+                "change": "+5.00",
+                "change_pct": "+1.01%",
+                "volume": "99999",
+            }
+        }
+        result = gms.format_us_market(data)
+        assert "99999" in result
+
+    def test_volume_missing_falls_back_to_na(self):
+        # volume key absent — dict.get("volume", "N/A") should handle it
+        data = {
+            "COIN": {
+                "name": "Coinbase",
+                "price": "200.00",
+                "change": "+1.00",
+                "change_pct": "+0.50%",
+            }
+        }
+        result = gms.format_us_market(data)
+        assert "Coinbase" in result
+
+
+# ---------------------------------------------------------------------------
+# format_korean_market
+# ---------------------------------------------------------------------------
+
+class TestFormatKoreanMarket:
+    def test_empty_data_returns_fallback(self):
+        result = gms.format_korean_market({})
+        assert "가져올 수 없습니다" in result
+        assert "KOSPI" in result
+
+    def test_formats_kospi(self):
+        data = {
+            "KOSPI": {"price": "2500.00", "change": "+20.00", "change_pct": "+0.81%"}
+        }
+        result = gms.format_korean_market(data)
+        assert "KOSPI" in result
+        assert "2500.00" in result
+
+    def test_positive_change_shows_green_icon(self):
+        data = {
+            "KOSPI": {"price": "2500.00", "change": "+20.00", "change_pct": "+0.81%"}
+        }
+        result = gms.format_korean_market(data)
+        assert "🟢" in result
+
+    def test_negative_change_shows_red_icon(self):
+        data = {
+            "KOSDAQ": {"price": "800.00", "change": "-5.00", "change_pct": "-0.62%"}
+        }
+        result = gms.format_korean_market(data)
+        assert "🔴" in result
+
+    def test_invalid_change_pct_no_crash(self):
+        data = {
+            "KOSPI": {"price": "N/A", "change": "N/A", "change_pct": "N/A"}
+        }
+        result = gms.format_korean_market(data)
+        assert "KOSPI" in result
+
+    def test_formats_multiple_indices(self):
+        data = {
+            "KOSPI": {"price": "2500.00", "change": "+10.00", "change_pct": "+0.40%"},
+            "KOSDAQ": {"price": "820.00", "change": "-3.00", "change_pct": "-0.36%"},
+            "USD/KRW 환율": {"price": "1320.00", "change": "+2.00", "change_pct": "+0.15%"},
+        }
+        result = gms.format_korean_market(data)
+        assert "KOSPI" in result
+        assert "KOSDAQ" in result
+        assert "USD/KRW" in result
+
+
+# ---------------------------------------------------------------------------
+# format_macro
+# ---------------------------------------------------------------------------
+
+class TestFormatMacro:
+    def test_empty_no_api_key_explains_missing_key(self):
+        result = gms.format_macro({}, has_api_key=False)
+        assert "FRED_API_KEY" in result
+
+    def test_empty_with_api_key_suggests_validity(self):
+        result = gms.format_macro({}, has_api_key=True)
+        assert "API" in result or "유효" in result or "가져오지 못했습니다" in result
+
+    def test_formats_fed_rate_in_금리_group(self):
+        data = {
+            "FED_RATE": {"label": "연방기금금리", "value": 5.25, "date": "2024-01-01", "change": 0.0},
+        }
+        result = gms.format_macro(data)
+        assert "금리" in result
+        assert "연방기금금리" in result
+        assert "5.25%" in result
+
+    def test_formats_m2_with_billions_suffix(self):
+        data = {
+            "M2": {"label": "M2 통화공급", "value": 20800.5, "date": "2024-01-01", "change": None},
+        }
+        result = gms.format_macro(data)
+        assert "20,800.5B" in result or "20800.5B" in result
+
+    def test_t10y2y_negative_gets_red_label(self):
+        data = {
+            "T10Y2Y": {"label": "장단기 금리 스프레드", "value": -0.4, "date": "2024-01-01", "change": -0.1},
+        }
+        result = gms.format_macro(data)
+        assert "🔴" in result
+
+    def test_t10y2y_positive_no_red_label(self):
+        data = {
+            "T10Y2Y": {"label": "장단기 금리 스프레드", "value": 0.5, "date": "2024-01-01", "change": 0.1},
+        }
+        result = gms.format_macro(data)
+        # Positive spread should not show red warning on the label
+        label_line = [line for line in result.split("\n") if "장단기" in line]
+        assert all("🔴" not in line for line in label_line)
+
+    def test_change_none_shows_na(self):
+        data = {
+            "FED_RATE": {"label": "연방기금금리", "value": 5.0, "date": "2024-01-01", "change": None},
+        }
+        result = gms.format_macro(data)
+        assert "N/A" in result
+
+    def test_unemployment_in_경제지표_group(self):
+        data = {
+            "UNEMPLOYMENT": {"label": "실업률", "value": 3.9, "date": "2024-01-01", "change": 0.1},
+        }
+        result = gms.format_macro(data)
+        assert "경제 지표" in result
+        assert "실업률" in result
+
+    def test_vix_in_유동성_group(self):
+        data = {
+            "VIX": {"label": "VIX 변동성 지수", "value": 18.5, "date": "2024-01-01", "change": -1.2},
+        }
+        result = gms.format_macro(data)
+        assert "유동성" in result
+        assert "VIX" in result
+
+    def test_unknown_key_goes_to_기타_group(self):
+        data = {
+            "UNKNOWN_KEY": {"label": "미분류 지표", "value": 1.23, "date": "2024-01-01", "change": 0.01},
+        }
+        result = gms.format_macro(data)
+        assert "기타" in result or "미분류" in result
+
+    def test_multiple_groups_all_present(self):
+        data = {
+            "FED_RATE": {"label": "연방기금금리", "value": 5.25, "date": "2024-01-01", "change": 0.0},
+            "UNEMPLOYMENT": {"label": "실업률", "value": 3.9, "date": "2024-01-01", "change": 0.0},
+            "VIX": {"label": "VIX 변동성 지수", "value": 18.5, "date": "2024-01-01", "change": 0.0},
+        }
+        result = gms.format_macro(data)
+        assert "금리" in result
+        assert "경제 지표" in result
+        assert "유동성" in result
+
+
+# ---------------------------------------------------------------------------
+# format_gainers_losers
+# ---------------------------------------------------------------------------
+
+class TestFormatGainersLosers:
+    def _make_coin(self, symbol, name, price, ch24):
+        return {
+            "symbol": symbol,
+            "name": name,
+            "current_price": price,
+            "price_change_percentage_24h": ch24,
+        }
+
+    def test_empty_returns_fallback(self):
+        result = gms.format_gainers_losers([])
+        assert "데이터를 가져올 수 없습니다" in result
+
+    def test_stablecoins_excluded_from_rankings(self):
+        coins = [
+            self._make_coin("usdt", "Tether", 1.0, 0.01),
+            self._make_coin("btc", "Bitcoin", 50000, 3.5),
+            self._make_coin("eth", "Ethereum", 3000, -1.2),
+        ]
+        result = gms.format_gainers_losers(coins)
+        # USDT is a stablecoin — its name should not appear in the ranking
+        assert "Tether" not in result
+
+    def test_top_gainers_section_present(self):
+        coins = [self._make_coin(f"coin{i}", f"Coin{i}", float(i * 10), float(i)) for i in range(1, 11)]
+        result = gms.format_gainers_losers(coins)
+        assert "상승" in result
+
+    def test_top_losers_section_present(self):
+        coins = [self._make_coin(f"coin{i}", f"Coin{i}", float(i * 10), float(i - 5)) for i in range(1, 11)]
+        result = gms.format_gainers_losers(coins)
+        assert "하락" in result
+
+    def test_price_below_1_uses_6_decimal_format(self):
+        coins = [
+            self._make_coin("pepe", "Pepe", 0.000012, 15.0),
+            self._make_coin("btc", "Bitcoin", 50000, -2.0),
+        ]
+        result = gms.format_gainers_losers(coins)
+        # Sub-cent price should use 6 decimal places
+        assert "0.000012" in result
+
+    def test_gainers_sorted_descending(self):
+        coins = [
+            self._make_coin("bnb", "BNB", 300, 1.0),
+            self._make_coin("sol", "Solana", 100, 8.5),
+            self._make_coin("btc", "Bitcoin", 50000, 3.0),
+        ]
+        result = gms.format_gainers_losers(coins)
+        # Solana (+8.5%) should appear before BNB (+1.0%) in the gainers table
+        assert result.index("Solana") < result.index("BNB")
+
+
+# ---------------------------------------------------------------------------
+# format_trending (content, not just isinstance)
+# ---------------------------------------------------------------------------
+
+class TestFormatTrendingContent:
+    def test_empty_returns_no_data_message(self):
+        result = gms.format_trending([])
+        assert "트렌딩" in result or "데이터" in result
+
+    def test_shows_coin_name_and_symbol(self):
+        coins = [{"item": {"name": "Dogecoin", "symbol": "DOGE", "market_cap_rank": 10}}]
+        result = gms.format_trending(coins)
+        assert "Dogecoin" in result
+        assert "DOGE" in result
+
+    def test_shows_market_cap_rank(self):
+        coins = [{"item": {"name": "Solana", "symbol": "SOL", "market_cap_rank": 5}}]
+        result = gms.format_trending(coins)
+        assert "#5" in result
+
+    def test_max_7_coins_shown(self):
+        coins = [
+            {"item": {"name": f"Coin{i}", "symbol": f"C{i}", "market_cap_rank": i}}
+            for i in range(1, 15)
+        ]
+        result = gms.format_trending(coins)
+        # Coin8 through Coin14 should not appear (only top 7 shown)
+        assert "Coin8" not in result
+        assert "Coin7" in result
+
+    def test_rank_na_when_missing(self):
+        coins = [{"item": {"name": "Unknown", "symbol": "UNK"}}]
+        result = gms.format_trending(coins)
+        assert "N/A" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_quant_signals (content verification)
+# ---------------------------------------------------------------------------
+
+class TestGenerateQuantSignalsContent:
+    def _btc(self, ch24, ch7d):
+        return {
+            "symbol": "BTC",
+            "current_price": 50000,
+            "price_change_percentage_24h": ch24,
+            "price_change_percentage_7d_in_currency": ch7d,
+        }
+
+    def _eth(self, ch24, ch7d):
+        return {
+            "symbol": "ETH",
+            "current_price": 3000,
+            "price_change_percentage_24h": ch24,
+            "price_change_percentage_7d_in_currency": ch7d,
+        }
+
+    def test_btc_uptrend_label(self):
+        result = gms.generate_quant_signals([self._btc(2.0, 5.0)], {}, {})
+        assert "상승 추세" in result
+
+    def test_btc_downtrend_label(self):
+        result = gms.generate_quant_signals([self._btc(-3.0, -5.0)], {}, {})
+        assert "하락 추세" in result
+
+    def test_btc_mixed_trend_label(self):
+        # ch24 positive, ch7d negative → 혼조
+        result = gms.generate_quant_signals([self._btc(1.0, -2.0)], {}, {})
+        assert "혼조" in result
+
+    def test_eth_momentum_included(self):
+        result = gms.generate_quant_signals([self._btc(1.0, 1.0), self._eth(0.5, -1.0)], {}, {})
+        assert "ETH" in result
+
+    def test_risk_on_regime_when_mcap_up_btc_dom_low(self):
+        global_data = {
+            "market_cap_change_percentage_24h_usd": 3.0,
+            "market_cap_percentage": {"btc": 45.0},
+        }
+        result = gms.generate_quant_signals([], global_data, {})
+        assert "리스크온" in result
+
+    def test_risk_off_regime_when_mcap_down_btc_dom_high(self):
+        global_data = {
+            "market_cap_change_percentage_24h_usd": -3.0,
+            "market_cap_percentage": {"btc": 55.0},
+        }
+        result = gms.generate_quant_signals([], global_data, {})
+        assert "리스크오프" in result
+
+    def test_neutral_regime_when_changes_small(self):
+        global_data = {
+            "market_cap_change_percentage_24h_usd": 0.5,
+            "market_cap_percentage": {"btc": 50.0},
+        }
+        result = gms.generate_quant_signals([], global_data, {})
+        assert "중립" in result
+
+    def test_fear_greed_line_included(self):
+        result = gms.generate_quant_signals([], {}, {"value": 22, "classification": "Extreme Fear"})
+        assert "Extreme Fear" in result
+        assert "22" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_key_highlights
+# ---------------------------------------------------------------------------
+
+class TestGenerateKeyHighlights:
+    def _btc_coin(self, price, ch24, ch7d):
+        return {
+            "symbol": "btc",
+            "name": "Bitcoin",
+            "current_price": price,
+            "price_change_percentage_24h": ch24,
+            "price_change_percentage_7d_in_currency": ch7d,
+        }
+
+    def test_empty_all_returns_empty_string(self):
+        result = gms.generate_key_highlights({}, [], {}, {})
+        assert result == ""
+
+    def test_extreme_fear_bullet_present(self):
+        fg = {"value": 12, "classification": "Extreme Fear"}
+        result = gms.generate_key_highlights({}, [], fg, {})
+        assert "극도의 공포" in result
+
+    def test_fear_bullet_present(self):
+        fg = {"value": 28, "classification": "Fear"}
+        result = gms.generate_key_highlights({}, [], fg, {})
+        assert "공포 장세" in result
+
+    def test_greed_bullet_present(self):
+        fg = {"value": 72, "classification": "Greed"}
+        result = gms.generate_key_highlights({}, [], fg, {})
+        assert "탐욕 장세" in result
+
+    def test_extreme_greed_bullet_present(self):
+        fg = {"value": 88, "classification": "Extreme Greed"}
+        result = gms.generate_key_highlights({}, [], fg, {})
+        assert "탐욕 장세" in result
+
+    def test_btc_price_bullet_present(self):
+        coins = [self._btc_coin(60000, 2.5, 5.0)]
+        result = gms.generate_key_highlights({}, coins, {}, {})
+        assert "비트코인" in result
+        assert "60,000" in result
+
+    def test_btc_price_shows_하락_when_negative(self):
+        coins = [self._btc_coin(40000, -3.0, -7.0)]
+        result = gms.generate_key_highlights({}, coins, {}, {})
+        assert "하락" in result
+
+    def test_global_market_cap_bullet(self):
+        global_data = {
+            "total_market_cap": {"usd": 2_500_000_000_000},
+            "market_cap_change_percentage_24h_usd": 1.8,
+            "market_cap_percentage": {"btc": 52.0},
+        }
+        result = gms.generate_key_highlights(global_data, [], {}, {})
+        assert "시가총액" in result
+
+    def test_btc_dominance_over_50_shows_지속(self):
+        global_data = {
+            "total_market_cap": {"usd": 2_000_000_000_000},
+            "market_cap_change_percentage_24h_usd": 0.5,
+            "market_cap_percentage": {"btc": 55.0},
+        }
+        result = gms.generate_key_highlights(global_data, [], {}, {})
+        assert "지속" in result
+
+    def test_btc_dominance_under_50_shows_약화(self):
+        global_data = {
+            "total_market_cap": {"usd": 2_000_000_000_000},
+            "market_cap_change_percentage_24h_usd": 0.5,
+            "market_cap_percentage": {"btc": 44.0},
+        }
+        result = gms.generate_key_highlights(global_data, [], {}, {})
+        assert "약화" in result
+
+    def test_korean_market_bullet_present(self):
+        kr_market = {
+            "KOSPI": {"price": "2500.00", "change": "+10.00", "change_pct": "+0.40%"}
+        }
+        result = gms.generate_key_highlights({}, [], {}, kr_market)
+        assert "KOSPI" in result
+
+    def test_commodity_gold_bullet_present(self):
+        commodity = {
+            "금 (Gold)": {"price": "1950.00", "change": "+10.00", "change_pct": "+0.52%"}
+        }
+        result = gms.generate_key_highlights({}, [], {}, {}, commodity_data=commodity)
+        assert "금" in result
+
+    def test_commodity_oil_bullet_present(self):
+        commodity = {
+            "원유 (WTI)": {"price": "78.00", "change": "-0.50", "change_pct": "-0.64%"}
+        }
+        result = gms.generate_key_highlights({}, [], {}, {}, commodity_data=commodity)
+        assert "원유" in result
+
+    def test_top_mover_bullet_only_when_both_gainers_and_losers(self):
+        # All positive — no losers, so mover bullet should not appear
+        coins = [
+            {"symbol": "bnb", "name": "BNB", "current_price": 300, "price_change_percentage_24h": 1.0},
+            {"symbol": "sol", "name": "Solana", "current_price": 100, "price_change_percentage_24h": 2.0},
+        ]
+        result = gms.generate_key_highlights({}, coins, {}, {})
+        assert "주목할 코인" not in result
+
+    def test_top_mover_bullet_with_mixed_changes(self):
+        coins = [
+            {"symbol": "sol", "name": "Solana", "current_price": 100, "price_change_percentage_24h": 8.0},
+            {"symbol": "link", "name": "Chainlink", "current_price": 15, "price_change_percentage_24h": -4.0},
+        ]
+        result = gms.generate_key_highlights({}, coins, {}, {})
+        assert "주목할 코인" in result
+        assert "Solana" in result
+        assert "Chainlink" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_insight
+# ---------------------------------------------------------------------------
+
+class TestGenerateInsight:
+    def _global(self, mcap_change, btc_dom):
+        return {
+            "market_cap_change_percentage_24h_usd": mcap_change,
+            "market_cap_percentage": {"btc": btc_dom},
+        }
+
+    def test_strong_rise_message_when_mcap_over_5(self):
+        result = gms.generate_insight(self._global(6.0, 50), [], {}, {}, {})
+        assert "강한 상승세" in result
+
+    def test_moderate_rise_when_mcap_1_to_5(self):
+        result = gms.generate_insight(self._global(2.0, 50), [], {}, {}, {})
+        assert "소폭 상승세" in result
+
+    def test_sideways_when_mcap_near_zero(self):
+        result = gms.generate_insight(self._global(0.0, 50), [], {}, {}, {})
+        assert "보합세" in result
+
+    def test_decline_when_mcap_minus1_to_minus5(self):
+        result = gms.generate_insight(self._global(-2.0, 50), [], {}, {}, {})
+        assert "하락세" in result
+
+    def test_sharp_decline_when_mcap_under_minus5(self):
+        result = gms.generate_insight(self._global(-6.0, 50), [], {}, {}, {})
+        assert "급격한 하락세" in result
+
+    def test_high_btc_dom_warns_altcoin_caution(self):
+        result = gms.generate_insight(self._global(0.0, 60), [], {}, {}, {})
+        assert "알트코인" in result or "비트코인 중심" in result
+
+    def test_low_btc_dom_suggests_alt_season(self):
+        result = gms.generate_insight(self._global(0.0, 40), [], {}, {}, {})
+        assert "알트 시즌" in result
+
+    def test_extreme_fear_insight_included(self):
+        fg = {"value": 10, "classification": "Extreme Fear"}
+        result = gms.generate_insight(self._global(0.0, 50), [], fg, {}, {})
+        assert "Extreme Fear" in result or "극도의 공포" in result
+
+    def test_neutral_fear_greed_included(self):
+        fg = {"value": 50, "classification": "Neutral"}
+        result = gms.generate_insight(self._global(0.0, 50), [], fg, {}, {})
+        assert "중립" in result
+
+    def test_top_coin_movers_included(self):
+        coins = [
+            {"symbol": "btc", "name": "Bitcoin", "current_price": 50000, "price_change_percentage_24h": 4.0},
+            {"symbol": "eth", "name": "Ethereum", "current_price": 3000, "price_change_percentage_24h": -2.0},
+        ]
+        result = gms.generate_insight(self._global(1.0, 50), coins, {}, {}, {})
+        assert "Bitcoin" in result or "Ethereum" in result
+
+    def test_spy_change_included_when_us_market_present(self):
+        us_market = {
+            "SPY": {
+                "name": "S&P 500 ETF",
+                "price": "500.00",
+                "change": "+5.00",
+                "change_pct": "+1.01%",
+                "volume": "100000",
+            }
+        }
+        result = gms.generate_insight(self._global(0.0, 50), [], {}, us_market, {})
+        assert "S&P 500" in result
+        assert "+1.01%" in result
+
+    def test_large_spy_move_triggers_additional_commentary(self):
+        us_market = {
+            "SPY": {
+                "name": "S&P 500 ETF",
+                "price": "500.00",
+                "change": "+15.00",
+                "change_pct": "+3.05%",
+                "volume": "100000",
+            }
+        }
+        result = gms.generate_insight(self._global(0.0, 50), [], {}, us_market, {})
+        assert "글로벌" in result or "대폭 변동" in result
+
+    def test_kospi_included_when_kr_market_present(self):
+        kr_market = {
+            "KOSPI": {"price": "2500.00", "change": "+10.00", "change_pct": "+0.40%"}
+        }
+        result = gms.generate_insight(self._global(0.0, 50), [], {}, {}, kr_market)
+        assert "KOSPI" in result
+
+    def test_usdkrw_included_when_present(self):
+        kr_market = {
+            "USD/KRW 환율": {"price": "1320.00", "change": "+2.00", "change_pct": "+0.15%"}
+        }
+        result = gms.generate_insight(self._global(0.0, 50), [], {}, {}, kr_market)
+        assert "1320.00" in result or "환율" in result
+
+    def test_disclaimer_always_present(self):
+        result = gms.generate_insight({}, [], {}, {}, {})
+        assert "투자 조언이 아닙니다" in result
+
+    def test_empty_all_inputs_still_returns_disclaimer(self):
+        result = gms.generate_insight({}, [], {}, {}, {})
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# format_top_coins (additional coverage)
+# ---------------------------------------------------------------------------
+
+class TestFormatTopCoinsExtra:
+    def _coin(self, symbol, name, price, ch24=0.0, ch7d=0.0, mcap=1_000_000_000):
+        return {
+            "symbol": symbol,
+            "name": name,
+            "current_price": price,
+            "price_change_percentage_24h": ch24,
+            "price_change_percentage_7d_in_currency": ch7d,
+            "market_cap": mcap,
+        }
+
+    def test_low_price_uses_6_decimal_format(self):
+        coins = [self._coin("shib", "Shiba Inu", 0.000008, ch24=1.5)]
+        result = gms.format_top_coins(coins)
+        assert "0.000008" in result
+
+    def test_high_price_uses_2_decimal_format(self):
+        coins = [self._coin("btc", "Bitcoin", 65000.50, ch24=2.0)]
+        result = gms.format_top_coins(coins)
+        assert "65,000.50" in result
+
+    def test_none_price_treated_as_zero(self):
+        # current_price=None should not crash (falls back to 0)
+        coins = [self._coin("xyz", "XYZ", None, ch24=None)]
+        result = gms.format_top_coins(coins)
+        assert "XYZ" in result
+
+    def test_only_first_20_coins_shown(self):
+        coins = [self._coin(f"c{i}", f"Coin{i}", float(i * 100)) for i in range(1, 26)]
+        result = gms.format_top_coins(coins)
+        assert "Coin20" in result
+        assert "Coin21" not in result
+
+    def test_symbol_uppercased(self):
+        coins = [self._coin("eth", "Ethereum", 3000)]
+        result = gms.format_top_coins(coins)
+        assert "ETH" in result
+
+
+# ---------------------------------------------------------------------------
+# calculate_yield_spread (edge cases)
+# ---------------------------------------------------------------------------
+
+class TestCalculateYieldSpreadEdgeCases:
+    def test_only_10y_yield_no_2y_returns_empty(self):
+        # Manual fallback requires both yields; only one present → empty dict
+        fred_data = {"10Y_YIELD": {"value": 4.5, "date": "2024-01-01"}}
+        result = gms.calculate_yield_spread(fred_data)
+        assert result == {}
+
+    def test_t10y2y_value_none_falls_through_to_manual(self):
+        # T10Y2Y present but value is None → manual calculation used
+        fred_data = {
+            "T10Y2Y": {"value": None, "date": "2024-01-01"},
+            "10Y_YIELD": {"value": 4.2, "date": "2024-01-01"},
+            "2Y_YIELD": {"value": 4.0},
+        }
+        result = gms.calculate_yield_spread(fred_data)
+        assert abs(result["spread"] - 0.2) < 0.001
+
+    def test_manual_inverted_spread(self):
+        fred_data = {
+            "10Y_YIELD": {"value": 3.8, "date": "2024-01-01"},
+            "2Y_YIELD": {"value": 4.5},
+        }
+        result = gms.calculate_yield_spread(fred_data)
+        assert result["inverted"] is True
+        assert result["spread"] < 0


### PR DESCRIPTION
## Summary
- `generate_daily_summary.py` 커버리지 17% → 44% (+92개 테스트)
- `generate_market_summary.py` 커버리지 28% → 55% (+80개 테스트)
- 순수 로직 함수 위주 테스트: sentiment, formatters, signal generation 등

## Test plan
- [x] 270개 테스트 전부 pass 확인
- [x] ruff check 통과