### PR TITLE
fix: config/dedup 개선 — CCG 코드 리뷰 반영

### DIFF
--- a/scripts/common/config.py
+++ b/scripts/common/config.py
@@ -161,8 +161,14 @@ def get_env(key: str, default: str = "") -> str:
 
 
 def get_env_bool(key: str, default: bool = False) -> bool:
-    """Get boolean environment variable."""
+    """Get boolean environment variable.
+
+    Strips whitespace and surrounding quotes for parity with get_env().
+    """
     val = os.environ.get(key, "")
+    if not val:
+        return default
+    val = val.strip().strip("\"'")
     if not val:
         return default
     return val.lower() in ("true", "1", "yes")
@@ -206,13 +212,13 @@ def get_verify_ssl():
 
 
 SITE_URL = "https://investing.2twodragon.com"
-REQUEST_TIMEOUT = 15
+REQUEST_TIMEOUT = int(os.environ.get("REQUEST_TIMEOUT", "15"))
 # Playwright/Chromium wait timeout in milliseconds. Intentionally higher than
 # REQUEST_TIMEOUT because JS-rendered pages need DOMContentLoaded + network
 # idle + render frames to complete. Do not lower without testing on
 # JS-heavy sites (Twitter/X, CoinMarketCap). Collectors should import this
 # and pass it to BrowserSession rather than hardcoding the literal.
-BROWSER_TIMEOUT_MS = 30_000
+BROWSER_TIMEOUT_MS = int(os.environ.get("BROWSER_TIMEOUT_MS", "30000"))
 USER_AGENT = "Mozilla/5.0 (compatible; InvestingDragon/1.0)"
 BROWSER_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "

--- a/scripts/common/dedup.py
+++ b/scripts/common/dedup.py
@@ -58,6 +58,8 @@ class DedupEngine:
         self.seen: Dict[str, str] = {}  # hash -> timestamp
         self.titles: List[List[str]] = []  # [[normalized_title, date_str], ...]
         self.seen_urls: Dict[str, str] = {}  # normalized_url -> timestamp
+        self._checked = 0
+        self._duplicates = 0
         self._load()
 
     def _load(self) -> None:
@@ -135,6 +137,15 @@ class DedupEngine:
             except OSError:
                 pass
 
+    def log_stats(self) -> None:
+        """Log dedup statistics for the current session."""
+        if self._checked:
+            kept = self._checked - self._duplicates
+            logger.info(
+                "Dedup stats: checked %d, removed %d duplicates, kept %d items",
+                self._checked, self._duplicates, kept,
+            )
+
     def is_duplicate(self, title: str, source: str, date_str: str, url: str = "") -> bool:
         """Check if a news item is a duplicate.
 
@@ -145,17 +156,20 @@ class DedupEngine:
         """
         if not title or not title.strip():
             return True
+        self._checked += 1
 
         # URL-based dedup: same URL from different source tags
         if url:
             norm_url = _normalize_url(url)
             if norm_url and norm_url in self.seen_urls:
                 logger.debug("URL duplicate: %s (source: %s)", url[:80], source)
+                self._duplicates += 1
                 return True
 
         # Exact hash check
         h = _make_hash(title, source, date_str)
         if h in self.seen:
+            self._duplicates += 1
             return True
 
         # Date-aware fuzzy matching against recent titles
@@ -179,6 +193,7 @@ class DedupEngine:
                     title[:50],
                     existing_title[:50],
                 )
+                self._duplicates += 1
                 return True
 
         return False


### PR DESCRIPTION
## Summary
- `get_env_bool()` 공백/따옴표 트리밍 추가 (`get_env()`와 동일 처리)
- `REQUEST_TIMEOUT`, `BROWSER_TIMEOUT_MS` 환경변수 오버라이드 지원
- `DedupEngine` 중복 제거 통계 로깅 (`log_stats()` 메서드 추가)

## Context
CCG tri-model 코드 리뷰에서 Codex(정확성/아키텍처)와 Gemini(UX/유지보수성)가 지적한 사항 반영:
- Codex: `get_env_bool()` 공백 입력 시 `False` 오판, timeout 하드코딩 문제
- Gemini: dedup 로직의 통계 가시성 부족

## Test plan
- [x] `ruff check` 통과
- [x] `pytest` 2952 passed (커버리지 62.74%)
- [x] 수집기 실행 테스트 (`collect_crypto_news.py`) 정상