### PR TITLE
feat(metrics): image rejection 집계 + 주간 Slack 인라인 리포트

### DIFF
--- a/.github/workflows/generate-weekly-report.yml
+++ b/.github/workflows/generate-weekly-report.yml
@@ -59,6 +59,12 @@ jobs:
             git push
           fi
 
+      - name: Capture image-rejection summary for Slack payload
+        id: rejection
+        run: |
+          ONELINER="$(python scripts/generate_weekly_report.py --slack-oneliner || true)"
+          echo "oneliner=${ONELINER}" >> "$GITHUB_OUTPUT"
+
       - name: Resolve Slack config
         id: slack
         uses: ./.github/actions/resolve-slack-config
@@ -87,4 +93,4 @@ jobs:
           token: ${{ steps.slack.outputs.token }}
           payload: |
             channel: "${{ steps.slack.outputs.channel }}"
-            text: ":bar_chart: *Weekly Report* generated (run #${{ github.run_number }}) — https://github.com/Twodragon0/investing/tree/main/docs"
+            text: ":bar_chart: *Weekly Report* generated (run #${{ github.run_number }}) — https://github.com/Twodragon0/investing/tree/main/docs\n${{ steps.rejection.outputs.oneliner }}"

--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -14,6 +14,7 @@ import requests
 
 from .config import get_verify_ssl
 from .encoding_guard import force_utf8_if_mislabelled, sanitize_mojibake
+from .image_rejection_metrics import record_image_rejection
 from .markdown_utils import smart_truncate
 from .utils import is_private_url_target
 
@@ -585,13 +586,16 @@ def _is_valid_image_url(url: str) -> bool:
     bad = match_bad_image_pattern(url)
     if bad is not None:
         logger.debug("image rejected: bad_pattern=%s url=%s", bad, url[:80])
+        record_image_rejection("bad_image", bad)
         return False
     url_lower = url.lower()
-    if any(url_lower.endswith(ext) for ext in _BAD_IMAGE_EXTENSIONS):
+    matched_ext = next((ext for ext in _BAD_IMAGE_EXTENSIONS if url_lower.endswith(ext)), None)
+    if matched_ext is not None:
         # Allow large gif if it has a meaningful path length
         if len(url) > 80:
             return True
         logger.debug("image rejected: bad_extension=%s url=%s", url_lower[-5:], url[:80])
+        record_image_rejection("bad_image", f"ext:{matched_ext.lstrip('.')}")
         return False
     return True
 

--- a/scripts/common/image_rejection_metrics.py
+++ b/scripts/common/image_rejection_metrics.py
@@ -1,0 +1,184 @@
+"""Thread-safe, flock-guarded image rejection metrics aggregator.
+
+Records per-family, per-bucket rejection counts in-process and flushes them
+to a JSON state file on ``atexit``.  A file-level lock (``fcntl.flock``) makes
+concurrent flush calls from multiple OS processes safe.
+
+Kill-switch: set ``IMAGE_REJECTION_METRICS_ENABLED=0`` to make every public
+function a no-op.  The weekly report renderer emits a stub when disabled.
+
+Schema v1:
+    {
+        "schema_version": 1,
+        "families": {
+            "bad_image": {
+                "buckets": {"pixel": 3, "tracker": 1, ...}
+            }
+        },
+        "since": "ISO-8601",
+        "last_seen": "ISO-8601"
+    }
+"""
+
+import atexit
+import fcntl
+import json
+import os
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Dict
+
+from .config import setup_logging
+
+logger = setup_logging("image_rejection_metrics")
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+_LOCK: threading.Lock = threading.Lock()
+_IMAGE_REJECTION_COUNTS: Dict[str, Dict[str, int]] = {}
+_STATE_PATH: Path = Path("_state/image_rejection_metrics.json")
+_ARCHIVE_DIR: Path = Path("_state/archive")
+_SCHEMA_VERSION: int = 1
+_ENABLED: bool = os.environ.get("IMAGE_REJECTION_METRICS_ENABLED", "1") != "0"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def record_image_rejection(family: str, bucket: str) -> None:
+    """Increment the in-memory counter for *family* / *bucket*.
+
+    No-op when the kill-switch is active (``IMAGE_REJECTION_METRICS_ENABLED=0``).
+    Thread-safe: protected by ``_LOCK``.
+    """
+    if not _ENABLED:
+        return
+    with _LOCK:
+        if family not in _IMAGE_REJECTION_COUNTS:
+            _IMAGE_REJECTION_COUNTS[family] = {}
+        _IMAGE_REJECTION_COUNTS[family][bucket] = _IMAGE_REJECTION_COUNTS[family].get(bucket, 0) + 1
+
+
+def flush_to_state(path: Path | None = None) -> None:
+    """Merge in-memory counts into the JSON state file atomically.
+
+    Uses ``fcntl.flock(LOCK_EX)`` on a sidecar lock file so concurrent OS
+    processes do not corrupt the state.  Writes via tmp-file + rename for
+    crash-safety.  No-op when the kill-switch is active.
+    """
+    if not _ENABLED:
+        return
+
+    target = path if path is not None else _STATE_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = target.with_suffix(".lock")
+
+    with open(lock_path, "a") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            existing = _read_raw(target)
+            # Merge in-memory counts into existing state
+            with _LOCK:
+                snapshot = {f: dict(buckets) for f, buckets in _IMAGE_REJECTION_COUNTS.items()}
+            for family, buckets in snapshot.items():
+                fam_entry = existing["families"].setdefault(family, {"buckets": {}})
+                fam_buckets = fam_entry.setdefault("buckets", {})
+                for bucket, count in buckets.items():
+                    fam_buckets[bucket] = fam_buckets.get(bucket, 0) + count
+
+            existing["last_seen"] = _now_iso()
+            if not existing.get("since"):
+                existing["since"] = existing["last_seen"]
+
+            # Atomic write
+            tmp = target.with_suffix(".tmp")
+            tmp.write_text(json.dumps(existing, ensure_ascii=False, indent=2))
+            tmp.replace(target)
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+
+def load_state(path: Path | None = None) -> dict:
+    """Return the current on-disk state as a v1-shaped dict.
+
+    Coerces the legacy v0 flat shape ``{"buckets": {...}}`` into v1.
+    Returns an empty stub if the file is missing or unreadable.
+    """
+    target = path if path is not None else _STATE_PATH
+    return _read_raw(target)
+
+
+def reset_for_archive(week_label: str) -> Path:
+    """Rotate the live state file into ``_state/archive/`` and zero counters.
+
+    Creates the archive directory if it does not exist.  Returns the path of
+    the archived file.
+    """
+    target = _STATE_PATH
+    dest_dir = _ARCHIVE_DIR
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"image_rejection_metrics-{week_label}.json"
+
+    if target.exists():
+        target.replace(dest)
+
+    with _LOCK:
+        _IMAGE_REJECTION_COUNTS.clear()
+
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _empty_v1() -> dict:
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "families": {},
+        "since": "",
+        "last_seen": "",
+    }
+
+
+def _read_raw(path: Path) -> dict:
+    """Read and coerce the JSON state file to v1 shape.  Returns empty stub on error."""
+    if not path.exists():
+        return _empty_v1()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("image_rejection_metrics: could not read %s: %s", path, exc)
+        return _empty_v1()
+
+    # v0 flat shape: {"buckets": {...}} — no schema_version key
+    if "schema_version" not in data and "buckets" in data:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "families": {"bad_image": {"buckets": dict(data["buckets"])}},
+            "since": data.get("since", ""),
+            "last_seen": data.get("last_seen", ""),
+        }
+
+    # Already v1 (or future version) — return as-is, ensure families key exists
+    data.setdefault("schema_version", _SCHEMA_VERSION)
+    data.setdefault("families", {})
+    data.setdefault("since", "")
+    data.setdefault("last_seen", "")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Register atexit flush
+# ---------------------------------------------------------------------------
+atexit.register(flush_to_state)

--- a/scripts/generate_weekly_report.py
+++ b/scripts/generate_weekly_report.py
@@ -21,6 +21,8 @@ from typing import Dict, List, Tuple
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from common.config import get_kst_now, setup_logging
+from common.image_rejection_metrics import _ENABLED as _METRICS_ENABLED
+from common.image_rejection_metrics import load_state as _load_metrics_state
 
 logger = setup_logging("generate_weekly_report")
 
@@ -219,6 +221,64 @@ def ci_summary() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Image rejection metrics section
+# ---------------------------------------------------------------------------
+
+
+def _render_image_rejection_slack_oneliner() -> str:
+    """Return a single-line Slack-friendly summary of the top rejection buckets.
+
+    Format: ``"이미지 거부 Top3: pixel=42, tracker=18, 1x1-pixel=9"`` or ``""``
+    when metrics are disabled / no state yet. Intended for workflow capture
+    into the existing weekly Slack notification (no new chat.postMessage).
+    """
+    if not _METRICS_ENABLED:
+        return ""
+
+    state = _load_metrics_state()
+    families = state.get("families", {})
+    bad = families.get("bad_image", {}).get("buckets", {}) if families else {}
+    if not bad:
+        return ""
+
+    top3 = sorted(bad.items(), key=lambda kv: -kv[1])[:3]
+    parts = [f"{bucket}={count}" for bucket, count in top3]
+    return f"이미지 거부 Top3: {', '.join(parts)}"
+
+
+def _render_image_rejection_section() -> str:
+    """Return the weekly markdown section for image rejection metrics.
+
+    Emits a "disabled" stub when the kill-switch is active
+    (``IMAGE_REJECTION_METRICS_ENABLED=0``) or when no state file exists yet.
+    Otherwise renders a compact table of pattern family / bucket / count.
+    """
+    if not _METRICS_ENABLED:
+        return "## 이미지 거부 패턴 통계\n\n- 이 기간에는 metrics disabled 상태였습니다.\n"
+
+    state = _load_metrics_state()
+    families = state.get("families", {})
+    if not families:
+        return "## 이미지 거부 패턴 통계\n\n- 집계된 거부 이벤트 없음 (metrics disabled 기간 또는 신규 수집).\n"
+
+    lines: List[str] = ["## 이미지 거부 패턴 통계\n"]
+    since = state.get("since", "")
+    last_seen = state.get("last_seen", "")
+    if since or last_seen:
+        lines.append(f"- 기간: {since or '?'} ~ {last_seen or '?'}")
+        lines.append("")
+
+    lines.append("| 패밀리 | 버킷 | 건수 |")
+    lines.append("|--------|------|------|")
+    for family, entry in sorted(families.items()):
+        buckets = entry.get("buckets", {})
+        for bucket, count in sorted(buckets.items(), key=lambda kv: -kv[1]):
+            lines.append(f"| {family} | {bucket} | {count} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Report builder
 # ---------------------------------------------------------------------------
 
@@ -279,7 +339,10 @@ def build_report(
         lines.append("| (데이터 없음) | 0 |")
     lines.append("")
 
-    # 4. 버그 수정 및 개선
+    # 4. 이미지 거부 패턴 통계 (match_bad_image_pattern / match_logo_pattern)
+    lines.append(_render_image_rejection_section())
+
+    # 5. 버그 수정 및 개선
     lines.append("## 버그 수정 및 개선\n")
     lines.append("### 수정된 버그")
     lines.append("- (이번 주 수정 사항을 직접 입력하세요)")
@@ -326,7 +389,16 @@ def main() -> int:
         action="store_true",
         help="Overwrite existing report file",
     )
+    parser.add_argument(
+        "--slack-oneliner",
+        action="store_true",
+        help="Print a one-line image-rejection summary to stdout and exit (for workflow capture)",
+    )
     args = parser.parse_args()
+
+    if args.slack_oneliner:
+        print(_render_image_rejection_slack_oneliner())
+        return 0
 
     if args.week_offset < 0:
         logger.error("--week-offset must be >= 0")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+import pytest
+
 # Add scripts/ to path so `from common.X import Y` works
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 if SCRIPTS_DIR not in sys.path:
@@ -12,3 +14,55 @@ if SCRIPTS_DIR not in sys.path:
 TOOLS_DIR = os.path.join(SCRIPTS_DIR, "tools")
 if TOOLS_DIR not in sys.path:
     sys.path.insert(0, TOOLS_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Module-level: redirect image_rejection_metrics state to a tmp dir BEFORE any
+# test imports the module, so the module's ``atexit`` flush (which runs at
+# interpreter shutdown, AFTER per-test monkeypatch has been restored) cannot
+# pollute the committed ``_state/image_rejection_metrics.json``.
+# ---------------------------------------------------------------------------
+try:
+    import tempfile
+    from pathlib import Path as _Path
+
+    import common.image_rejection_metrics as _irm_a
+
+    _IRM_TEST_DIR = _Path(tempfile.mkdtemp(prefix="inv_irm_test_"))
+    _STATE_TMP = _IRM_TEST_DIR / "image_rejection_metrics.json"
+    _ARCHIVE_TMP = _IRM_TEST_DIR / "archive"
+
+    _irm_a._STATE_PATH = _STATE_TMP
+    _irm_a._ARCHIVE_DIR = _ARCHIVE_TMP
+
+    # Some tests import via `scripts.common.*` (e.g. test_summarizer_helpers.py),
+    # which registers a distinct module object in sys.modules from `common.*`.
+    # Patch both namespaces so the atexit flush cannot target the repo state.
+    try:
+        import scripts.common.image_rejection_metrics as _irm_b
+
+        if _irm_b is not _irm_a:
+            _irm_b._STATE_PATH = _STATE_TMP
+            _irm_b._ARCHIVE_DIR = _ARCHIVE_TMP
+    except ImportError:
+        pass
+except ImportError:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _isolate_image_rejection_state(tmp_path, monkeypatch):
+    """Redirect image_rejection_metrics state + archive paths to a per-test tmp dir.
+
+    The module registers an ``atexit`` flush that would otherwise pollute the
+    committed ``_state/image_rejection_metrics.json`` during local and CI test
+    runs. Routing both paths to a throwaway location preserves the module's
+    contract without touching production state. Individual tests can still
+    override via ``monkeypatch.setattr`` when they need to assert the path.
+    """
+    try:
+        import common.image_rejection_metrics as m
+    except ImportError:
+        return
+    monkeypatch.setattr(m, "_STATE_PATH", tmp_path / "image_rejection_metrics.json")
+    monkeypatch.setattr(m, "_ARCHIVE_DIR", tmp_path / "archive")

--- a/tests/test_image_rejection_metrics.py
+++ b/tests/test_image_rejection_metrics.py
@@ -1,0 +1,307 @@
+"""TDD tests for scripts/common/image_rejection_metrics.py.
+
+All tests must FAIL before the implementation exists (ImportError or AttributeError).
+Run: PYTHONPATH=scripts python3 -m pytest tests/test_image_rejection_metrics.py --no-cov -v
+"""
+
+import concurrent.futures
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+# Allow `from common.X import Y` when running from repo root
+_SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+
+# ---------------------------------------------------------------------------
+# Helper: reset module-level state between tests so counters don't bleed.
+# ---------------------------------------------------------------------------
+
+
+def _reset_module():
+    """Reset in-memory counters and re-evaluate kill switch for isolation."""
+
+    import common.image_rejection_metrics as m
+
+    with m._LOCK:
+        m._IMAGE_REJECTION_COUNTS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: record_increments_bucket — happy path, single-thread
+# ---------------------------------------------------------------------------
+
+
+def test_record_increments_bucket():
+    import common.image_rejection_metrics as m
+
+    _reset_module()
+    m.record_image_rejection("bad_image", "pixel")
+    m.record_image_rejection("bad_image", "pixel")
+    m.record_image_rejection("bad_image", "tracker")
+    with m._LOCK:
+        assert m._IMAGE_REJECTION_COUNTS["bad_image"]["pixel"] == 2
+        assert m._IMAGE_REJECTION_COUNTS["bad_image"]["tracker"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 2: concurrent 8 threads, 10k total calls split across 3 distinct buckets
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_8_threads_10k_calls_per_bucket():
+    import common.image_rejection_metrics as m
+
+    _reset_module()
+
+    buckets = ["pixel", "tracker", "beacon"]
+    calls_per_bucket = 10_000 // len(buckets)  # ~3333 each
+
+    def _call(family_bucket):
+        family, bucket = family_bucket
+        m.record_image_rejection(family, bucket)
+
+    tasks = [("bad_image", b) for b in buckets for _ in range(calls_per_bucket)]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+        list(ex.map(_call, tasks))
+
+    with m._LOCK:
+        counts = m._IMAGE_REJECTION_COUNTS.get("bad_image", {})
+        for b in buckets:
+            assert counts.get(b) == calls_per_bucket, f"bucket={b!r} expected={calls_per_bucket} got={counts.get(b)}"
+        total = sum(counts.values())
+        assert total == calls_per_bucket * len(buckets)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: flock 2-process mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_flock_2_process_mutual_exclusion(tmp_path):
+    """Spawn 2 subprocesses each calling flush_to_state() with distinct counters.
+
+    After both finish, state file must be valid JSON with schema_version=1
+    and no partial writes.
+    """
+    state_file = tmp_path / "image_rejection_metrics.json"
+
+    # Helper script each subprocess will run
+    helper_code = textwrap.dedent(
+        """
+        import sys, os, json
+        sys.path.insert(0, sys.argv[1])
+        os.environ["IMAGE_REJECTION_METRICS_ENABLED"] = "1"
+
+        import common.image_rejection_metrics as m
+        m._STATE_PATH = __import__('pathlib').Path(sys.argv[2])
+
+        family = sys.argv[3]
+        bucket = sys.argv[4]
+        count = int(sys.argv[5])
+
+        with m._LOCK:
+            m._IMAGE_REJECTION_COUNTS.setdefault(family, {})[bucket] = count
+
+        m.flush_to_state()
+        """
+    ).strip()
+
+    helper_path = tmp_path / "helper.py"
+    helper_path.write_text(helper_code)
+
+    scripts_dir = str(Path(__file__).resolve().parent.parent / "scripts")
+
+    p1 = subprocess.Popen(
+        [
+            sys.executable,
+            str(helper_path),
+            scripts_dir,
+            str(state_file),
+            "bad_image",
+            "pixel",
+            "7",
+        ]
+    )
+    p2 = subprocess.Popen(
+        [
+            sys.executable,
+            str(helper_path),
+            scripts_dir,
+            str(state_file),
+            "bad_image",
+            "tracker",
+            "3",
+        ]
+    )
+    p1.wait(timeout=30)
+    p2.wait(timeout=30)
+
+    assert state_file.exists(), "state file not created by either subprocess"
+    raw = state_file.read_text()
+    data = json.loads(raw)  # raises if partial/corrupt write
+    assert data.get("schema_version") == 1
+    families = data.get("families", {})
+    assert "bad_image" in families
+
+
+# ---------------------------------------------------------------------------
+# Test 4: kill-switch — record is a no-op when disabled
+# ---------------------------------------------------------------------------
+
+
+def test_kill_switch_record_is_noop(monkeypatch):
+
+    # Must reload to pick up env change at module init time
+    monkeypatch.setenv("IMAGE_REJECTION_METRICS_ENABLED", "0")
+    import common.image_rejection_metrics as m
+
+    # Force re-evaluate _ENABLED
+    monkeypatch.setattr(m, "_ENABLED", False)
+    _reset_module()
+
+    m.record_image_rejection("bad_image", "pixel")
+    with m._LOCK:
+        assert "bad_image" not in m._IMAGE_REJECTION_COUNTS
+
+
+# ---------------------------------------------------------------------------
+# Test 5: kill-switch — _render_image_rejection_section emits disabled stub
+# ---------------------------------------------------------------------------
+
+
+def test_kill_switch_report_emits_stub(monkeypatch, tmp_path):
+    import common.image_rejection_metrics as m
+
+    monkeypatch.setattr(m, "_ENABLED", False)
+
+    # Import the weekly report module and call the section renderer
+    scripts_dir = str(Path(__file__).resolve().parent.parent / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    import generate_weekly_report as report
+
+    result = report._render_image_rejection_section()
+    assert "disabled" in result.lower() or "metrics disabled" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: schema v1 load
+# ---------------------------------------------------------------------------
+
+
+def test_schema_v1_load(tmp_path):
+    import common.image_rejection_metrics as m
+
+    state_file = tmp_path / "image_rejection_metrics.json"
+    v1_data = {
+        "schema_version": 1,
+        "families": {
+            "bad_image": {
+                "buckets": {"pixel": 5, "tracker": 2},
+            }
+        },
+        "since": "2026-01-01T00:00:00",
+        "last_seen": "2026-01-07T00:00:00",
+    }
+    state_file.write_text(json.dumps(v1_data))
+
+    result = m.load_state(path=state_file)
+    assert result["schema_version"] == 1
+    assert "bad_image" in result["families"]
+    bad = result["families"]["bad_image"]
+    assert bad.get("buckets", {}).get("pixel") == 5 or bad.get("pixel") == 5
+
+
+# ---------------------------------------------------------------------------
+# Test 7: schema v0 flat fallback
+# ---------------------------------------------------------------------------
+
+
+def test_schema_v0_flat_fallback(tmp_path):
+    import common.image_rejection_metrics as m
+
+    state_file = tmp_path / "image_rejection_metrics.json"
+    v0_data = {"buckets": {"pixel": 10, "tracker": 3}}
+    state_file.write_text(json.dumps(v0_data))
+
+    result = m.load_state(path=state_file)
+    assert result["schema_version"] == 1
+    families = result.get("families", {})
+    assert "bad_image" in families
+    bad_buckets = families["bad_image"].get("buckets", families["bad_image"])
+    assert bad_buckets.get("pixel") == 10
+
+
+# ---------------------------------------------------------------------------
+# Test 8: reset_for_archive creates parent dir and archives file
+# ---------------------------------------------------------------------------
+
+
+def test_reset_for_archive_creates_parent_dir(tmp_path, monkeypatch):
+    import common.image_rejection_metrics as m
+
+    # Redirect state and archive paths to tmp_path
+    state_file = tmp_path / "image_rejection_metrics.json"
+    archive_dir = tmp_path / "archive"
+
+    monkeypatch.setattr(m, "_STATE_PATH", state_file)
+    monkeypatch.setattr(m, "_ARCHIVE_DIR", archive_dir)
+
+    # Seed state file
+    state_file.write_text(json.dumps({"schema_version": 1, "families": {"bad_image": {"buckets": {"pixel": 3}}}}))
+
+    assert not archive_dir.exists()
+    m.reset_for_archive("2026-W17")
+
+    assert archive_dir.exists()
+    archived = list(archive_dir.glob("image_rejection_metrics-*.json"))
+    assert len(archived) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 9: symmetry with match_bad_image_pattern (PR #747 contract lock)
+# ---------------------------------------------------------------------------
+
+
+def test_symmetry_with_match_bad_image_pattern():
+    """Feed URLs through _is_valid_image_url and verify rejection tokens match.
+
+    _IMAGE_REJECTION_COUNTS["bad_image"] must contain exactly the pattern
+    tokens returned by match_bad_image_pattern for rejected URLs.
+    """
+    import common.image_rejection_metrics as m
+    from common.enrichment import _is_valid_image_url, match_bad_image_pattern
+
+    _reset_module()
+
+    test_urls = [
+        "https://tracker.com/pixel.png",  # matches "pixel"
+        "https://analytics.com/beacon.gif",  # matches "beacon"
+        "https://cdn.example.com/article-hero.jpg",  # valid — no rejection
+        "https://example.com/spacer.gif",  # matches "spacer"
+        "https://media.site.com/photo.jpg",  # valid — no rejection
+    ]
+
+    expected_patterns = set()
+    for url in test_urls:
+        # Call purely for its side effect of recording rejection bucket
+        _is_valid_image_url(url)
+        token = match_bad_image_pattern(url)
+        if token is not None:
+            expected_patterns.add(token)
+
+    with m._LOCK:
+        recorded = m._IMAGE_REJECTION_COUNTS.get("bad_image", {})
+
+    for token in expected_patterns:
+        assert token in recorded, (
+            f"Expected rejected token {token!r} in _IMAGE_REJECTION_COUNTS but got {dict(recorded)}"
+        )


### PR DESCRIPTION
## Summary

Ralplan 합의 플랜 (`/.omc/plans/image-rejection-metrics.md` v2, Planner/Architect/Critic APPROVE) 구현.

이미지 거부 사유(pattern family)를 Counter로 누적하고, 주간 리포트에 마크다운 섹션 + 기존 Slack post의 `text:` 페이로드에 one-liner inline 주입.

## 변경 파일 (6)

### 신규
- `scripts/common/image_rejection_metrics.py` (190 LOC) — 스레드/프로세스 안전 Counter + state 관리
- `tests/test_image_rejection_metrics.py` (314 LOC, 9 tests)

### 수정
- `scripts/common/enrichment.py` — `_is_valid_image_url` 함수명 기준 2-line hot-path hook (Critic nit #1)
- `scripts/generate_weekly_report.py` — `_render_image_rejection_section()` + `_render_image_rejection_slack_oneliner()` + `--slack-oneliner` CLI
- `.github/workflows/generate-weekly-report.yml` — `rejection.outputs.oneliner` capture 스텝 + 기존 Slack post text 인라인 주입
- `tests/conftest.py` — autouse fixture + module-level `_STATE_PATH`/`_ARCHIVE_DIR` tmp 리다이렉트 (scripts.common.* namespace 포함)

## 핵심 설계

| 요소 | 구현 |
|------|------|
| 스레드 안전 | `_LOCK = threading.Lock()` wrapping dict mutation |
| 프로세스 안전 | `fcntl.flock(LOCK_EX)` on sidecar lock file + tmp+rename 원자 쓰기 |
| 스키마 | v1 `{"schema_version": 1, "families": {"bad_image": {"buckets": {...}}}, "since", "last_seen"}` — v0 flat fallback 지원 |
| 킬 스위치 | `IMAGE_REJECTION_METRICS_ENABLED=0` — record/report 양측 no-op/stub |
| Slack | 기존 post에 `\n${{ steps.rejection.outputs.oneliner }}` inline (새 post 없음) |

## Critic nit 3건 모두 반영

1. **함수명 기준 hot-path 타겟팅** — 라인 기반 참조 제거
2. **per-bucket + sum 병행 단언** — race로 한 bucket 누락되고 다른 bucket 중복 집계되는 시나리오 감지
3. **2-process flock smoke test** — `subprocess.Popen` × 2 → 동시 flush → schema_version=1 JSON 무결성 검증

## 검증

- [x] `python3 -m ruff check scripts/ tests/` — clean
- [x] `python3 -m ruff format --check scripts/ tests/` — clean
- [x] `PYTHONPATH=scripts python3 -m pytest tests/` — **3954 passed** (기존 3945 + 신규 9)
- [x] `--slack-oneliner` CLI 스모크: `이미지 거부 Top3: 1x1-pixel=18, ext:gif=12, pixel=10`
- [x] Test isolation: 전체 테스트 후 `_state/image_rejection_metrics.json` 오염 없음
- [ ] CI green
- [ ] 내일 09:10 KST cron 사이클 이후 실제 family별 분포 관측

## 관련

- #741 `match_logo_pattern` API
- #744 1x1 path-segment regex (FP 방지)
- #747 `match_bad_image_pattern` API
- Plan: `/.omc/plans/image-rejection-metrics.md` (v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)