### PR TITLE
fix: 사이트 경고 수정 + dedup exact 통계 카운터

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,9 +14,7 @@
   {% if page.image %}
   {% if page.image contains '/assets/images/generated/' %}
   {% assign preload_avif = page.image | replace: '.png', '.avif' | replace: '.jpg', '.avif' | replace: '.jpeg', '.avif' %}
-  {% assign preload_webp = page.image | replace: '.png', '.webp' | replace: '.jpg', '.webp' | replace: '.jpeg', '.webp' %}
   <link rel="preload" as="image" type="image/avif" href="{{ preload_avif | relative_url }}" fetchpriority="high">
-  <link rel="preload" as="image" type="image/webp" href="{{ preload_webp | relative_url }}" fetchpriority="high">
   {% endif %}
   {% endif %}
   {% include critical-css.html %}

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
     {
       "src": "/assets/images/apple-touch-icon.png",
       "sizes": "180x180",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/assets/images/favicon-192.png",

--- a/scripts/common/dedup.py
+++ b/scripts/common/dedup.py
@@ -206,9 +206,13 @@ class DedupEngine:
         """
         if not title or not title.strip():
             return True
+        self._checked += 1
 
         h = _make_hash(title, source, date_str)
-        return h in self.seen
+        if h in self.seen:
+            self._duplicates += 1
+            return True
+        return False
 
     def mark_seen(self, title: str, source: str, date_str: str, url: str = "") -> None:
         """Mark a news item as seen."""


### PR DESCRIPTION
## Summary
- `manifest.json`: apple-touch-icon에 `purpose: any` 명시 (브라우저 경고 해소)
- `default.html`: 미사용 WebP preload 제거, AVIF만 ���지 (preload 낭비 방지)
- `dedup.py`: `is_duplicate_exact()`에도 `_checked`/`_duplicates` 카운터 추가

## Test plan
- [x] `ruff check` 통과
- [x] Jekyll build 성공
- [x] `collect_stock_news.py` 실행 시 `Dedup stats` 로그 출력 확인