### PR TITLE
refactor(summarizer): _is_logo_url을 enrichment 단일 소스에서 임포트

### DIFF
--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -16,6 +16,7 @@ import re
 from collections import Counter
 from typing import Any, Dict, List, Optional, Tuple
 
+from .enrichment import _is_logo_like_url as _is_logo_url
 from .markdown_utils import html_source_tag, markdown_link
 from .post_generator import _MISTRANSLATION_FIXES
 from .utils import truncate_sentence as _truncate_sentence_util
@@ -141,38 +142,6 @@ def _truncate_sentence(text: str, max_len: int = 300) -> str:
     if best_idx > 20:
         return text[:best_idx].strip()
     return _truncate_sentence_util(text, max_length=max_len)
-
-
-# Logo/icon URL patterns that indicate a site branding image rather than article content
-_LOGO_URL_PATTERNS = [
-    "/logo/",
-    "/logos/",
-    "/favicon",
-    "/icon/",
-    "/icons/",
-    "default-logo",
-    "snslogo",
-    "snslogotrans",
-    "-logo.",
-    "_logo.",
-    "logo%20",  # encoded "logo " (e.g. "logo%20217x217")
-    "256x256",
-    "128x128",
-    "64x64",
-    "32x32",
-    "16x16",
-]
-
-
-def _is_logo_url(url: str) -> bool:
-    """Return True if *url* looks like a site logo or icon rather than an article image.
-
-    Matches paths that contain known logo/favicon patterns or icon dimensions.
-    """
-    if not url:
-        return False
-    url_lower = url.lower()
-    return any(pattern in url_lower for pattern in _LOGO_URL_PATTERNS)
 
 
 def _favicon_url(link: str) -> str:


### PR DESCRIPTION
## Summary

- `scripts/common/summarizer.py`의 `_LOGO_URL_PATTERNS`(16개) 및 `_is_logo_url` 중복 정의 제거
- `enrichment._is_logo_like_url`을 `_is_logo_url` 별칭으로 임포트하여 단일 소스화

## Context

직전 PR #709에서 `enrichment.py`에 `_is_logo_like_url`을 도입하면서 summarizer.py의 기존 `_is_logo_url`과 로고 패턴 리스트가 중복됨. 한쪽만 업데이트될 경우 수집 파이프라인과 포스트 렌더링 계층이 로고 판정 기준을 달리할 수 있어 단일 소스화.

## Test plan

- [x] `python3 -m pytest tests/` — 3908 passed
- [x] `python3 -m ruff check scripts/common/` — All checks passed
- [x] `summarizer._is_logo_url is enrichment._is_logo_like_url` 항등성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)