### PR TITLE
feat(enrichment): 1x1 패턴 path-segment regex로 전환 (FP 방지)

### DIFF
--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -512,7 +512,6 @@ _BROWSER_UA = _USER_AGENT
 
 # Tracking pixels and placeholder image URL patterns
 _BAD_IMAGE_PATTERNS = [
-    "1x1",
     "pixel",
     "tracker",
     "beacon",
@@ -524,6 +523,11 @@ _BAD_IMAGE_PATTERNS = [
     "gravatar.com/avatar",
     "wp-content/plugins",
 ]
+# "1x1" must match as a path/filename token (tracking pixel), not a bare substring.
+# A substring check previously flagged article slugs like "/articles/1x1-interview.jpg"
+# as tracking pixels. This regex requires 1x1 to be bounded by a path separator on
+# the left AND followed by an extension / query marker / end-of-string on the right.
+_BAD_IMAGE_REGEX = re.compile(r"(?:^|[/_-])1x1(?:\.[a-z0-9]{2,4}|[?#]|$)")
 # Non-image file extensions to reject (.gif is often a tracking pixel; .svg/.ico are usually logos)
 # Note: .webp is intentionally excluded — webp images are valid content images
 _BAD_IMAGE_EXTENSIONS = [".gif", ".svg", ".ico"]
@@ -554,6 +558,8 @@ def _is_valid_image_url(url: str) -> bool:
         return False
     url_lower = url.lower()
     if any(p in url_lower for p in _BAD_IMAGE_PATTERNS):
+        return False
+    if _BAD_IMAGE_REGEX.search(url_lower):
         return False
     if any(url_lower.endswith(ext) for ext in _BAD_IMAGE_EXTENSIONS):
         # Allow large gif if it has a meaningful path length

--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -1386,9 +1386,7 @@ class ThemeSummarizer:
                     else:
                         lines.append(f"<li>{item}</li>")
                 if remaining_count > OVERFLOW_PREVIEW_LIMIT:
-                    lines.append(
-                        f"<li><em>...외 {remaining_count - OVERFLOW_PREVIEW_LIMIT}건</em></li>"
-                    )
+                    lines.append(f"<li><em>...외 {remaining_count - OVERFLOW_PREVIEW_LIMIT}건</em></li>")
                 lines.append("</ol></div></details>\n")
 
             lines.append("")

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -74,6 +74,58 @@ class TestIsValidImageUrl:
         assert _is_valid_image_url(long_webp)
 
 
+class TestBadImagePatternPrecision:
+    """Regression: 1x1 substring match previously flagged legitimate article URLs.
+
+    Converted to path-segment regex so only tracking-pixel filenames are rejected
+    while article slugs containing "1x1" (e.g., "1-on-1 interview" written as
+    "1x1") pass through. See enrichment._BAD_IMAGE_REGEX.
+    """
+
+    # --- tracking pixels (must still be rejected) ---------------------------
+
+    def test_rejects_bare_1x1_png_on_path(self):
+        # Only 1x1 drives rejection — no other bad substring present in host/path.
+        assert not _is_valid_image_url("https://images.cdn.io/assets/1x1.png")
+
+    def test_rejects_hyphen_prefixed_1x1_filename(self):
+        assert not _is_valid_image_url("https://images.cdn.io/ad-1x1.png")
+
+    def test_rejects_underscore_prefixed_1x1_filename(self):
+        assert not _is_valid_image_url("https://images.cdn.io/ad_1x1.png")
+
+    def test_rejects_1x1_with_query_string(self):
+        assert not _is_valid_image_url("https://serve.cdn.io/1x1?campaign=abc")
+
+    def test_rejects_1x1_at_path_end(self):
+        assert not _is_valid_image_url("https://serve.cdn.io/proxy/1x1")
+
+    # --- FP regression (legitimate article URLs must now pass) --------------
+
+    def test_allows_1x1_prefixed_article_slug(self):
+        """Article about '1-on-1' (written '1x1') must not be flagged."""
+        url = "https://cdn.example.com/articles/1x1-interview-with-ceo.jpg"
+        assert _is_valid_image_url(url)
+
+    def test_allows_1x1_midword_in_article_slug(self):
+        url = "https://cdn.example.com/research/summit-1x1-report.webp"
+        assert _is_valid_image_url(url)
+
+    def test_allows_11x1_digit_run(self):
+        """Previous substring check rejected anything containing '1x1' — 11x1 too."""
+        url = "https://cdn.example.com/galleries/11x1.webp"
+        assert _is_valid_image_url(url)
+
+    def test_allows_1x1_as_directory_segment(self):
+        """A path segment named '1x1' followed by '/' (not extension) is allowed."""
+        url = "https://cdn.example.com/gallery-1x1/photo.jpg"
+        assert _is_valid_image_url(url)
+
+    def test_allows_alnum_embedded_1x1(self):
+        url = "https://cdn.example.com/hash/a1x1b.jpg"
+        assert _is_valid_image_url(url)
+
+
 class TestCleanDescription:
     """Validate description text cleaning."""
 

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -1036,9 +1036,7 @@ class TestFetchOgImage:
 
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
-        mock_resp.text = (
-            '<meta property="og:image:secure_url" content="https://cdn.example.com/secure.jpg"/>'
-        )
+        mock_resp.text = '<meta property="og:image:secure_url" content="https://cdn.example.com/secure.jpg"/>'
         mock_get.return_value = mock_resp
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/secure.jpg"
@@ -1050,9 +1048,7 @@ class TestFetchOgImage:
 
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
-        mock_resp.text = (
-            '<meta property="article:image" content="https://cdn.example.com/article.jpg"/>'
-        )
+        mock_resp.text = '<meta property="article:image" content="https://cdn.example.com/article.jpg"/>'
         mock_get.return_value = mock_resp
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/article.jpg"

--- a/tests/test_summarizer_helpers.py
+++ b/tests/test_summarizer_helpers.py
@@ -13,7 +13,6 @@ from scripts.common.summarizer import (
     _classify_news_severity,
     _favicon_url,
     _fix_mistranslations,
-    _is_logo_url,
 )
 
 # ---------------------------------------------------------------------------
@@ -125,59 +124,12 @@ class TestFixMistranslations:
             assert wrong not in result
 
 
-# ---------------------------------------------------------------------------
-# _is_logo_url
-# ---------------------------------------------------------------------------
-
-
-class TestIsLogoUrl:
-    def test_empty_string_returns_false(self):
-        assert _is_logo_url("") is False
-
-    def test_logo_path_returns_true(self):
-        assert _is_logo_url("https://example.com/logo/site-logo.png") is True
-
-    def test_logos_path_returns_true(self):
-        assert _is_logo_url("https://cdn.example.com/logos/brand.svg") is True
-
-    def test_favicon_returns_true(self):
-        assert _is_logo_url("https://example.com/favicon.ico") is True
-
-    def test_icon_path_returns_true(self):
-        assert _is_logo_url("https://example.com/icon/app-icon.png") is True
-
-    def test_icon_dimensions_256_returns_true(self):
-        assert _is_logo_url("https://example.com/image-256x256.png") is True
-
-    def test_icon_dimensions_128_returns_true(self):
-        assert _is_logo_url("https://example.com/image-128x128.png") is True
-
-    def test_icon_dimensions_64_returns_true(self):
-        assert _is_logo_url("https://example.com/image-64x64.png") is True
-
-    def test_icon_dimensions_32_returns_true(self):
-        assert _is_logo_url("https://example.com/image-32x32.png") is True
-
-    def test_icon_dimensions_16_returns_true(self):
-        assert _is_logo_url("https://example.com/image-16x16.png") is True
-
-    def test_snslogo_returns_true(self):
-        assert _is_logo_url("https://example.com/snslogo.jpg") is True
-
-    def test_dash_logo_returns_true(self):
-        assert _is_logo_url("https://cdn.example.com/brand-logo.png") is True
-
-    def test_underscore_logo_returns_true(self):
-        assert _is_logo_url("https://cdn.example.com/brand_logo.png") is True
-
-    def test_article_image_returns_false(self):
-        assert _is_logo_url("https://example.com/articles/bitcoin-article.jpg") is False
-
-    def test_regular_image_returns_false(self):
-        assert _is_logo_url("https://cdn.example.com/photos/news-photo.jpg") is False
-
-    def test_case_insensitive(self):
-        assert _is_logo_url("https://example.com/FAVICON.PNG") is True
+# NOTE: _is_logo_url test class removed — the function was retired in #741
+# (로고 패턴 정밀화 + match_logo_pattern API A-lite). Logo detection is now
+# covered by tests/test_enrichment_logo.py against match_logo_pattern /
+# is_logo_like_url, which summarizer.py consumes via `from .enrichment import
+# is_logo_like_url`. Size-dimension patterns (256x256, 64x64, etc.) were
+# intentionally dropped in A-lite as false-positive-prone OG image conflicts.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_BAD_IMAGE_PATTERNS`의 naive `1x1` substring 매칭으로 인한 False Positive 제거
- `/articles/1x1-interview.jpg` 같은 "1-on-1" 의미의 기사 슬러그가 트래킹 픽셀로 오분류되던 문제 해결
- 실제 트래킹 픽셀 (`/1x1.gif`, `-1x1.png`, `/ad_1x1.png` 등)은 계속 차단

## Changes

- `scripts/common/enrichment.py`
  - `_BAD_IMAGE_PATTERNS`에서 `"1x1"` 제거
  - `_BAD_IMAGE_REGEX = r"(?:^|[/_-])1x1(?:\.[a-z0-9]{2,4}|[?#]|$)"` 신설 — 경로 구분자로 감싸이고 확장자/쿼리/EOS로 마무리될 때만 매치
  - `_is_valid_image_url`에 regex 검사 추가
- `tests/test_enrichment.py`
  - `TestBadImagePatternPrecision` 클래스 신설 (10개 테스트)
  - 거부 5개: `/assets/1x1.png`, `-1x1.png`, `_1x1.png`, `?campaign=x`, path-end
  - 허용 5개: `1x1-interview-*.jpg`, `summit-1x1-report.webp`, `11x1.webp`, `gallery-1x1/photo.jpg`, `a1x1b.jpg`

## Precision analysis

| 케이스 | 이전 | 이후 |
|--------|------|------|
| `tracker.com/1x1.gif` | ❌ reject | ❌ reject |
| `/ad-1x1.png` | ❌ reject | ❌ reject |
| `/articles/1x1-interview.jpg` | ❌ reject (FP) | ✅ allow |
| `/summit-1x1-report.webp` | ❌ reject (FP) | ✅ allow |
| `/galleries/11x1.webp` | ❌ reject (FP) | ✅ allow |

## Test plan

- [x] `python3 -m ruff check scripts/` — clean
- [x] `python3 -m pytest tests/test_enrichment.py tests/test_enrichment_logo.py` — 358 passed
- [x] 새로 추가된 10개 precision 테스트 모두 통과
- [ ] CI 통과 확인
- [ ] 내일 cron 사이클(2026-04-22 09:10 KST) 이후 신규 포스트에서 FP 감소 실측

## Related

- #741 feat(enrichment): 로고 패턴 정밀화 + match_logo_pattern API (A-lite) 후속 precision 패스
- 다음 단계: match_bad_image_pattern API 대칭화 (별도 PR 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)