### PR TITLE
feat(enrichment): match_bad_image_pattern API 신설 + 로그 버킷팅 (A-lite follow-up)

### DIFF
--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -31,6 +31,7 @@ __all__ = [
     "generate_synthetic_description",
     "is_logo_like_url",
     "is_private_url",
+    "match_bad_image_pattern",
     "match_logo_pattern",
 ]
 
@@ -528,6 +529,10 @@ _BAD_IMAGE_PATTERNS = [
 # as tracking pixels. This regex requires 1x1 to be bounded by a path separator on
 # the left AND followed by an extension / query marker / end-of-string on the right.
 _BAD_IMAGE_REGEX = re.compile(r"(?:^|[/_-])1x1(?:\.[a-z0-9]{2,4}|[?#]|$)")
+# Synthetic bucket token returned by match_bad_image_pattern when the 1x1 regex
+# fires. All size-marker variants collapse to this single metric key so callers
+# counting rejections get stable bucketing across /1x1.gif, -1x1.png, /1x1?... etc.
+_BAD_IMAGE_REGEX_BUCKET = "1x1-pixel"
 # Non-image file extensions to reject (.gif is often a tracking pixel; .svg/.ico are usually logos)
 # Note: .webp is intentionally excluded — webp images are valid content images
 _BAD_IMAGE_EXTENSIONS = [".gif", ".svg", ".ico"]
@@ -552,19 +557,41 @@ _LOGO_URL_PATTERNS = (
 )
 
 
+def match_bad_image_pattern(url: str) -> str | None:
+    """Return the matched bad-image pattern token for *url*, or None.
+
+    Exposes which pattern fired so callers can log or bucket image
+    rejections by cause. Substring matches from ``_BAD_IMAGE_PATTERNS``
+    return the matched substring verbatim; the 1x1 tracking-pixel regex
+    returns the synthetic bucket token ``"1x1-pixel"`` so all size-marker
+    variants (``/1x1.gif``, ``-1x1.png``, ``/1x1?...``) collapse to a
+    single metric key. Symmetric with :func:`match_logo_pattern`.
+    """
+    if not url:
+        return None
+    url_lower = url.lower()
+    for pattern in _BAD_IMAGE_PATTERNS:
+        if pattern in url_lower:
+            return pattern
+    if _BAD_IMAGE_REGEX.search(url_lower):
+        return _BAD_IMAGE_REGEX_BUCKET
+    return None
+
+
 def _is_valid_image_url(url: str) -> bool:
     """Check if a URL is likely a valid, useful image (not a placeholder/tracking pixel)."""
     if not _has_http_image_scheme(url):
         return False
+    bad = match_bad_image_pattern(url)
+    if bad is not None:
+        logger.debug("image rejected: bad_pattern=%s url=%s", bad, url[:80])
+        return False
     url_lower = url.lower()
-    if any(p in url_lower for p in _BAD_IMAGE_PATTERNS):
-        return False
-    if _BAD_IMAGE_REGEX.search(url_lower):
-        return False
     if any(url_lower.endswith(ext) for ext in _BAD_IMAGE_EXTENSIONS):
         # Allow large gif if it has a meaningful path length
         if len(url) > 80:
             return True
+        logger.debug("image rejected: bad_extension=%s url=%s", url_lower[-5:], url[:80])
         return False
     return True
 

--- a/tests/test_enrichment_bad_image.py
+++ b/tests/test_enrichment_bad_image.py
@@ -57,17 +57,11 @@ def test_blank_substring_matches():
 
 
 def test_gravatar_substring_matches():
-    assert (
-        match_bad_image_pattern("https://gravatar.com/avatar/abc123")
-        == "gravatar.com/avatar"
-    )
+    assert match_bad_image_pattern("https://gravatar.com/avatar/abc123") == "gravatar.com/avatar"
 
 
 def test_wp_plugin_substring_matches():
-    assert (
-        match_bad_image_pattern("https://example.com/wp-content/plugins/share.png")
-        == "wp-content/plugins"
-    )
+    assert match_bad_image_pattern("https://example.com/wp-content/plugins/share.png") == "wp-content/plugins"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_enrichment_bad_image.py
+++ b/tests/test_enrichment_bad_image.py
@@ -1,0 +1,149 @@
+"""Bad image pattern (tracking pixel / placeholder) regression tests.
+
+Symmetric with ``tests/test_enrichment_logo.py``. Covers the
+``match_bad_image_pattern`` API added in the A-lite follow-up:
+
+1. Substring-pattern cases — one per retained family in ``_BAD_IMAGE_PATTERNS``.
+2. Regex-bucketed 1x1 tracking pixel cases — all variants collapse to the
+   synthetic token ``"1x1-pixel"`` for metric bucketing.
+3. Miss cases — real article images and empty string return ``None``.
+4. API contract — return type and boolean identity with ``_is_valid_image_url``
+   behavior for logged rejection paths.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from common.enrichment import _is_valid_image_url, match_bad_image_pattern  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Substring-pattern match cases — one per family in _BAD_IMAGE_PATTERNS
+# ---------------------------------------------------------------------------
+
+
+def test_pixel_substring_matches():
+    assert match_bad_image_pattern("https://ads.example.com/pixel/track.png") == "pixel"
+
+
+def test_tracker_substring_matches():
+    assert match_bad_image_pattern("https://tracker.example.com/beacon.png") == "tracker"
+
+
+def test_beacon_substring_matches():
+    # Hostname lacks "tracker" so "beacon" wins — independent of tracker pattern.
+    assert match_bad_image_pattern("https://ads.cdn.io/beacon-hit.png") == "beacon"
+
+
+def test_spacer_substring_matches():
+    assert match_bad_image_pattern("https://cdn.example.com/spacer.gif") == "spacer"
+
+
+def test_placeholder_substring_matches():
+    assert match_bad_image_pattern("https://cdn.example.com/placeholder.png") == "placeholder"
+
+
+def test_default_image_substring_matches():
+    assert match_bad_image_pattern("https://cdn.example.com/default-image.jpg") == "default-image"
+
+
+def test_no_image_substring_matches():
+    assert match_bad_image_pattern("https://cdn.example.com/no-image.png") == "no-image"
+
+
+def test_blank_substring_matches():
+    assert match_bad_image_pattern("https://cdn.example.com/blank.gif") == "blank."
+
+
+def test_gravatar_substring_matches():
+    assert (
+        match_bad_image_pattern("https://gravatar.com/avatar/abc123")
+        == "gravatar.com/avatar"
+    )
+
+
+def test_wp_plugin_substring_matches():
+    assert (
+        match_bad_image_pattern("https://example.com/wp-content/plugins/share.png")
+        == "wp-content/plugins"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regex-bucketed 1x1 tracking pixel cases — all collapse to "1x1-pixel"
+# ---------------------------------------------------------------------------
+
+
+def test_1x1_bare_filename_returns_pixel_bucket():
+    assert match_bad_image_pattern("https://images.cdn.io/assets/1x1.png") == "1x1-pixel"
+
+
+def test_1x1_hyphen_prefixed_returns_pixel_bucket():
+    assert match_bad_image_pattern("https://images.cdn.io/ad-1x1.png") == "1x1-pixel"
+
+
+def test_1x1_underscore_prefixed_returns_pixel_bucket():
+    assert match_bad_image_pattern("https://images.cdn.io/ad_1x1.png") == "1x1-pixel"
+
+
+def test_1x1_with_query_string_returns_pixel_bucket():
+    assert match_bad_image_pattern("https://serve.cdn.io/1x1?campaign=x") == "1x1-pixel"
+
+
+def test_1x1_path_end_returns_pixel_bucket():
+    assert match_bad_image_pattern("https://serve.cdn.io/proxy/1x1") == "1x1-pixel"
+
+
+# ---------------------------------------------------------------------------
+# Miss cases — real article images and empty string return None
+# ---------------------------------------------------------------------------
+
+
+def test_real_article_image_returns_none():
+    assert match_bad_image_pattern("https://cdn.sanity.io/images/article-hero.jpg") is None
+
+
+def test_empty_string_returns_none():
+    assert match_bad_image_pattern("") is None
+
+
+def test_1x1_as_article_slug_fragment_returns_none():
+    """Article about 1-on-1 ('1x1') written in URL slug must not be flagged."""
+    url = "https://cdn.example.com/articles/1x1-interview-with-ceo.jpg"
+    assert match_bad_image_pattern(url) is None
+
+
+def test_11x1_digit_run_returns_none():
+    """Previous substring check rejected anything containing '1x1'; regex must not."""
+    assert match_bad_image_pattern("https://cdn.example.com/galleries/11x1.webp") is None
+
+
+# ---------------------------------------------------------------------------
+# API contract — return type + boolean identity with _is_valid_image_url
+# ---------------------------------------------------------------------------
+
+
+def test_match_bad_image_pattern_return_type():
+    hit = match_bad_image_pattern("https://cdn.example.com/1x1.png")
+    miss = match_bad_image_pattern("https://cdn.example.com/article-hero.jpg")
+    assert isinstance(hit, str)
+    assert miss is None
+
+
+def test_is_valid_image_url_mirrors_match_bad_image_pattern():
+    """When match_bad_image_pattern returns non-None, _is_valid_image_url must be False."""
+    samples = [
+        "https://ads.example.com/pixel/track.png",
+        "https://cdn.example.com/placeholder.png",
+        "https://images.cdn.io/assets/1x1.png",
+        "https://cdn.example.com/articles/1x1-interview.jpg",  # miss — FP regression
+        "https://cdn.sanity.io/images/article-hero.jpg",  # miss — real image
+    ]
+    for url in samples:
+        bad = match_bad_image_pattern(url)
+        valid = _is_valid_image_url(url)
+        # If bad pattern matched, URL must not be valid; converse isn't guaranteed
+        # (e.g., .gif extension also rejects via a separate rule).
+        if bad is not None:
+            assert valid is False, f"{url!r} matched {bad!r} but _is_valid_image_url=True"


### PR DESCRIPTION
## Summary

Stacked on #744. Adds `match_bad_image_pattern(url) -> str | None` — symmetric with `match_logo_pattern` from #741 — so image-rejection cause is inspectable, and adds `logger.debug` bucketing so callers can aggregate rejection-family metrics.

## Changes

**`scripts/common/enrichment.py`**
- `match_bad_image_pattern()` (new, public) — unifies `_BAD_IMAGE_PATTERNS` substring match with `_BAD_IMAGE_REGEX`. Substring matches return the matched pattern verbatim (e.g. `"pixel"`, `"blank."`); regex matches return `_BAD_IMAGE_REGEX_BUCKET` (`"1x1-pixel"`) so all 1x1 size-marker variants collapse to one metric key
- `_BAD_IMAGE_REGEX_BUCKET = "1x1-pixel"` — synthetic bucket constant extracted for symbolic reference (code-reviewer MEDIUM)
- `_is_valid_image_url` — refactored to call `match_bad_image_pattern`, emits `logger.debug("image rejected: bad_pattern=%s url=%s", ...)` / `bad_extension=%s` on rejection
- `__all__` += `match_bad_image_pattern`

**`tests/test_enrichment_bad_image.py`** (new, 21 tests — mirrors `test_enrichment_logo.py`)
- 10 substring-pattern families (pixel, tracker, beacon, spacer, placeholder, default-image, no-image, blank., gravatar, wp-content/plugins)
- 5 regex-bucketed 1x1 variants (`/1x1.png`, `-1x1.png`, `_1x1.png`, `?query`, path-end)
- 4 miss cases (real image, empty, 1x1-interview slug FP, 11x1 digit-run)
- 2 API contract (return type, `_is_valid_image_url` identity)

## API symmetry

| Aspect | `match_logo_pattern` (#741) | `match_bad_image_pattern` (this PR) |
|---|---|---|
| Signature | `(url: str) -> str \| None` | `(url: str) -> str \| None` |
| Empty guard | `if not url: return None` | `if not url: return None` |
| Case | `url.lower()` | `url.lower()` |
| Return | matched substring | matched substring or synthetic bucket |
| Wrapper | `is_logo_like_url` | `_is_valid_image_url` (negated) |

## Verification

- [x] `python3 -m ruff check scripts/` — clean
- [x] `python3 -m pytest tests/test_enrichment.py tests/test_enrichment_logo.py tests/test_enrichment_bad_image.py` — 379 passed
- [x] code-reviewer: APPROVE-WITH-NITS (MEDIUM resolved: `_BAD_IMAGE_REGEX_BUCKET` constant extraction)
- [ ] CI green
- [ ] Future: wire `match_bad_image_pattern` into `fetch_images_concurrent` / `fetch_page_metadata` for metrics aggregation (separate PR)

## Related

- #741 feat(enrichment): 로고 패턴 정밀화 + match_logo_pattern API
- #744 feat(enrichment): 1x1 패턴 path-segment regex로 전환 (FP 방지) — base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)