### PR TITLE
fix: PWA manifest apple-touch-icon 제거 + PWA 가이드라인 문서화

### DIFF
--- a/.claude/rules/news-collector.md
+++ b/.claude/rules/news-collector.md
@@ -28,6 +28,7 @@ globs: ["scripts/**/*.py", "_posts/**/*.md", ".github/workflows/**/*.yml"]
 - Keep Korean-first operational readability in generated summaries and briefings
 - Generated image filenames must stay English-only under `assets/images/generated/`
 - Never manually edit `_state/*.json`
+- PWA manifest and hero-image preload rules: see `docs/pwa-guidelines.md` (manifest icons 32/192/512 only, apple-touch-icon via HTML `<link>`, single-format AVIF preload)
 
 # Workflow And Automation Guardrails
 

--- a/docs/pwa-guidelines.md
+++ b/docs/pwa-guidelines.md
@@ -1,0 +1,47 @@
+# PWA Guidelines
+
+## 매니페스트 아이콘 규칙
+
+`manifest.json`의 `icons` 배열에는 **표준 PWA 사이즈만** 포함합니다.
+
+| 용도 | 위치 | 사이즈 |
+|------|------|--------|
+| PWA 표준 | `manifest.json` | 192×192, 512×512 (`purpose: "any maskable"`) |
+| 파비콘 | `manifest.json` | 32×32 (`purpose` 생략) |
+| iOS 홈스크린 | `_layouts/default.html` `<link rel="apple-touch-icon">` | 180×180 |
+
+### 왜 180×180을 매니페스트에 넣지 않는가
+
+- Chrome은 `manifest.json`에서 비표준 사이즈(180×180 등)를 감지하면 `"Resource size is not correct - typo in the Manifest?"` 경고를 띄웁니다.
+- iOS Safari는 매니페스트를 참조하지 않고 `<link rel="apple-touch-icon">` HTML 태그만 사용합니다 — 매니페스트에 중복 선언할 필요가 없습니다.
+- 따라서 180×180 아이콘은 **HTML `<link>` 태그 전용**으로 유지합니다.
+
+### 현재 아이콘 파일
+
+```
+assets/images/
+├── favicon-32.png       (32×32, 매니페스트+브라우저 탭)
+├── favicon-192.png      (192×192, 매니페스트 표준)
+├── favicon-512.png      (512×512, 매니페스트 표준)
+└── apple-touch-icon.png (180×180, HTML <link>만)
+```
+
+## 이미지 Preload 규칙
+
+`_layouts/default.html`에서 LCP 히어로 이미지(`page.image`)를 preload할 때:
+
+- **AVIF 한 가지만** preload (`type="image/avif"` 힌트로 미지원 브라우저는 스킵)
+- 동일 이미지의 WebP/PNG는 preload하지 않음 — `<picture>` 엘리먼트가 브라우저에 맞춰 선택
+- 여러 포맷을 동시에 preload하면 브라우저가 실제로 사용하지 않은 포맷에 대해 "preloaded but not used" 콘솔 경고 발생
+
+```html
+<link rel="preload" as="image" type="image/avif"
+      href="{{ preload_avif | relative_url }}" fetchpriority="high">
+```
+
+## 관련 파일
+
+- `manifest.json` — PWA 매니페스트
+- `_layouts/default.html` — 아이콘/이미지 preload HTML 태그
+- `_includes/generated-picture.html` — AVIF/WebP/PNG `<picture>` 렌더링
+- `sw.js` — 서비스 워커 (이미지 캐시)

--- a/manifest.json
+++ b/manifest.json
@@ -14,12 +14,6 @@
       "type": "image/png"
     },
     {
-      "src": "/assets/images/apple-touch-icon.png",
-      "sizes": "180x180",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
       "src": "/assets/images/favicon-192.png",
       "sizes": "192x192",
       "type": "image/png",


### PR DESCRIPTION
## Summary

- Chrome PWA 매니페스트 경고 해소: 비표준 사이즈(180×180) 아이콘 엔트리 제거
- iOS는 기존 `<link rel=\"apple-touch-icon\">`로 계속 지원되어 기능 손실 없음
- `docs/pwa-guidelines.md` 신규 생성: 아이콘/preload 규칙 명문화
- `.claude/rules/news-collector.md`에 가이드 링크 추가해 향후 에이전트가 참조

## 배경

브라우저 콘솔에서 두 경고 발생:
1. `apple-touch-icon.png ... Resource size is not correct - typo in the Manifest?`
2. `og-fmp-economic-calendar-2026-04-17.webp ... preloaded but not used` (이전 커밋 c6253424에서 해결, 캐시 경유)

## 변경 파일

- `manifest.json` — 180×180 apple-touch-icon 엔트리 제거 (32/192/512만 유지)
- `docs/pwa-guidelines.md` — 신규 (아이콘 배치 규칙, AVIF-only preload 규칙)
- `.claude/rules/news-collector.md` — Post And Image Guardrails에 PWA 가이드 링크 추가

## Test plan

- [ ] GitHub Pages 배포 완료 확인
- [ ] Chrome DevTools Application → Manifest 탭 경고 0 확인
- [ ] Console에서 preload 경고 재발 없음 확인 (하드 리프레시)
- [ ] iOS Safari 홈스크린 추가 시 apple-touch-icon 정상 표시 확인