### PR TITLE
chore: .gitignore에 루트 .tmp 파일 항목 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ assets/images/test-*
 # OMC / temp / coverage
 .omc-config.json
 .tmp/
+/.tmp
 .coverage
 scripts/.coverage
 coverage-html/


### PR DESCRIPTION
## Summary

- 루트 .tmp 파일이 추적되는 문제 해결
- 기존 `.tmp/` 규칙은 디렉토리만 매치했음 → `/.tmp` 파일 규칙 추가

## Test plan

- [x] `git check-ignore -v .tmp` 로 규칙 매치 확인
- [ ] CI 통과
