### PR TITLE
feat(enrichment): 로고 패턴 정밀화 + match_logo_pattern API

### DIFF
--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -31,6 +31,7 @@ __all__ = [
     "generate_synthetic_description",
     "is_logo_like_url",
     "is_private_url",
+    "match_logo_pattern",
 ]
 
 # Cache for resolved Google News URLs to avoid redundant lookups
@@ -527,9 +528,11 @@ _BAD_IMAGE_PATTERNS = [
 # Note: .webp is intentionally excluded — webp images are valid content images
 _BAD_IMAGE_EXTENSIONS = [".gif", ".svg", ".ico"]
 
-# Logo/icon URL patterns — mirror scripts/common/summarizer.py:_LOGO_URL_PATTERNS.
-# When an RSS feed ships only a site logo, we should still try to fetch a proper
-# og:image so the post thumbnail reflects real article content.
+# Logo/icon URL patterns. When an RSS feed ships only a site logo, we should
+# still try to fetch a proper og:image so the post thumbnail reflects real
+# article content. Size patterns (256x256, 64x64, …) were removed in the
+# A-lite iteration: they conflict with OG standard image sizes and never
+# contributed a real logo rejection in recent measurements.
 _LOGO_URL_PATTERNS = (
     "/logo/",
     "/logos/",
@@ -542,11 +545,6 @@ _LOGO_URL_PATTERNS = (
     "-logo.",
     "_logo.",
     "logo%20",
-    "256x256",
-    "128x128",
-    "64x64",
-    "32x32",
-    "16x16",
 )
 
 
@@ -565,12 +563,25 @@ def _is_valid_image_url(url: str) -> bool:
     return True
 
 
+def match_logo_pattern(url: str) -> str | None:
+    """Return the matched logo/icon substring for *url*, or None.
+
+    Exposes which pattern fired so callers can log or bucket rejections
+    by cause. The boolean wrapper ``is_logo_like_url`` stays the public
+    yes/no API to preserve callers' existing truthy-check semantics.
+    """
+    if not url:
+        return None
+    url_lower = url.lower()
+    for pattern in _LOGO_URL_PATTERNS:
+        if pattern in url_lower:
+            return pattern
+    return None
+
+
 def is_logo_like_url(url: str) -> bool:
     """Return True if *url* looks like a site logo/icon rather than article art."""
-    if not url:
-        return False
-    url_lower = url.lower()
-    return any(pattern in url_lower for pattern in _LOGO_URL_PATTERNS)
+    return match_logo_pattern(url) is not None
 
 
 # Meta tag patterns for article image extraction, tried in priority order.

--- a/tests/test_enrichment_logo.py
+++ b/tests/test_enrichment_logo.py
@@ -1,0 +1,94 @@
+"""Logo URL pattern precision regression tests.
+
+Covers the RALPLAN A-lite change:
+1. Six pattern-match cases (one per pattern family still in _LOGO_URL_PATTERNS).
+2. Two pattern-miss cases (real article image, empty string).
+3. Two size-pattern removal checks (256x256 and 64x64 must now pass).
+4. Two API-contract checks (match_logo_pattern return type + is_logo_like_url
+   boolean identity with match_logo_pattern).
+"""
+
+import sys
+from pathlib import Path
+
+# Allow `from common.enrichment import ...` when running tests from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from common.enrichment import is_logo_like_url, match_logo_pattern  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Pattern match cases (6) — one per retained pattern family
+# ---------------------------------------------------------------------------
+
+
+def test_favicon_matches():
+    assert match_logo_pattern("https://www.google.com/s2/favicons?domain=x") == "/favicon"
+
+
+def test_logo_directory_matches():
+    assert match_logo_pattern("https://cdn.example.com/logo/site-banner.png") == "/logo/"
+
+
+def test_dash_logo_dot_matches():
+    assert match_logo_pattern("https://cdn.example.com/assets/site-logo.png") == "-logo."
+
+
+def test_underscore_logo_dot_matches():
+    assert match_logo_pattern("https://cdn.example.com/assets/site_logo.png") == "_logo."
+
+
+def test_snslogo_matches():
+    assert match_logo_pattern("https://www.etoday.co.kr/_var/snslogo.png") == "snslogo"
+
+
+def test_default_logo_matches():
+    assert match_logo_pattern("https://example.com/default-logo.png") == "default-logo"
+
+
+# ---------------------------------------------------------------------------
+# Pattern miss cases (2) — real article images
+# ---------------------------------------------------------------------------
+
+
+def test_real_article_image_returns_none():
+    assert match_logo_pattern("https://cdn.sanity.io/images/photo-hero.jpg") is None
+
+
+def test_empty_string_returns_none():
+    assert match_logo_pattern("") is None
+
+
+# ---------------------------------------------------------------------------
+# Size-pattern removal (2) — these used to be flagged, now must pass through
+# ---------------------------------------------------------------------------
+
+
+def test_256x256_path_no_longer_flagged():
+    """RALPLAN A-lite removed size tokens — OG-standard 256x256 must pass."""
+    assert match_logo_pattern("https://cdn.example.com/img/256x256/hero.jpg") is None
+
+
+def test_64x64_path_no_longer_flagged():
+    assert match_logo_pattern("https://cdn.example.com/64x64/banner.png") is None
+
+
+# ---------------------------------------------------------------------------
+# API contract (2) — return type + boolean identity
+# ---------------------------------------------------------------------------
+
+
+def test_match_logo_pattern_return_type():
+    hit = match_logo_pattern("https://cdn.example.com/logo/x.png")
+    miss = match_logo_pattern("https://cdn.example.com/article-hero.jpg")
+    assert isinstance(hit, str)
+    assert miss is None
+
+
+def test_is_logo_like_url_matches_bool_of_match_logo_pattern():
+    samples = [
+        "https://www.google.com/s2/favicons?domain=x",
+        "https://cdn.sanity.io/images/photo-hero.jpg",
+        "",
+    ]
+    for url in samples:
+        assert is_logo_like_url(url) is (match_logo_pattern(url) is not None)


### PR DESCRIPTION
## Summary

RALPLAN 컨센서스 승인 계획(Option A-lite) 1단계 구현.

- `_LOGO_URL_PATTERNS`에서 크기 5종(`256x256`, `128x128`, `64x64`, `32x32`, `16x16`) 제거
- 신규 `match_logo_pattern(url) -> str | None` API — 매칭된 패턴을 반환해 카운터/로거에서 cause 버킷팅 가능
- `is_logo_like_url`은 `match_logo_pattern`의 bool 래퍼로 축약 (시그니처 불변)
- `__all__`에 `match_logo_pattern` 추가
- outdated "mirror" 주석 삭제 (summarizer는 PR #710/#711로 단일 출처화 완료)

## Context

크기 패턴은 OG 표준 이미지 크기(256x256 등)와 충돌 가능. 최근 60 포스트 × 80 unique URL 실측에서 크기 패턴이 진짜 로고를 잡은 케이스 0건. Architect + Critic 양측이 "설계상 코드 스멜" + "즉시 제거 정당화" 동의.

## 계획 문서

`.omc/plans/ralplan-logo-detection-accuracy.md` (로컬 ADR, gitignored)
- Planner → Architect (ITERATE → 수정) → Critic APPROVED

## Test plan

- [x] `python3 -m ruff check` — All checks passed
- [x] `python3 -m pytest tests/test_enrichment_logo.py tests/test_enrichment.py tests/test_summarizer.py` — 504 passed
- [x] 신규 12 케이스: 패턴 매치 6 + 미매치 2 + 크기 제거 검증 2 + API 계약 2

## 다음 단계 (본 PR 아님)

- PR-2: 호출부 3곳에 `match_logo_pattern` 사용한 `logger.debug` + `log_collection_summary(extras=...)` 집계
- W6 gate 정량 조건(주간 FN ≥2 × 2주, `/logo/` WoW >30%, 또는 favicon 외 주당 ≥5건) 충족 시 Option B 트리거

🤖 Generated with [Claude Code](https://claude.com/claude-code)