### PR TITLE
test: 생성기 커버리지 2차 개선 (daily 71%, market 76%)

### DIFF
--- a/tests/test_generate_daily_summary.py
+++ b/tests/test_generate_daily_summary.py
@@ -1194,3 +1194,775 @@ class TestRelationRows:
         rows = gds._relation_rows(s_map)
         for row in rows:
             assert len(row) == 4  # (left_name, right_name, score, note)
+
+
+# ---------------------------------------------------------------------------
+# _load_today_posts
+# ---------------------------------------------------------------------------
+
+class TestLoadTodayPosts:
+    """Tests for _load_today_posts using tmp_path stubs instead of real _posts/."""
+
+    def _write_post(self, directory, filename: str, content: str):
+        p = directory / filename
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_returns_empty_when_no_posts(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        result = gds._load_today_posts("2099-01-01")
+        summary_map, post_links, security_summary, all_summaries = result
+        assert summary_map == {}
+        assert post_links == []
+        assert security_summary is None
+        assert all_summaries == []
+
+    def test_loads_crypto_post(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-01"
+        self._write_post(
+            tmp_path,
+            f"{today}-crypto-news-digest.md",
+            "---\ntitle: 암호화폐 뉴스\ncategory: crypto\n---\n"
+            "## 핵심 요약\n- BTC 급등\n오늘 10건의 뉴스가 수집되었습니다.",
+        )
+        summary_map, post_links, _, all_summaries = gds._load_today_posts(today)
+        assert summary_map.get("crypto") is not None
+        assert summary_map["crypto"]["type"] == "crypto"
+        assert summary_map["crypto"]["count"] == 10
+        assert any("암호화폐" in name for name, _, _ in post_links)
+
+    def test_loads_stock_post(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-02"
+        self._write_post(
+            tmp_path,
+            f"{today}-stock-news-digest.md",
+            "---\ntitle: 주식 뉴스\n---\n"
+            "KOSPI 2500 상승.\n총 수집 건수: 5건",
+        )
+        summary_map, post_links, _, _ = gds._load_today_posts(today)
+        assert summary_map.get("stock") is not None
+        assert any("주식" in name for name, _, _ in post_links)
+
+    def test_loads_security_post(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-03"
+        self._write_post(
+            tmp_path,
+            f"{today}-security-report.md",
+            "---\ntitle: 보안 리포트\n---\n"
+            "## 보안 사고 현황\n| H1 | H2 | H3 |\n|---|---|---|\n| A | B | C |\n"
+            "오늘 3건의 뉴스가 수집되었습니다.",
+        )
+        summary_map, post_links, security_summary, _ = gds._load_today_posts(today)
+        assert security_summary is not None
+        assert security_summary["type"] == "security"
+        assert any("보안" in name for name, _, _ in post_links)
+
+    def test_loads_regulatory_post(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-04"
+        self._write_post(
+            tmp_path,
+            f"{today}-regulatory-report.md",
+            "---\ntitle: 규제 동향\n---\n"
+            "## 핵심 요약\n- SEC 조사\n오늘 7건의 뉴스가 수집되었습니다.",
+        )
+        summary_map, _, _, _ = gds._load_today_posts(today)
+        assert summary_map.get("regulatory") is not None
+        assert summary_map["regulatory"]["type"] == "regulatory"
+
+    def test_loads_social_post(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-05"
+        self._write_post(
+            tmp_path,
+            f"{today}-social-media-digest.md",
+            "---\ntitle: 소셜 미디어\n---\n"
+            "## 핵심 요약\n- BTC 트위터 급증\n총 8건을 수집했습니다.",
+        )
+        summary_map, _, _, _ = gds._load_today_posts(today)
+        assert summary_map.get("social") is not None
+        assert summary_map["social"]["type"] == "social"
+
+    def test_loads_political_post(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-06"
+        self._write_post(
+            tmp_path,
+            f"{today}-political-trades-report.md",
+            "---\ntitle: 정치인 거래\n---\n"
+            "## 핵심 요약\n- 펠로시 매수\n오늘 4건의 뉴스가 수집되었습니다.",
+        )
+        summary_map, _, _, _ = gds._load_today_posts(today)
+        assert summary_map.get("political") is not None
+        assert summary_map["political"]["type"] == "political"
+
+    def test_loads_worldmonitor_post(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-07"
+        self._write_post(
+            tmp_path,
+            f"{today}-worldmonitor-briefing.md",
+            "---\ntitle: 월드모니터 브리핑\n---\n"
+            "## 핵심 요약\n- 글로벌 이슈\n수집 건수: **20건**",
+        )
+        summary_map, post_links, _, _ = gds._load_today_posts(today)
+        assert summary_map.get("worldmonitor") is not None
+        assert any("월드모니터" in name for name, _, _ in post_links)
+
+    def test_skips_daily_news_summary_post(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-08"
+        self._write_post(
+            tmp_path,
+            f"{today}-daily-news-summary.md",
+            "---\ntitle: 일일 요약\n---\n이미 생성된 요약입니다.",
+        )
+        summary_map, post_links, _, all_summaries = gds._load_today_posts(today)
+        # daily-news-summary should be ignored — nothing should be loaded
+        assert all(v is None for v in summary_map.values())
+        assert post_links == []
+
+    def test_all_summaries_flat_list(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-02-09"
+        self._write_post(
+            tmp_path,
+            f"{today}-crypto-news-digest.md",
+            "---\ntitle: 암호화폐 뉴스\n---\n오늘 10건의 뉴스가 수집되었습니다.",
+        )
+        _, _, _, all_summaries = gds._load_today_posts(today)
+        # all_summaries should be a flat list (may contain None for absent categories)
+        assert isinstance(all_summaries, list)
+        assert len(all_summaries) == 7  # always 7 slots
+
+
+# ---------------------------------------------------------------------------
+# _write_summary_post
+# ---------------------------------------------------------------------------
+
+class TestWriteSummaryPost:
+    """Tests for _write_summary_post using tmp_path."""
+
+    def test_creates_file_with_correct_name(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-03-01"
+        filepath = gds._write_summary_post(today, "본문 내용입니다.", 42, "암호화폐 42건", None)
+        assert os.path.exists(filepath)
+        assert f"{today}-daily-news-summary.md" in filepath
+
+    def test_file_contains_frontmatter(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-03-02"
+        gds._write_summary_post(today, "본문.", 10, "뉴스 10건", None)
+        content = (tmp_path / f"{today}-daily-news-summary.md").read_text(encoding="utf-8")
+        assert "layout: post" in content
+        assert f'title: "일일 뉴스 종합 요약 - {today}"' in content
+        assert "categories: [market-analysis]" in content
+
+    def test_file_contains_body_content(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-03-03"
+        body = "## 오늘의 핵심\n- 비트코인 급등"
+        gds._write_summary_post(today, body, 5, "뉴스 5건", None)
+        content = (tmp_path / f"{today}-daily-news-summary.md").read_text(encoding="utf-8")
+        assert "## 오늘의 핵심" in content
+        assert "비트코인 급등" in content
+
+    def test_description_contains_counts_str(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-03-04"
+        counts_str = "암호화폐 30건, 주식 20건"
+        gds._write_summary_post(today, "본문.", 50, counts_str, None)
+        content = (tmp_path / f"{today}-daily-news-summary.md").read_text(encoding="utf-8")
+        assert counts_str in content
+
+    def test_returns_filepath_string(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        result = gds._write_summary_post("2099-03-05", "내용.", 0, "뉴스", None)
+        assert isinstance(result, str)
+        assert result.endswith(".md")
+
+    def test_lang_ko_in_frontmatter(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-03-06"
+        gds._write_summary_post(today, "내용.", 1, "뉴스 1건", None)
+        content = (tmp_path / f"{today}-daily-news-summary.md").read_text(encoding="utf-8")
+        assert 'lang: "ko"' in content
+
+    def test_source_consolidated_in_frontmatter(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-03-07"
+        gds._write_summary_post(today, "내용.", 1, "뉴스 1건", None)
+        content = (tmp_path / f"{today}-daily-news-summary.md").read_text(encoding="utf-8")
+        assert 'source: "consolidated"' in content
+
+    def test_image_line_absent_when_no_briefing_image(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gds, "POSTS_DIR", str(tmp_path))
+        today = "2099-03-08"
+        gds._write_summary_post(today, "내용.", 0, "뉴스", None)
+        content = (tmp_path / f"{today}-daily-news-summary.md").read_text(encoding="utf-8")
+        assert "\nimage:" not in content
+
+
+# ---------------------------------------------------------------------------
+# _build_briefing_section
+# ---------------------------------------------------------------------------
+
+class TestBuildBriefingSection:
+    """Tests for _build_briefing_section with mocked ThemeSummarizer."""
+
+    def _make_sentiment(self, ratio=50):
+        return {
+            "tone": "중립",
+            "positive": ratio,
+            "negative": 100 - ratio,
+            "ratio": ratio,
+            "pos_examples": [],
+            "neg_examples": [],
+        }
+
+    def _make_crypto_summary(self, count=10, highlights=None):
+        return {
+            "type": "crypto",
+            "title": "암호화폐 뉴스",
+            "count": count,
+            "highlights": highlights or ["- BTC 상승"],
+            "key_summary": highlights or ["- BTC 상승"],
+            "content": "BTC 상승 소식이 있습니다.",
+            "themes": [("금리/유동성", 5)],
+            "url": "https://example.com/crypto",
+        }
+
+    def _make_summary_map(self, crypto_summary=None):
+        return {
+            "crypto": crypto_summary,
+            "stock": None,
+            "regulatory": None,
+            "social": None,
+            "worldmonitor": None,
+            "political": None,
+        }
+
+    def _make_mock_summarizer(self, concentration=None, anomalies=None):
+        from unittest.mock import MagicMock
+        mock = MagicMock()
+        mock.detect_concentration.return_value = concentration
+        mock.detect_anomalies.return_value = anomalies or []
+        return mock
+
+    def test_returns_list_of_strings(self):
+        mock_summ = self._make_mock_summarizer()
+        result = gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=[],
+            summary_map=self._make_summary_map(),
+            theme_payload=[],
+            sentiment=self._make_sentiment(),
+            today="2099-04-01",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        assert isinstance(result, list)
+        assert all(isinstance(line, str) for line in result)
+
+    def test_includes_dashboard_heading(self):
+        mock_summ = self._make_mock_summarizer()
+        result = gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=[],
+            summary_map=self._make_summary_map(),
+            theme_payload=[],
+            sentiment=self._make_sentiment(),
+            today="2099-04-02",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "종합 대시보드" in combined
+
+    def test_includes_briefing_heading(self):
+        mock_summ = self._make_mock_summarizer()
+        result = gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=[],
+            summary_map=self._make_summary_map(),
+            theme_payload=[],
+            sentiment=self._make_sentiment(),
+            today="2099-04-03",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "핵심 브리핑" in combined
+
+    def test_concentration_warning_when_detect_concentration_returns_value(self):
+        mock_summ = self._make_mock_summarizer(concentration=("금리/유동성", "interest", 0.45))
+        news_items = [{"title": "금리 뉴스", "link": "https://ex.com", "type": "crypto"}]
+        result = gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=news_items,
+            summary_map=self._make_summary_map(),
+            theme_payload=[],
+            sentiment=self._make_sentiment(),
+            today="2099-04-04",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "집중도 경고" in combined
+        assert "45%" in combined
+
+    def test_anomaly_line_when_detect_anomalies_returns_value(self):
+        anomalies = [("리스크 이벤트", "risk", 8, "이상 급등 패턴이 감지되었습니다.")]
+        mock_summ = self._make_mock_summarizer(anomalies=anomalies)
+        news_items = [{"title": "리스크 뉴스", "link": "https://ex.com", "type": "crypto"}]
+        result = gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=news_items,
+            summary_map=self._make_summary_map(),
+            theme_payload=[],
+            sentiment=self._make_sentiment(),
+            today="2099-04-05",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "이상 탐지" in combined
+        assert "이상 급등 패턴" in combined
+
+    def test_sentiment_line_present(self):
+        mock_summ = self._make_mock_summarizer()
+        sentiment = self._make_sentiment(ratio=70)
+        result = gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=[],
+            summary_map=self._make_summary_map(),
+            theme_payload=[],
+            sentiment=sentiment,
+            today="2099-04-06",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "시장 심리" in combined
+        assert "70%" in combined
+
+    def test_pos_neg_examples_rendered_when_present(self):
+        mock_summ = self._make_mock_summarizer()
+        sentiment = {
+            "tone": "긍정 우세",
+            "positive": 7,
+            "negative": 3,
+            "ratio": 70,
+            "pos_examples": ["BTC 급등"],
+            "neg_examples": ["ETH 하락"],
+        }
+        result = gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=[],
+            summary_map=self._make_summary_map(),
+            theme_payload=[],
+            sentiment=sentiment,
+            today="2099-04-07",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "긍정 신호" in combined
+        assert "주의 신호" in combined
+
+    def test_category_briefing_line_for_crypto(self):
+        mock_summ = self._make_mock_summarizer()
+        crypto = self._make_crypto_summary(count=15)
+        result = gds._build_briefing_section(
+            all_summaries=[crypto],
+            all_news_items=[],
+            summary_map=self._make_summary_map(crypto_summary=crypto),
+            theme_payload=[],
+            sentiment=self._make_sentiment(),
+            today="2099-04-08",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "암호화폐" in combined
+        assert "15건" in combined
+
+    def test_detect_concentration_not_called_when_no_news_items(self):
+        mock_summ = self._make_mock_summarizer()
+        gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=[],
+            summary_map=self._make_summary_map(),
+            theme_payload=[],
+            sentiment=self._make_sentiment(),
+            today="2099-04-09",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        mock_summ.detect_concentration.assert_not_called()
+
+    def test_cross_topics_shown_when_multiple_summaries(self):
+        mock_summ = self._make_mock_summarizer()
+        crypto = {
+            "type": "crypto",
+            "title": "암호화폐",
+            "count": 10,
+            "highlights": [],
+            "key_summary": [],
+            "content": "금리 연준 fed fomc 금리인상",
+            "themes": [],
+            "url": "#",
+        }
+        stock = {
+            "type": "stock",
+            "title": "주식",
+            "count": 10,
+            "highlights": [],
+            "key_summary": [],
+            "content": "금리 연준 fed fomc 금리인상",
+            "themes": [],
+            "url": "#",
+        }
+        result = gds._build_briefing_section(
+            all_summaries=[crypto, stock],
+            all_news_items=[],
+            summary_map={"crypto": crypto, "stock": stock, "regulatory": None, "social": None, "worldmonitor": None, "political": None},
+            theme_payload=[],
+            sentiment=self._make_sentiment(),
+            today="2099-04-10",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "교차 테마" in combined
+
+    def test_theme_snapshot_table_rendered_with_theme_payload(self):
+        mock_summ = self._make_mock_summarizer()
+        theme_payload = [
+            {"name": "금리/유동성", "emoji": "💰", "count": 25, "keywords": ["금리", "연준"]},
+            {"name": "정책/규제", "emoji": "📋", "count": 10, "keywords": ["sec", "etf"]},
+        ]
+        result = gds._build_briefing_section(
+            all_summaries=[],
+            all_news_items=[],
+            summary_map=self._make_summary_map(),
+            theme_payload=theme_payload,
+            sentiment=self._make_sentiment(),
+            today="2099-04-11",
+            briefing_image=None,
+            priority_items={"P0": [], "P1": [], "P2": []},
+            summarizer=mock_summ,
+        )
+        combined = "\n".join(result)
+        assert "테마 스냅샷" in combined
+        assert "금리/유동성" in combined
+
+
+# ---------------------------------------------------------------------------
+# _build_priority_and_category_sections
+# ---------------------------------------------------------------------------
+
+class TestBuildPriorityAndCategorySections:
+    """Tests for _build_priority_and_category_sections."""
+
+    def _make_summary_map(
+        self,
+        crypto=None,
+        stock=None,
+        regulatory=None,
+        social=None,
+        worldmonitor=None,
+        political=None,
+    ):
+        return {
+            "crypto": crypto,
+            "stock": stock,
+            "regulatory": regulatory,
+            "social": social,
+            "worldmonitor": worldmonitor,
+            "political": political,
+        }
+
+    def _crypto(self, count=10):
+        return {
+            "type": "crypto",
+            "count": count,
+            "highlights": ["- BTC 상승"],
+            "key_summary": [],
+            "content": "BTC 상승. [Bitcoin ETF approval confirmed today](https://ex.com)",
+            "themes": [("금리/유동성", 5)],
+            "url": "https://example.com/crypto",
+        }
+
+    def _stock(self, count=5):
+        return {
+            "type": "stock",
+            "count": count,
+            "highlights": ["- KOSPI 상승"],
+            "key_summary": [],
+            "market_data": ["KOSPI 2500 상승"],
+            "content": "KOSPI 2500 상승.",
+            "themes": [],
+            "url": "https://example.com/stock",
+        }
+
+    def _political(self, count=3):
+        return {
+            "type": "political",
+            "count": count,
+            "highlights": ["- 펠로시 매수"],
+            "key_summary": ["- 주요 거래 정보"],
+            "content": "펠로시 매수.",
+            "themes": [],
+            "url": "https://example.com/political",
+        }
+
+    def _security(self, count=2):
+        return {
+            "type": "security",
+            "count": count,
+            "highlights": [],
+            "key_summary": [],
+            "incidents": ["| DeFi | $1M | 해킹 |"],
+            "content": "보안 사고 발생.",
+            "themes": [],
+            "url": "https://example.com/security",
+        }
+
+    def test_returns_list_of_strings(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        assert isinstance(result, list)
+        assert all(isinstance(line, str) for line in result)
+
+    def test_p0_section_rendered_when_p0_items_present(self):
+        p0_item = {
+            "title": "비트코인 거래소 해킹 사고 발생 긴급",
+            "description": "대형 거래소 해킹으로 수억 달러 피해 발생",
+            "link": "https://example.com/hack",
+            "type": "crypto",
+        }
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [p0_item], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "긴급 알림" in combined
+
+    def test_p1_section_rendered_when_p1_items_present(self):
+        p1_item = {
+            "title": "비트코인 ETF 최종 승인 결정 발표",
+            "description": "SEC가 비트코인 현물 ETF를 승인했습니다.",
+            "link": "https://example.com/etf",
+            "type": "crypto",
+        }
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [p1_item], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "중요 뉴스" in combined
+
+    def test_p2_section_rendered_when_p2_items_present(self):
+        p2_item = {
+            "title": "이더리움 개발자 컨퍼런스 개최 예정 안내",
+            "link": "https://example.com/eth",
+            "type": "crypto",
+        }
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": [p2_item]},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "주목할 소식" in combined
+
+    def test_category_summary_section_always_present(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "카테고리별 요약" in combined
+
+    def test_crypto_section_shows_count_and_link(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(crypto=self._crypto(count=12)),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "암호화폐 뉴스" in combined
+        assert "12건" in combined
+        assert "상세 보기" in combined
+
+    def test_stock_section_shows_market_data(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(stock=self._stock(count=8)),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "주식 시장 뉴스" in combined
+        assert "KOSPI" in combined
+
+    def test_political_watch_section_shown_when_political_summary_present(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(political=self._political()),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "정치인 워치" in combined
+
+    def test_security_section_shown_when_security_summary_present(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=self._security(),
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "보안 리포트" in combined
+
+    def test_report_links_section_always_present(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[("암호화폐 뉴스", 10, "https://example.com/crypto")],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "상세 리포트 링크" in combined
+
+    def test_post_links_rendered_in_report_section(self):
+        post_links = [
+            ("암호화폐 뉴스", 10, "https://example.com/crypto"),
+            ("주식 시장 뉴스", 5, "https://example.com/stock"),
+        ]
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=post_links,
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "암호화폐 뉴스" in combined or "🪙" in combined
+
+    def test_disclaimer_line_present(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "투자 조언" in combined
+
+    def test_market_overview_section_shown_when_market_summary_present(self):
+        market_summary = {
+            "type": "market",
+            "count": 5,
+            "highlights": ["- 코스피 +1.5%"],
+            "exec_summary": [],
+            "indicator_rows": [],
+            "yield_section": "",
+            "content": "코스피 상승.",
+            "url": "https://example.com/market",
+        }
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=market_summary,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "시장 개요" in combined
+        assert "코스피" in combined
+
+    def test_cross_asset_section_present_when_multiple_summaries(self):
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(
+                crypto=self._crypto(), stock=self._stock()
+            ),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "교차자산 연관성" in combined
+
+    def test_p0_noise_title_filtered_out(self):
+        p0_noise = {"title": "가격 알림: BTC/USDT", "link": "https://ex.com", "type": "crypto"}
+        p0_real = {
+            "title": "비트코인 거래소 해킹 사고 발생 긴급",
+            "description": "긴급 사고 발생",
+            "link": "https://ex.com/real",
+            "type": "crypto",
+        }
+        result = gds._build_priority_and_category_sections(
+            priority_items={"P0": [p0_noise, p0_real], "P1": [], "P2": []},
+            market_summary=None,
+            security_summary=None,
+            summary_map=self._make_summary_map(),
+            post_links=[],
+            all_news_items=[],
+        )
+        combined = "\n".join(result)
+        assert "가격 알림" not in combined

--- a/tests/test_generate_market_summary.py
+++ b/tests/test_generate_market_summary.py
@@ -993,3 +993,700 @@ class TestCalculateYieldSpreadEdgeCases:
         result = gms.calculate_yield_spread(fred_data)
         assert result["inverted"] is True
         assert result["spread"] < 0
+
+
+# ---------------------------------------------------------------------------
+# fetch_us_market_data — Alpha Vantage path (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+class TestFetchUsMarketDataAlphaVantage:
+    """Tests for the Alpha Vantage branch of fetch_us_market_data."""
+
+    def _av_response(self, symbol, price, change, change_pct, volume):
+        return {
+            "Global Quote": {
+                "01. symbol": symbol,
+                "05. price": price,
+                "06. volume": volume,
+                "09. change": change,
+                "10. change percent": change_pct,
+            }
+        }
+
+    def test_parses_spy_quote_from_alpha_vantage(self, monkeypatch):
+        import requests as _requests
+
+        mock_resp = type("R", (), {
+            "raise_for_status": lambda self: None,
+            "json": lambda self: self._data,
+            "_data": self._av_response("SPY", "500.00", "+5.00", "+1.01%", "50000000"),
+        })()
+
+        monkeypatch.setattr(_requests, "get", lambda *a, **kw: mock_resp)
+
+        # Also stub yfinance so the fallback/crypto branch doesn't try the network
+        import sys
+        yf_stub = type("yf", (), {
+            "Ticker": lambda sym: type("T", (), {
+                "fast_info": type("FI", (), {"last_price": None, "previous_close": None})()
+            })()
+        })()
+        monkeypatch.setitem(sys.modules, "yfinance", yf_stub)
+
+        result = gms.fetch_us_market_data("FAKE_KEY")
+        assert "SPY" in result
+        assert result["SPY"]["price"] == "500.00"
+        assert result["SPY"]["change"] == "+5.00"
+        assert result["SPY"]["volume"] == "50000000"
+
+    def test_missing_price_field_skips_symbol(self, monkeypatch):
+        import requests as _requests
+
+        # Global Quote present but no '05. price'
+        mock_resp = type("R", (), {
+            "raise_for_status": lambda self: None,
+            "json": lambda self: {"Global Quote": {}},
+        })()
+        monkeypatch.setattr(_requests, "get", lambda *a, **kw: mock_resp)
+
+        import sys
+        yf_stub = type("yf", (), {
+            "Ticker": lambda sym: type("T", (), {
+                "fast_info": type("FI", (), {"last_price": None, "previous_close": None})()
+            })()
+        })()
+        monkeypatch.setitem(sys.modules, "yfinance", yf_stub)
+
+        result = gms.fetch_us_market_data("FAKE_KEY")
+        assert "SPY" not in result
+
+    def test_network_error_skips_symbol_and_continues(self, monkeypatch):
+        import requests as _requests
+
+        call_count = {"n": 0}
+
+        def fake_get(*a, **kw):
+            call_count["n"] += 1
+            raise _requests.exceptions.ConnectionError("timeout")
+
+        monkeypatch.setattr(_requests, "get", fake_get)
+
+        import sys
+        yf_stub = type("yf", (), {
+            "Ticker": lambda sym: type("T", (), {
+                "fast_info": type("FI", (), {"last_price": None, "previous_close": None})()
+            })()
+        })()
+        monkeypatch.setitem(sys.modules, "yfinance", yf_stub)
+
+        # Should not raise; returns partial (possibly empty) dict
+        result = gms.fetch_us_market_data("FAKE_KEY")
+        assert isinstance(result, dict)
+
+    def test_no_api_key_skips_alpha_vantage_calls(self, monkeypatch):
+        import requests as _requests
+
+        called = {"n": 0}
+
+        def fake_get(*a, **kw):
+            called["n"] += 1
+            return type("R", (), {
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {},
+            })()
+
+        monkeypatch.setattr(_requests, "get", fake_get)
+
+        import sys
+        yf_stub = type("yf", (), {
+            "Ticker": lambda sym: type("T", (), {
+                "fast_info": type("FI", (), {"last_price": None, "previous_close": None})()
+            })()
+        })()
+        monkeypatch.setitem(sys.modules, "yfinance", yf_stub)
+
+        gms.fetch_us_market_data("")
+        assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# fetch_us_market_data — yfinance crypto-related stocks branch
+# ---------------------------------------------------------------------------
+
+class TestFetchUsMarketDataYfinance:
+    """Tests for yfinance-based crypto stock fetching (COIN, MSTR, IBIT)."""
+
+    def _make_yf_stub(self, price, prev_close):
+        fast_info = type("FI", (), {
+            "last_price": price,
+            "previous_close": prev_close,
+        })()
+        ticker = type("T", (), {"fast_info": fast_info})()
+        return type("yf", (), {"Ticker": staticmethod(lambda sym: ticker)})()
+
+    def test_parses_coin_stock_data(self, monkeypatch):
+        import sys
+
+        import requests as _requests
+
+        # No API key → skip AV; patch yfinance
+        monkeypatch.setattr(_requests, "get", lambda *a, **kw: (_ for _ in ()).throw(Exception("no-call")))
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(230.50, 225.00))
+
+        result = gms.fetch_us_market_data("")
+        # COIN, MSTR, IBIT all use same price/prev — all should be present
+        assert "COIN" in result
+        assert result["COIN"]["price"] == "230.50"
+        # change = 230.50 - 225.00 = +5.50
+        assert "+5.50" in result["COIN"]["change"]
+
+    def test_change_pct_calculated_correctly(self, monkeypatch):
+        import sys
+
+        import requests as _requests
+
+        monkeypatch.setattr(_requests, "get", lambda *a, **kw: (_ for _ in ()).throw(Exception("no-call")))
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(110.0, 100.0))
+
+        result = gms.fetch_us_market_data("")
+        assert "COIN" in result
+        # (110 - 100) / 100 * 100 = +10.00%
+        assert "+10.00%" in result["COIN"]["change_pct"]
+
+    def test_none_price_skips_symbol(self, monkeypatch):
+        import sys
+
+        import requests as _requests
+
+        monkeypatch.setattr(_requests, "get", lambda *a, **kw: (_ for _ in ()).throw(Exception("no-call")))
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(None, 100.0))
+
+        result = gms.fetch_us_market_data("")
+        # Neither COIN, MSTR, nor IBIT should be in results when price is None
+        assert "COIN" not in result
+        assert "MSTR" not in result
+        assert "IBIT" not in result
+
+    def test_yfinance_import_error_returns_empty(self, monkeypatch):
+        import sys
+
+        import requests as _requests
+
+        monkeypatch.setattr(_requests, "get", lambda *a, **kw: (_ for _ in ()).throw(Exception("no-call")))
+        # Remove yfinance entirely
+        monkeypatch.setitem(sys.modules, "yfinance", None)
+
+        result = gms.fetch_us_market_data("")
+        assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# fetch_korean_market — yfinance branch
+# ---------------------------------------------------------------------------
+
+class TestFetchKoreanMarket:
+
+    def _make_yf_stub(self, price, prev):
+        fi = type("FI", (), {"last_price": price, "previous_close": prev})()
+        ticker = type("T", (), {"fast_info": fi})()
+        return type("yf", (), {"Ticker": staticmethod(lambda sym: ticker)})()
+
+    def test_parses_kospi_data(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(2500.0, 2450.0))
+
+        result = gms.fetch_korean_market()
+        assert "KOSPI" in result
+        assert result["KOSPI"]["price"] == "2,500.00"
+
+    def test_change_and_pct_calculated(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(2500.0, 2450.0))
+
+        result = gms.fetch_korean_market()
+        # change = 2500 - 2450 = +50
+        assert "+50.00" in result["KOSPI"]["change"]
+        # pct = 50/2450 * 100 ≈ +2.04%
+        assert "+" in result["KOSPI"]["change_pct"]
+
+    def test_returns_all_three_symbols(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(1000.0, 990.0))
+
+        result = gms.fetch_korean_market()
+        # ^KS11 → KOSPI, ^KQ11 → KOSDAQ, KRW=X → USD/KRW 환율
+        assert "KOSPI" in result
+        assert "KOSDAQ" in result
+        assert "USD/KRW 환율" in result
+
+    def test_none_price_skips_symbol(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(None, 1000.0))
+
+        result = gms.fetch_korean_market()
+        assert result == {}
+
+    def test_yfinance_import_error_returns_empty(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", None)
+
+        result = gms.fetch_korean_market()
+        assert result == {}
+
+    def test_ticker_exception_skips_and_continues(self, monkeypatch):
+        import sys
+
+        call_count = {"n": 0}
+
+        class BrokenFI:
+            @property
+            def last_price(self):
+                raise RuntimeError("yf error")
+            previous_close = 1000.0
+
+        class BrokenTicker:
+            fast_info = BrokenFI()
+
+        yf_stub = type("yf", (), {"Ticker": staticmethod(lambda sym: BrokenTicker())})()
+        monkeypatch.setitem(sys.modules, "yfinance", yf_stub)
+
+        result = gms.fetch_korean_market()
+        assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# fetch_commodity_data — yfinance branch
+# ---------------------------------------------------------------------------
+
+class TestFetchCommodityData:
+
+    def _make_yf_stub(self, price, prev):
+        fi = type("FI", (), {"last_price": price, "previous_close": prev})()
+        ticker = type("T", (), {"fast_info": fi})()
+        return type("yf", (), {"Ticker": staticmethod(lambda sym: ticker)})()
+
+    def test_parses_gold_data(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(1950.0, 1940.0))
+
+        result = gms.fetch_commodity_data()
+        assert "금 (Gold)" in result
+        assert result["금 (Gold)"]["price"] == "1,950.00"
+
+    def test_returns_all_four_commodities(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(100.0, 98.0))
+
+        result = gms.fetch_commodity_data()
+        assert "금 (Gold)" in result
+        assert "원유 (WTI)" in result
+        assert "천연가스" in result
+        assert "달러 인덱스 (DXY)" in result
+
+    def test_change_pct_sign_positive(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(100.0, 98.0))
+
+        result = gms.fetch_commodity_data()
+        # (100 - 98) / 98 * 100 ≈ +2.04%
+        assert "+" in result["금 (Gold)"]["change_pct"]
+
+    def test_change_pct_sign_negative(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(95.0, 100.0))
+
+        result = gms.fetch_commodity_data()
+        assert "-" in result["금 (Gold)"]["change_pct"]
+
+    def test_none_price_skips_commodity(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(None, 100.0))
+
+        result = gms.fetch_commodity_data()
+        assert result == {}
+
+    def test_yfinance_import_error_returns_empty(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", None)
+
+        result = gms.fetch_commodity_data()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# fetch_fred_indicators — mocked HTTP via request_with_retry
+# ---------------------------------------------------------------------------
+
+class TestFetchFredIndicators:
+
+    def _obs(self, value, date="2024-01-15", prev_value="4.50", prev_date="2023-12-15"):
+        return {
+            "observations": [
+                {"value": str(value), "date": date},
+                {"value": prev_value, "date": prev_date},
+            ]
+        }
+
+    def test_no_api_key_returns_empty(self):
+        result = gms.fetch_fred_indicators("")
+        assert result == {}
+
+    def test_parses_fed_rate_observation(self, monkeypatch):
+        mock_resp = type("R", (), {"json": lambda self: self._data})()
+        mock_resp._data = self._obs("5.25", prev_value="5.00")
+
+        import scripts.generate_market_summary as _gms
+        monkeypatch.setattr(_gms, "request_with_retry", lambda *a, **kw: mock_resp)
+
+        result = gms.fetch_fred_indicators("FAKE_KEY")
+        assert "FED_RATE" in result
+        assert result["FED_RATE"]["value"] == 5.25
+        assert result["FED_RATE"]["label"] == "연방기금금리"
+
+    def test_change_calculated_from_two_observations(self, monkeypatch):
+        mock_resp = type("R", (), {"json": lambda self: self._data})()
+        mock_resp._data = self._obs("5.25", prev_value="5.00")
+
+        import scripts.generate_market_summary as _gms
+        monkeypatch.setattr(_gms, "request_with_retry", lambda *a, **kw: mock_resp)
+
+        result = gms.fetch_fred_indicators("FAKE_KEY")
+        assert abs(result["FED_RATE"]["change"] - 0.25) < 0.001
+
+    def test_dot_value_skips_observation(self, monkeypatch):
+        # FRED returns "." for missing data
+        mock_resp = type("R", (), {"json": lambda self: self._data})()
+        mock_resp._data = {"observations": [{"value": ".", "date": "2024-01-15"}]}
+
+        import scripts.generate_market_summary as _gms
+        monkeypatch.setattr(_gms, "request_with_retry", lambda *a, **kw: mock_resp)
+
+        result = gms.fetch_fred_indicators("FAKE_KEY")
+        assert "FED_RATE" not in result
+
+    def test_single_observation_change_is_none(self, monkeypatch):
+        mock_resp = type("R", (), {"json": lambda self: self._data})()
+        mock_resp._data = {"observations": [{"value": "5.25", "date": "2024-01-15"}]}
+
+        import scripts.generate_market_summary as _gms
+        monkeypatch.setattr(_gms, "request_with_retry", lambda *a, **kw: mock_resp)
+
+        result = gms.fetch_fred_indicators("FAKE_KEY")
+        assert result["FED_RATE"]["change"] is None
+
+    def test_exception_skips_indicator_and_continues(self, monkeypatch):
+        import scripts.generate_market_summary as _gms
+
+        call_count = {"n": 0}
+
+        def failing_retry(*a, **kw):
+            call_count["n"] += 1
+            raise RuntimeError("network error")
+
+        monkeypatch.setattr(_gms, "request_with_retry", failing_retry)
+
+        result = gms.fetch_fred_indicators("FAKE_KEY")
+        assert isinstance(result, dict)
+        # Should have attempted all 11 indicators
+        assert call_count["n"] == 11
+
+    def test_date_stored_from_observation(self, monkeypatch):
+        mock_resp = type("R", (), {"json": lambda self: self._data})()
+        mock_resp._data = self._obs("4.00", date="2024-03-01")
+
+        import scripts.generate_market_summary as _gms
+        monkeypatch.setattr(_gms, "request_with_retry", lambda *a, **kw: mock_resp)
+
+        result = gms.fetch_fred_indicators("FAKE_KEY")
+        assert result["FED_RATE"]["date"] == "2024-03-01"
+
+    def test_prev_dot_value_change_is_none(self, monkeypatch):
+        mock_resp = type("R", (), {"json": lambda self: self._data})()
+        mock_resp._data = {
+            "observations": [
+                {"value": "5.25", "date": "2024-01-15"},
+                {"value": ".", "date": "2023-12-15"},
+            ]
+        }
+
+        import scripts.generate_market_summary as _gms
+        monkeypatch.setattr(_gms, "request_with_retry", lambda *a, **kw: mock_resp)
+
+        result = gms.fetch_fred_indicators("FAKE_KEY")
+        assert result["FED_RATE"]["change"] is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_sector_performance — yfinance branch
+# ---------------------------------------------------------------------------
+
+class TestFetchSectorPerformance:
+
+    def _make_yf_stub(self, price, prev):
+        fi = type("FI", (), {"last_price": price, "previous_close": prev})()
+        ticker = type("T", (), {"fast_info": fi})()
+        return type("yf", (), {"Ticker": staticmethod(lambda sym: ticker)})()
+
+    def test_returns_sector_data_with_name(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(200.0, 195.0))
+
+        result = gms.fetch_sector_performance()
+        assert "XLK" in result
+        assert result["XLK"]["name"] == "기술 (Technology)"
+
+    def test_returns_all_11_sectors(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(100.0, 99.0))
+
+        result = gms.fetch_sector_performance()
+        expected = {"XLK", "XLF", "XLE", "XLV", "XLI", "XLC", "XLP", "XLY", "XLU", "XLRE", "XLB"}
+        assert expected == set(result.keys())
+
+    def test_change_pct_is_float(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(110.0, 100.0))
+
+        result = gms.fetch_sector_performance()
+        assert isinstance(result["XLK"]["change_pct"], float)
+        assert abs(result["XLK"]["change_pct"] - 10.0) < 0.01
+
+    def test_price_formatted_as_string(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(199.50, 198.0))
+
+        result = gms.fetch_sector_performance()
+        assert result["XLK"]["price"] == "199.50"
+
+    def test_none_price_skips_sector(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(None, 100.0))
+
+        result = gms.fetch_sector_performance()
+        assert result == {}
+
+    def test_yfinance_import_error_returns_empty(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", None)
+
+        result = gms.fetch_sector_performance()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# fetch_btc_etf_data — yfinance + rss_fetcher branch
+# ---------------------------------------------------------------------------
+
+def _patch_rss_fetcher(monkeypatch, return_value):
+    """Patch fetch_rss_feeds_concurrent on the module that gms resolves at call time.
+
+    gms inserts scripts/ onto sys.path then does:
+        from common.rss_fetcher import fetch_rss_feeds_concurrent
+    so the live module is sys.modules["common.rss_fetcher"].
+    """
+    _rss = sys.modules["common.rss_fetcher"]
+    monkeypatch.setattr(_rss, "fetch_rss_feeds_concurrent", lambda feeds: return_value)
+
+
+def _patch_rss_fetcher_capture(monkeypatch):
+    """Patch and return a capture dict that records the feeds argument."""
+    _rss = sys.modules["common.rss_fetcher"]
+    captured = {}
+
+    def fake_rss(feeds):
+        captured["feeds"] = feeds
+        return []
+
+    monkeypatch.setattr(_rss, "fetch_rss_feeds_concurrent", fake_rss)
+    return captured
+
+
+class TestFetchBtcEtfData:
+
+    def _make_yf_stub(self, price, prev):
+        fi = type("FI", (), {"last_price": price, "previous_close": prev})()
+        ticker = type("T", (), {"fast_info": fi})()
+        return type("yf", (), {"Ticker": staticmethod(lambda sym: ticker)})()
+
+    def _patch_rss(self, monkeypatch, return_value):
+        _patch_rss_fetcher(monkeypatch, return_value)
+
+    def test_returns_etfs_and_news_keys(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(35.0, 34.0))
+        self._patch_rss(monkeypatch, [])
+
+        result = gms.fetch_btc_etf_data()
+        assert "etfs" in result
+        assert "news" in result
+
+    def test_parses_ibit_price(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(35.50, 34.00))
+        self._patch_rss(monkeypatch, [])
+
+        result = gms.fetch_btc_etf_data()
+        assert "IBIT" in result["etfs"]
+        assert result["etfs"]["IBIT"]["price"] == "35.50"
+
+    def test_parses_all_three_etfs(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(30.0, 29.0))
+        self._patch_rss(monkeypatch, [])
+
+        result = gms.fetch_btc_etf_data()
+        assert "IBIT" in result["etfs"]
+        assert "FBTC" in result["etfs"]
+        assert "GBTC" in result["etfs"]
+
+    def test_change_pct_formatted_with_sign(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(110.0, 100.0))
+        self._patch_rss(monkeypatch, [])
+
+        result = gms.fetch_btc_etf_data()
+        assert result["etfs"]["IBIT"]["change_pct"] == "+10.00%"
+
+    def test_news_items_from_rss_included(self, monkeypatch):
+        import sys
+        news = [{"title": "Bitcoin ETF 자금 유입", "link": "https://example.com"}]
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(None, 30.0))
+        self._patch_rss(monkeypatch, news)
+
+        result = gms.fetch_btc_etf_data()
+        assert result["news"] == news
+
+    def test_none_price_skips_etf(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", self._make_yf_stub(None, 30.0))
+        self._patch_rss(monkeypatch, [])
+
+        result = gms.fetch_btc_etf_data()
+        assert result["etfs"] == {}
+
+    def test_yfinance_import_error_etfs_empty(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", None)
+        self._patch_rss(monkeypatch, [])
+
+        result = gms.fetch_btc_etf_data()
+        assert result["etfs"] == {}
+
+
+# ---------------------------------------------------------------------------
+# fetch_whale_trades — rss_fetcher branch
+# ---------------------------------------------------------------------------
+
+class TestFetchWhaleTrades:
+
+    def test_returns_list(self, monkeypatch):
+        _patch_rss_fetcher(monkeypatch, [])
+        result = gms.fetch_whale_trades()
+        assert isinstance(result, list)
+
+    def test_passes_three_feeds_to_rss(self, monkeypatch):
+        captured = _patch_rss_fetcher_capture(monkeypatch)
+        gms.fetch_whale_trades()
+        assert len(captured["feeds"]) == 3
+
+    def test_returns_news_items_from_rss(self, monkeypatch):
+        items = [
+            {"title": "1000 BTC moved", "link": "https://whale-alert.io/1"},
+            {"title": "500 ETH moved", "link": "https://whale-alert.io/2"},
+        ]
+        _patch_rss_fetcher(monkeypatch, items)
+        result = gms.fetch_whale_trades()
+        assert result == items
+
+    def test_feeds_contain_whale_alert_url(self, monkeypatch):
+        captured = _patch_rss_fetcher_capture(monkeypatch)
+        gms.fetch_whale_trades()
+        all_urls = [f[0] for f in captured["feeds"]]
+        assert any("whale" in url.lower() for url in all_urls)
+
+    def test_feeds_include_korean_language_feed(self, monkeypatch):
+        captured = _patch_rss_fetcher_capture(monkeypatch)
+        gms.fetch_whale_trades()
+        tags_lists = [f[2] for f in captured["feeds"]]
+        assert any("korean" in tags for tags in tags_lists)
+
+
+# ---------------------------------------------------------------------------
+# fetch_us_market_data — yfinance fallback for AV symbols (^GSPC etc.)
+# ---------------------------------------------------------------------------
+
+class TestFetchUsMarketDataYfinanceFallback:
+    """Covers the yfinance fallback path for AV symbols when AV returns < 3 results."""
+
+    def test_yfinance_fallback_fills_spy_when_av_incomplete(self, monkeypatch):
+        import sys
+
+        import requests as _requests
+
+        # AV returns empty Global Quote → no SPY from AV
+        empty_resp = type("R", (), {
+            "raise_for_status": lambda self: None,
+            "json": lambda self: {"Global Quote": {}},
+        })()
+        monkeypatch.setattr(_requests, "get", lambda *a, **kw: empty_resp)
+
+        # yfinance returns valid data for ^GSPC → should fill SPY
+        call_log = []
+
+        def ticker_factory(sym):
+            call_log.append(sym)
+            if sym in ("^GSPC", "^IXIC", "^DJI", "^VIX"):
+                fi = type("FI", (), {"last_price": 5000.0, "previous_close": 4950.0})()
+            else:
+                fi = type("FI", (), {"last_price": 100.0, "previous_close": 99.0})()
+            return type("T", (), {"fast_info": fi})()
+
+        yf_stub = type("yf", (), {"Ticker": staticmethod(ticker_factory)})()
+        monkeypatch.setitem(sys.modules, "yfinance", yf_stub)
+
+        result = gms.fetch_us_market_data("FAKE_KEY")
+        assert "SPY" in result
+        assert result["SPY"]["price"] == "5,000.00"
+
+    def test_fallback_skips_already_fetched_symbols(self, monkeypatch):
+        """If SPY was already fetched from AV, yfinance fallback should not overwrite it."""
+        import sys
+
+        import requests as _requests
+
+        # AV returns valid SPY only
+        call_count = {"n": 0}
+
+        def fake_get(url, params=None, **kw):
+            sym = (params or {}).get("symbol", "")
+            call_count["n"] += 1
+            if sym == "SPY":
+                return type("R", (), {
+                    "raise_for_status": lambda self: None,
+                    "json": lambda self: {"Global Quote": {
+                        "05. price": "499.00",
+                        "09. change": "+1.00",
+                        "10. change percent": "+0.20%",
+                        "06. volume": "1000",
+                    }},
+                })()
+            return type("R", (), {
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {"Global Quote": {}},
+            })()
+
+        monkeypatch.setattr(_requests, "get", fake_get)
+
+        yf_ticker_calls = []
+
+        def ticker_factory(sym):
+            yf_ticker_calls.append(sym)
+            fi = type("FI", (), {"last_price": 9999.0, "previous_close": 1.0})()
+            return type("T", (), {"fast_info": fi})()
+
+        yf_stub = type("yf", (), {"Ticker": staticmethod(ticker_factory)})()
+        monkeypatch.setitem(sys.modules, "yfinance", yf_stub)
+
+        result = gms.fetch_us_market_data("FAKE_KEY")
+        # SPY came from AV; yfinance fallback must not overwrite it
+        assert result.get("SPY", {}).get("price") == "499.00"


### PR DESCRIPTION
## Summary
- `generate_daily_summary.py` 커버리지 44% → 71% (+44개 테스트)
- `generate_market_summary.py` 커버리지 55% → 76% (+48개 테스트)
- 전체 스위트 2849 passed, 전체 커버리지 55% → 60%

## Test plan
- [x] 362개 테스트 전부 pass
- [x] 전체 스위트 2849 passed