### PR TITLE
feat(summarizer): overflow 썸네일 프리뷰 2 → 10건 확대

### DIFF
--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -737,6 +737,10 @@ THEMES = [
 
 TOP_THEMES_COUNT = 5
 ARTICLES_PER_THEME = 5
+# Overflow preview cap per theme — how many articles past the featured cards
+# get a thumbnail preview in the <details> section. Raised from implicit 2 → 10
+# so "그 외 38건 보기" expands into a visual list instead of a bare stub line.
+OVERFLOW_PREVIEW_LIMIT = 10
 BAR_WIDTH = 18
 
 # Build a set of theme names (Korean + English keys) for cross-theme keyword filtering
@@ -1319,7 +1323,11 @@ class ThemeSummarizer:
                     )
 
                 shown += 1
-                if shown >= max_articles:
+                # Featured cards stop at max_articles, but keep accumulating
+                # remaining_links up to OVERFLOW_PREVIEW_LIMIT so the <details>
+                # overflow section renders thumbnails for ~10 items instead of
+                # collapsing to a bare "외 N건" stub.
+                if shown >= max_articles and len(remaining_links) >= OVERFLOW_PREVIEW_LIMIT:
                     break
 
             overflow = len([a for a in articles if a.get("title") and a["title"] not in seen_titles])
@@ -1331,7 +1339,7 @@ class ThemeSummarizer:
                     f"<details><summary>그 외 {remaining_count}건 보기</summary>"
                     f'<div class="details-content"><ol class="news-overflow-list">'
                 )
-                for item in remaining_links[:15]:
+                for item in remaining_links[:OVERFLOW_PREVIEW_LIMIT]:
                     if isinstance(item, dict):
                         t = _esc(item.get("title", ""), quote=True)
                         lnk = item.get("link", "")
@@ -1377,8 +1385,10 @@ class ThemeSummarizer:
                             )
                     else:
                         lines.append(f"<li>{item}</li>")
-                if remaining_count > 15:
-                    lines.append(f"<li><em>...외 {remaining_count - 15}건</em></li>")
+                if remaining_count > OVERFLOW_PREVIEW_LIMIT:
+                    lines.append(
+                        f"<li><em>...외 {remaining_count - OVERFLOW_PREVIEW_LIMIT}건</em></li>"
+                    )
                 lines.append("</ol></div></details>\n")
 
             lines.append("")


### PR DESCRIPTION
## Summary

- `OVERFLOW_PREVIEW_LIMIT = 10` 상수 도입
- `shown >= max_articles` 시점 이후에도 `remaining_links`를 10개까지 계속 누적
- 렌더 슬라이스/스텁 계산에 `OVERFLOW_PREVIEW_LIMIT` 일관 사용

## Context

QA 에이전트 분석 (2026-04-20 daily-crypto-news-digest, 85건 뉴스):
- 렌더된 `news-card-thumb` + `overflow-thumb` = 26개
- 테마당 3 featured + 2 overflow만 썸네일로 노출
- `<details>그 외 38건 보기</details>` 섹션이 "외 N건" 스텁만 보여줌 → 사용자가 확장해도 대부분 시각 정보 손실

## 기대 효과

- 5 테마 × (3 featured + 10 overflow) = 최대 65개 썸네일 커버리지 (현재 26개 → 2.5배)
- featured 영역은 변경 없음 (상위 3개는 그대로 big-card)
- overflow 섹션만 썸네일 리스트로 풍부화

## Test plan

- [x] `python3 -m ruff check scripts/common/summarizer.py` — All checks passed
- [x] `python3 -m pytest tests/test_summarizer.py` — 156 passed
- [ ] 다음 자동 포스팅 cycle 후 렌더된 HTML에서 overflow-thumb 수량 재측정 (~60 이상 기대)

🤖 Generated with [Claude Code](https://claude.com/claude-code)