### PR TITLE
fix(risk): risk_classifier import 경로 수정 (모든 수집기 실패 해결)

### DIFF
--- a/scripts/common/risk_classifier.py
+++ b/scripts/common/risk_classifier.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from scripts.common.config import setup_logging
+from .config import setup_logging
 
 setup_logging()
 logger = logging.getLogger(__name__)

--- a/scripts/common/risk_classifier.py
+++ b/scripts/common/risk_classifier.py
@@ -323,7 +323,7 @@ def _resolve_source_weight(source: str) -> float:
     """Return base weight for a source string using 6-type classification."""
     # Lazy import to avoid circular dependency with markdown_utils
     try:
-        from scripts.common.markdown_utils import _classify_source  # type: ignore[import]
+        from .markdown_utils import _classify_source  # type: ignore[import]
 
         src_type = _classify_source(source)
         weight = _SOURCE_TYPE_WEIGHTS.get(src_type, 1.0)

--- a/tests/test_import_compatibility.py
+++ b/tests/test_import_compatibility.py
@@ -1,0 +1,211 @@
+"""Regression tests for import compatibility.
+
+Guards against the recurrence of `from scripts.common.X import Y` style absolute
+imports in scripts/common/ modules. These fail when scripts are executed directly
+(e.g. `python scripts/collect_crypto_news.py`) because `scripts/` is not always
+on sys.path as a package root. All imports must use either:
+  - relative imports inside scripts/common/  (from .X import Y)
+  - package-relative imports in collector scripts  (from common.X import Y)
+
+Related fix: PR #773 (fix/risk-classifier-import branch).
+"""
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# All scripts/common/ modules — imported via `from common.X import ...`
+# (conftest.py adds scripts/ to sys.path, so this matches real collector usage)
+# ---------------------------------------------------------------------------
+
+COMMON_MODULES = [
+    "common.base_collector",
+    "common.bettafish_analyzer",
+    "common.blockchain_api",
+    "common.browser",
+    "common.collector_config",
+    "common.collector_metrics",
+    "common.config",
+    "common.content_filters",
+    "common.crypto_api",
+    "common.dedup",
+    "common.encoding_guard",
+    "common.enrichment",
+    "common.entity_extractor",
+    "common.fmp_api",
+    "common.formatters",
+    "common.image_rejection_metrics",
+    "common.markdown_utils",
+    "common.mindspider",
+    "common.post_generator",
+    "common.risk_classifier",
+    "common.rss_fetcher",
+    "common.signal_composer",
+    "common.signal_tracker",
+    "common.summarizer",
+    "common.time_series_state",
+    "common.translator",
+    "common.utils",
+    "common.worldmonitor_utils",
+]
+
+
+@pytest.mark.parametrize("module_name", COMMON_MODULES)
+def test_common_module_importable(module_name):
+    """Each scripts/common/ module must be importable without ImportError.
+
+    This catches any `from scripts.common.X import Y` style imports that break
+    when running collectors directly (without scripts/ as a package root).
+    """
+    try:
+        importlib.import_module(module_name)
+    except ImportError as exc:
+        pytest.fail(
+            f"ImportError importing {module_name!r}: {exc}\n"
+            "Likely cause: absolute 'from scripts.common.X import Y' in module. "
+            "Fix by using relative imports (from .X import Y) inside scripts/common/."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Subprocess tests — simulate running collectors as __main__ scripts.
+# Uses --help / a no-op dry path so no real I/O or API calls are made.
+# CWD is set to repo root (parent of scripts/), matching real CI execution.
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = pytest.importorskip  # just to verify pytest is importable
+
+
+def _repo_root() -> str:
+    """Return the repository root path."""
+    import os
+
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+COLLECTOR_SCRIPTS = [
+    "scripts/collect_crypto_news.py",
+    "scripts/collect_stock_news.py",
+]
+
+
+@pytest.mark.parametrize("script_path", COLLECTOR_SCRIPTS)
+def test_collector_script_imports_cleanly(script_path):
+    """Collector scripts must not raise ImportError on startup.
+
+    Runs `python -c "import importlib.util; ..."` to load the module without
+    executing the main guard, then checks the exit code. This replicates the
+    real execution environment (CWD=repo root, python path without scripts/).
+    """
+    repo_root = _repo_root()
+
+    # We run a minimal Python snippet that:
+    # 1. Does NOT add scripts/ to sys.path (replicating bare `python scripts/X.py`)
+    # 2. Adds only the repo root (so relative `from common.X` works via scripts/ dir)
+    # 3. Imports the script as a spec/module without running __main__
+    snippet = (
+        "import sys, importlib.util; "
+        f"sys.path.insert(0, '{repo_root}/scripts'); "
+        f"spec = importlib.util.spec_from_file_location('_col', '{repo_root}/{script_path}'); "
+        "mod = importlib.util.module_from_spec(spec); "
+        "spec.loader.exec_module(mod)"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        timeout=30,
+    )
+
+    if result.returncode != 0:
+        # Filter for ImportError specifically to avoid failing on missing env vars
+        # or other runtime errors that are expected in a no-API-key environment.
+        stderr = result.stderr
+        if "ImportError" in stderr or "ModuleNotFoundError" in stderr:
+            pytest.fail(
+                f"Import error running {script_path!r}:\n{stderr}\n"
+                "Fix by using 'from common.X import Y' (not 'from scripts.common.X import Y')."
+            )
+        # Non-import runtime errors (missing API keys, etc.) are expected — pass.
+
+
+# ---------------------------------------------------------------------------
+# Explicit regression test: risk_classifier must not use scripts.common imports
+# ---------------------------------------------------------------------------
+
+
+def test_risk_classifier_no_absolute_scripts_import():
+    """risk_classifier.py must not contain 'from scripts.common' anywhere.
+
+    This is the exact pattern fixed in PR #773. Guard against regression.
+    """
+    import os
+
+    risk_classifier_path = os.path.join(
+        _repo_root(), "scripts", "common", "risk_classifier.py"
+    )
+    with open(risk_classifier_path, encoding="utf-8") as f:
+        source = f.read()
+
+    assert "from scripts.common" not in source, (
+        "risk_classifier.py contains 'from scripts.common' absolute import. "
+        "This breaks direct script execution. Use relative imports (from .X import Y)."
+    )
+    assert "import scripts.common" not in source, (
+        "risk_classifier.py contains 'import scripts.common' absolute import. "
+        "Use relative imports instead."
+    )
+
+
+def test_no_absolute_scripts_imports_in_common():
+    """No file in scripts/common/ should use 'from scripts.' or 'import scripts.' imports.
+
+    Scans all .py files in scripts/common/ for the banned patterns.
+    Docstrings are excluded via a simple heuristic (lines starting with spaces
+    inside triple-quoted blocks are allowed — but the import line itself must
+    not appear as a real statement).
+    """
+    import ast
+    import os
+
+    common_dir = os.path.join(_repo_root(), "scripts", "common")
+    violations = []
+
+    for fname in sorted(os.listdir(common_dir)):
+        if not fname.endswith(".py"):
+            continue
+        fpath = os.path.join(common_dir, fname)
+        with open(fpath, encoding="utf-8") as f:
+            source = f.read()
+
+        try:
+            tree = ast.parse(source, filename=fpath)
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            # Check `from scripts.common.X import Y`
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module.startswith("scripts."):
+                    violations.append(
+                        f"{fname}:{node.lineno}: from {module} import ..."
+                    )
+            # Check `import scripts.common.X`
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith("scripts."):
+                        violations.append(
+                            f"{fname}:{node.lineno}: import {alias.name}"
+                        )
+
+    assert not violations, (
+        "Found absolute 'scripts.*' imports in scripts/common/ (breaks direct execution):\n"
+        + "\n".join(f"  {v}" for v in violations)
+        + "\nFix: use relative imports (from .X import Y) inside scripts/common/."
+    )

--- a/tests/test_import_compatibility.py
+++ b/tests/test_import_compatibility.py
@@ -146,9 +146,7 @@ def test_risk_classifier_no_absolute_scripts_import():
     """
     import os
 
-    risk_classifier_path = os.path.join(
-        _repo_root(), "scripts", "common", "risk_classifier.py"
-    )
+    risk_classifier_path = os.path.join(_repo_root(), "scripts", "common", "risk_classifier.py")
     with open(risk_classifier_path, encoding="utf-8") as f:
         source = f.read()
 
@@ -157,8 +155,7 @@ def test_risk_classifier_no_absolute_scripts_import():
         "This breaks direct script execution. Use relative imports (from .X import Y)."
     )
     assert "import scripts.common" not in source, (
-        "risk_classifier.py contains 'import scripts.common' absolute import. "
-        "Use relative imports instead."
+        "risk_classifier.py contains 'import scripts.common' absolute import. Use relative imports instead."
     )
 
 
@@ -193,16 +190,12 @@ def test_no_absolute_scripts_imports_in_common():
             if isinstance(node, ast.ImportFrom):
                 module = node.module or ""
                 if module.startswith("scripts."):
-                    violations.append(
-                        f"{fname}:{node.lineno}: from {module} import ..."
-                    )
+                    violations.append(f"{fname}:{node.lineno}: from {module} import ...")
             # Check `import scripts.common.X`
             elif isinstance(node, ast.Import):
                 for alias in node.names:
                     if alias.name.startswith("scripts."):
-                        violations.append(
-                            f"{fname}:{node.lineno}: import {alias.name}"
-                        )
+                        violations.append(f"{fname}:{node.lineno}: import {alias.name}")
 
     assert not violations, (
         "Found absolute 'scripts.*' imports in scripts/common/ (breaks direct execution):\n"


### PR DESCRIPTION
## Summary

🚨 **Hotfix**: 2026-04-23 00:00 UTC 이후 모든 수집기 워크플로우가 `ModuleNotFoundError` 로 실패하여 신규 포스트가 중단된 상태. 즉시 머지 권장.

## Root Cause

`scripts/common/risk_classifier.py:14` 가 `from scripts.common.config import setup_logging` 로 작성됨. GitHub Actions 수집기는 `PYTHONPATH=scripts` 로 실행되어 `scripts.common.*` 네임스페이스가 존재하지 않음. `risk_classifier` 를 lazy-import 하는 `summarizer.py` 경유로 13개 collector 전체가 실패.

```
File "scripts/common/risk_classifier.py", line 14, in <module>
    from scripts.common.config import setup_logging
ModuleNotFoundError: No module named 'scripts'
```

## Fix

```diff
-from scripts.common.config import setup_logging
+from .config import setup_logging
```

다른 `common/*` 모듈 관행(`enrichment.py`, `summarizer.py` 등)과 일치.

## Impact

| 환경 | 이전 | 이후 |
|------|------|------|
| `PYTHONPATH=scripts python -c "from common.risk_classifier import ..."` | ❌ ModuleNotFoundError | ✅ OK |
| `pytest tests/test_risk_classifier.py` | ✅ (pytest는 repo root 기반) | ✅ 68 passed |
| GitHub Actions 수집기 | ❌ all fail | ✅ 복구 예상 |

## Verification

- [x] ruff check + format clean
- [x] `PYTHONPATH=scripts python -c "from common.risk_classifier import classify_risk"` → OK
- [x] `pytest tests/test_risk_classifier.py tests/test_risk_cases_fixtures.py` → 68 passed
- [ ] CI green
- [ ] Merge 후 다음 cron 사이클에서 수집기 복구 확인

## Related

- 도입 커밋: b6730d9d `feat(risk): risk_classifier 모듈 + 53 tests (P4 Phase 1)`
- 기존 Plan: `docs/critical-alert-redesign.md` — 해당 문서도 relative import (`from .risk_classifier import ...`)를 사용하도록 설계됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)