### PR TITLE
feat(enrichment): og:image 메타 체인 7종 + 로고 자동 스킵

### DIFF
--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -573,8 +573,36 @@ def is_logo_like_url(url: str) -> bool:
     return any(pattern in url_lower for pattern in _LOGO_URL_PATTERNS)
 
 
+# Meta tag patterns for article image extraction, tried in priority order.
+# Each entry is (attr_pair, label) — the regex builder below produces both
+# content-first and property/name-first variants to handle either attr order.
+# Logo-like URLs are rejected so the fallback chain keeps searching for a
+# real article image instead of returning a site banner.
+_IMAGE_META_PATTERNS = [
+    # OpenGraph standard
+    (r'property=["\']og:image["\']', "og:image"),
+    (r'property=["\']og:image:secure_url["\']', "og:image:secure_url"),
+    (r'property=["\']og:image:url["\']', "og:image:url"),
+    # Twitter Cards
+    (r'name=["\']twitter:image["\']', "twitter:image"),
+    (r'name=["\']twitter:image:src["\']', "twitter:image:src"),
+    # OpenGraph article namespace (used by some Korean/legacy publishers)
+    (r'property=["\']article:image["\']', "article:image"),
+    # Schema.org / Microdata
+    (r'itemprop=["\']image["\']', "itemprop=image"),
+]
+
+
 def _fetch_og_image(url: str, timeout: int = 8) -> str:
-    """Fetch only og:image from a URL (lightweight, no description)."""
+    """Fetch an article image URL from a page's meta tags.
+
+    Searches in priority order: og:image, og:image:secure_url, og:image:url,
+    twitter:image, twitter:image:src, article:image, itemprop=image, and
+    <link rel="image_src">. Returns the first URL that passes both
+    _is_valid_image_url (rejects placeholders/trackers) and is_logo_like_url
+    (rejects site logos/favicons). Returns empty string on network failure,
+    SSRF block, or when no valid article image is found.
+    """
     if not url:
         return ""
     try:
@@ -589,22 +617,37 @@ def _fetch_og_image(url: str, timeout: int = 8) -> str:
         )
         resp.raise_for_status()
         force_utf8_if_mislabelled(resp)
-        # Search in first 30KB of HTML for og:image via regex (faster than BS4)
+        # Search first 30KB only — meta tags live in <head>
         head_html = resp.text[:30_000]
-        for pattern in [
-            r'<meta[^>]+property=["\']og:image["\'][^>]+content=["\']([^"\']+)',
-            r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+property=["\']og:image',
-            r'<meta[^>]+name=["\']twitter:image["\'][^>]+content=["\']([^"\']+)',
-            r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+name=["\']twitter:image',
-        ]:
-            match = re.search(pattern, head_html, re.IGNORECASE)
-            if match:
-                img_url = match.group(1).strip()
-                if not img_url.startswith(("http://", "https://")):
-                    logger.debug("og:image blocked unsafe scheme: %s", img_url[:80])
-                    continue
-                if _is_valid_image_url(img_url):
-                    return img_url
+
+        def _accept(img_url: str) -> bool:
+            img_url = img_url.strip()
+            if not img_url.startswith(("http://", "https://")):
+                return False
+            if not _is_valid_image_url(img_url):
+                return False
+            if is_logo_like_url(img_url):
+                return False
+            return True
+
+        for attr_pattern, _label in _IMAGE_META_PATTERNS:
+            # Try both attribute orders (property-first or content-first)
+            for regex in (
+                rf'<meta[^>]+{attr_pattern}[^>]+content=["\']([^"\']+)',
+                rf'<meta[^>]+content=["\']([^"\']+)["\'][^>]+{attr_pattern}',
+            ):
+                match = re.search(regex, head_html, re.IGNORECASE)
+                if match and _accept(match.group(1)):
+                    return match.group(1).strip()
+
+        # <link rel="image_src" href="..."> — Pinterest/legacy schema
+        link_match = re.search(
+            r'<link[^>]+rel=["\']image_src["\'][^>]+href=["\']([^"\']+)',
+            head_html,
+            re.IGNORECASE,
+        )
+        if link_match and _accept(link_match.group(1)):
+            return link_match.group(1).strip()
     except Exception as exc:
         logger.debug("og:image fetch failed for %s: %s", url, exc)
     return ""

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -913,6 +913,88 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == ""
 
+    @patch("common.enrichment.requests.get")
+    def test_og_image_secure_url_used(self, mock_get):
+        """og:image:secure_url should be picked when og:image is absent."""
+        from common.enrichment import _fetch_og_image
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.text = (
+            '<meta property="og:image:secure_url" content="https://cdn.example.com/secure.jpg"/>'
+        )
+        mock_get.return_value = mock_resp
+        result = _fetch_og_image("https://example.com/article")
+        assert result == "https://cdn.example.com/secure.jpg"
+
+    @patch("common.enrichment.requests.get")
+    def test_article_image_used(self, mock_get):
+        """article:image (OpenGraph article namespace) should be picked up."""
+        from common.enrichment import _fetch_og_image
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.text = (
+            '<meta property="article:image" content="https://cdn.example.com/article.jpg"/>'
+        )
+        mock_get.return_value = mock_resp
+        result = _fetch_og_image("https://example.com/article")
+        assert result == "https://cdn.example.com/article.jpg"
+
+    @patch("common.enrichment.requests.get")
+    def test_itemprop_image_used(self, mock_get):
+        """Schema.org itemprop=image should be used as a late fallback."""
+        from common.enrichment import _fetch_og_image
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.text = '<meta itemprop="image" content="https://cdn.example.com/schema.jpg"/>'
+        mock_get.return_value = mock_resp
+        result = _fetch_og_image("https://example.com/article")
+        assert result == "https://cdn.example.com/schema.jpg"
+
+    @patch("common.enrichment.requests.get")
+    def test_link_image_src_used(self, mock_get):
+        """<link rel="image_src"> legacy fallback should be picked up last."""
+        from common.enrichment import _fetch_og_image
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.text = '<link rel="image_src" href="https://cdn.example.com/link-src.jpg"/>'
+        mock_get.return_value = mock_resp
+        result = _fetch_og_image("https://example.com/article")
+        assert result == "https://cdn.example.com/link-src.jpg"
+
+    @patch("common.enrichment.requests.get")
+    def test_priority_og_over_twitter(self, mock_get):
+        """og:image must win over twitter:image when both are present."""
+        from common.enrichment import _fetch_og_image
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.text = (
+            '<meta name="twitter:image" content="https://cdn.example.com/tw.jpg"/>'
+            '<meta property="og:image" content="https://cdn.example.com/og.jpg"/>'
+        )
+        mock_get.return_value = mock_resp
+        result = _fetch_og_image("https://example.com/article")
+        assert result == "https://cdn.example.com/og.jpg"
+
+    @patch("common.enrichment.requests.get")
+    def test_logo_url_rejected_falls_through(self, mock_get):
+        """A logo-ish og:image should be skipped in favor of a later valid URL."""
+        from common.enrichment import _fetch_og_image
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.text = (
+            '<meta property="og:image" content="https://cdn.example.com/site-logo.png"/>'
+            '<meta name="twitter:image" content="https://cdn.example.com/hero.jpg"/>'
+        )
+        mock_get.return_value = mock_resp
+        result = _fetch_og_image("https://example.com/article")
+        assert result == "https://cdn.example.com/hero.jpg"
+
 
 # ---------------------------------------------------------------------------
 # fetch_images_concurrent extended — lines 279-293


### PR DESCRIPTION
## Summary

- `_fetch_og_image` 우선순위 체인 2 → 7단계 확장
  - og:image → og:image:secure_url → og:image:url → twitter:image → twitter:image:src → article:image → itemprop=image → `<link rel="image_src">`
- 로고성 URL(`is_logo_like_url`) 자동 스킵 후 다음 패턴 시도
- `_IMAGE_META_PATTERNS` 상수로 패턴 관리, `_accept` 헬퍼로 검증 일원화

## Context

PR #709에서 fetch_images_concurrent 예산을 60으로 늘렸지만, 각 페이지가 `og:image`/`twitter:image`만 가지는 건 아님. 한국 언론사(`article:image`), 레거시 스키마(`itemprop=image`, `<link rel="image_src">`), 최신 스펙(`og:image:secure_url`, `og:image:url`)도 실제로 사용되는데 놓치고 있었음.

## 테스트

- 기존 7건 + 신규 6건 = 13 TestFetchOgImage 케이스
- 신규: secure_url, article:image, itemprop, link rel=image_src, 우선순위(og > twitter), logo 스킵 후 fallthrough

## Test plan

- [x] `python3 -m ruff check` — All checks passed
- [x] `python3 -m pytest tests/test_enrichment.py tests/test_enrichment_utils.py tests/test_summarizer.py` — 614 passed
- [ ] 다음 수집 사이클 후 favicon 폴백 비율 재측정 (현재 23% → 15% 이하 기대)

🤖 Generated with [Claude Code](https://claude.com/claude-code)