### PR TITLE
refactor(enrichment): _is_logo_like_url → is_logo_like_url 공개 API 승격

### DIFF
--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -19,6 +19,20 @@ from .utils import is_private_url_target
 
 logger = logging.getLogger(__name__)
 
+# Public API — names documented for import by collectors and renderers.
+# Names prefixed with _ remain internal helpers (shared via explicit import only).
+__all__ = [
+    "enrich_item",
+    "enrich_items",
+    "fetch_descriptions_concurrent",
+    "fetch_images_concurrent",
+    "fetch_page_description",
+    "fetch_page_metadata",
+    "generate_synthetic_description",
+    "is_logo_like_url",
+    "is_private_url",
+]
+
 # Cache for resolved Google News URLs to avoid redundant lookups
 _gnews_url_cache: Dict[str, str] = {}
 
@@ -551,7 +565,7 @@ def _is_valid_image_url(url: str) -> bool:
     return True
 
 
-def _is_logo_like_url(url: str) -> bool:
+def is_logo_like_url(url: str) -> bool:
     """Return True if *url* looks like a site logo/icon rather than article art."""
     if not url:
         return False
@@ -620,7 +634,7 @@ def fetch_images_concurrent(
         img = item.get("image") or ""
         if not img:
             missing.append((i, item))
-        elif _is_logo_like_url(img):
+        elif is_logo_like_url(img):
             logo_only.append((i, item))
 
     targets = (missing + logo_only)[:max_items]
@@ -654,7 +668,7 @@ def fetch_images_concurrent(
                 if not prev:
                     items[idx]["image"] = img_url
                     fetched += 1
-                elif _is_logo_like_url(prev) and not _is_logo_like_url(img_url):
+                elif is_logo_like_url(prev) and not is_logo_like_url(img_url):
                     items[idx]["image"] = img_url
                     replaced += 1
             except Exception as exc:

--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -16,7 +16,7 @@ import re
 from collections import Counter
 from typing import Any, Dict, List, Optional, Tuple
 
-from .enrichment import _is_logo_like_url as _is_logo_url
+from .enrichment import is_logo_like_url
 from .markdown_utils import html_source_tag, markdown_link
 from .post_generator import _MISTRANSLATION_FIXES
 from .utils import truncate_sentence as _truncate_sentence_util
@@ -1256,7 +1256,7 @@ class ThemeSummarizer:
 
                     # Add thumbnail if image available and not a site logo/icon
                     image_url = article.get("image", "")
-                    if image_url and not _is_logo_url(image_url):
+                    if image_url and not is_logo_like_url(image_url):
                         safe_img = _esc(image_url, quote=True)
                         onerr = "this.parentElement.style.display='none'"
                         card_parts.append(
@@ -1338,7 +1338,7 @@ class ThemeSummarizer:
                         img = item.get("image", "")
                         src = item.get("source", "")
                         thumb_html = ""
-                        if img and not _is_logo_url(img):
+                        if img and not is_logo_like_url(img):
                             safe_img = _esc(img, quote=True)
                             onerr = "this.parentElement.style.display='none'"
                             thumb_html = (


### PR DESCRIPTION
## Summary

- `scripts/common/enrichment.py`: `_is_logo_like_url` → `is_logo_like_url` (언더스코어 제거)
- `__all__` 추가 — 9개 공개 API 명시 (`enrich_item`, `enrich_items`, `fetch_*`, `is_logo_like_url`, `is_private_url`)
- `scripts/common/summarizer.py`: import 별칭 제거, 호출부 2곳 업데이트

## Context

PR #710에서 summarizer가 `_is_logo_like_url as _is_logo_url` 별칭으로 import하고 있어, 수집(collector)과 렌더링(summarizer) 계층이 "내부 함수"를 크로스 모듈 참조하는 형태였음. `__all__` 선언과 공개명 변경으로 모듈 경계를 명확화.

## Test plan

- [x] `python3 -m ruff check scripts/common/` — All checks passed
- [x] `python3 -m pytest tests/test_enrichment*.py tests/test_summarizer.py` — 608 passed
- [x] 전체 repo grep: `_is_logo_like_url` / `_is_logo_url` 잔여 참조 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)