### PR TITLE
fix(regulatory): 연속 실패 알림 + 세계 최대 정규식 오탐 제거

### DIFF
--- a/.github/workflows/collect-regulatory.yml
+++ b/.github/workflows/collect-regulatory.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 concurrency:
   group: collect-regulatory
@@ -29,3 +30,68 @@ jobs:
           script: scripts/collect_regulatory.py
           commit-message: 'chore: collect regulatory news'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    # Detect 3+ consecutive failures to catch silent multi-day outages
+    # (e.g. the 2026-04-21~23 risk_classifier import regression that went
+    # unnoticed until manual inspection — see PR #773).
+    needs: collect
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 1
+
+      - name: Check previous run conclusions
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Count failures in the last 2 completed runs excluding the current one.
+          # Combined with the current failure, 2+ previous failures = 3+ consecutive.
+          prev_failures=$(gh run list \
+            --workflow "Collect Regulatory News" \
+            --limit 3 \
+            --json conclusion,databaseId \
+            --repo "${{ github.repository }}" | \
+            jq --arg id "${{ github.run_id }}" \
+              '[.[] | select(.databaseId != ($id | tonumber)) | select(.conclusion == "failure")] | length')
+          echo "prev_failures=${prev_failures}" >> "$GITHUB_OUTPUT"
+          if [ "${prev_failures:-0}" -ge 2 ]; then
+            echo "alert=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "alert=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve Slack config
+        if: steps.check.outputs.alert == 'true'
+        id: slack
+        uses: ./.github/actions/resolve-slack-config
+        with:
+          target_channel_alias: investing
+          token_candidates: |
+            ${{ secrets.SLACK_BOT_TOKEN }}
+            ${{ secrets.AI_SLACK_BOT_TOKEN }}
+            ${{ secrets.SLACK_TOKEN }}
+          channel_candidates_investing: |
+            ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
+            ${{ secrets.AI_SLACK_CHANNEL_ID_INVESTING }}
+            ${{ secrets.SLACK_CHANNEL_INVESTING }}
+            ${{ secrets.SLACK_CHANNEL_ID }}
+            ${{ secrets.AI_SLACK_CHANNEL_ID }}
+            ${{ secrets.SLACK_CHANNEL }}
+
+      - name: Post consecutive failure alert to Slack
+        if: steps.check.outputs.alert == 'true' && steps.slack.outputs.can_post == 'true'
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ steps.slack.outputs.token }}
+          payload: |
+            channel: "${{ steps.slack.outputs.channel }}"
+            text: ":rotating_light: [${{ steps.slack.outputs.profile_label }}] Collect Regulatory News failed 3+ consecutive runs. Investigate: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/scripts/check_description_quality.py
+++ b/scripts/check_description_quality.py
@@ -67,7 +67,15 @@ _SITE_BOILERPLATE_PATTERNS = [
         re.I,
     ),
     re.compile(r"^(?:the )?(?:latest|breaking|live|real-time) (?:news|updates?|prices?)\b", re.I),
-    re.compile(r"(?:세계 최대|글로벌 리더|세계적인 리더)", re.I),
+    # Keep in sync with scripts/common/enrichment.py:_SITE_BOILERPLATE_PATTERNS.
+    # Anchored to end-of-string copula to avoid false positives on factual
+    # news like "세계 최대 생산업체인 카렉스는…".
+    re.compile(
+        r"(?:세계 최대|글로벌 리더|세계적인 리더)"
+        r"[^.!?\n]{0,40}"
+        r"\s*(?:입니다|을 제공(?:합니다)?|를 제공(?:합니다)?)\s*\.?\s*$",
+        re.I,
+    ),
     re.compile(r"(?:에 참여하세요|구독하세요|가입하세요)$", re.I),
     re.compile(r"\d+년 (?:넘게|이상) .{0,40}(?:제공|서비스)", re.I),
 ]

--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -53,8 +53,15 @@ _SITE_BOILERPLATE_PATTERNS = [
         re.I,
     ),
     re.compile(r"^(?:the )?(?:latest|breaking|live|real-time) (?:news|updates?|prices?)\b", re.I),
-    # Korean patterns: translated site descriptions
-    re.compile(r"(?:세계 최대|글로벌 리더|세계적인 리더)", re.I),
+    # Korean patterns: translated site self-descriptions.
+    # Anchored to end-of-string copula ("입니다"/"제공합니다") to avoid false
+    # positives on factual news quoting (e.g. "세계 최대 생산업체인 카렉스는…").
+    re.compile(
+        r"(?:세계 최대|글로벌 리더|세계적인 리더)"
+        r"[^.!?\n]{0,40}"
+        r"\s*(?:입니다|을 제공(?:합니다)?|를 제공(?:합니다)?)\s*\.?\s*$",
+        re.I,
+    ),
     re.compile(r"(?:에 참여하세요|구독하세요|가입하세요)$", re.I),
     re.compile(r"\d+년 (?:넘게|이상) .{0,40}(?:제공|서비스)", re.I),
 ]

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -2449,6 +2449,34 @@ class TestIsSiteBoilerplate:
         # Under 35 chars BUT contains a number with unit
         assert _is_site_boilerplate("지수 5% 하락") is False
 
+    # ------------------------------------------------------------------
+    # Regression: false-positive on factual "세계 최대" (2026-04-23 worldmonitor)
+    # ------------------------------------------------------------------
+
+    def test_factual_global_largest_mid_sentence_not_boilerplate(self):
+        """News quoting "세계 최대 생산업체..." should not trigger the Korean regex.
+
+        The original pattern `(?:세계 최대|글로벌 리더|세계적인 리더)` had no
+        anchor and matched factual third-party descriptors, flagging 2026-04-23
+        worldmonitor briefing as boilerplate. The new pattern requires
+        end-of-string copula (입니다/제공합니다).
+        """
+        desc = (
+            "글로벌 20건 수집. 사회/기타, 지정학/안보, 금융시장 등 주요 테마 분석. "
+            "세계 최대 생산업체인 카렉스는 이란 전쟁으로 콘돔 가격이 30% 오를 수 등 "
+            "핵심 이슈 포함. GDELT·Polymarket 등 데이터 참조."
+        )
+        assert _is_site_boilerplate(desc) is False
+
+    def test_global_largest_self_promo_still_flagged(self):
+        """Self-promo "세계 최대의 … 플랫폼입니다." must still be flagged."""
+        assert _is_site_boilerplate("세계 최대의 실시간 암호화폐 뉴스 플랫폼입니다.") is True
+
+    def test_global_leader_self_promo_ending_still_flagged(self):
+        """Self-promo "세계적인 리더입니다." ending must still match."""
+        desc = "CNBC는 비즈니스, 기술, 시장에 관한 뉴스를 제공하는 세계적인 리더입니다."
+        assert _is_site_boilerplate(desc) is True
+
 
 # =============================================================================
 # _is_desc_duplicate_of_title

--- a/tests/test_risk_classifier.py
+++ b/tests/test_risk_classifier.py
@@ -8,6 +8,8 @@ Layer 4: classify_risk integration (3+ tests)
 
 from __future__ import annotations
 
+import pathlib
+
 from scripts.common.risk_classifier import (
     _AMOUNT_RE,
     P0_ITEM_THRESHOLD,
@@ -19,6 +21,63 @@ from scripts.common.risk_classifier import (
     extract_signals,
     score_item,
 )
+
+# ---------------------------------------------------------------------------
+# Regression: #773 — risk_classifier.py must use relative imports.
+# ---------------------------------------------------------------------------
+
+
+def test_risk_classifier_uses_relative_imports():
+    """risk_classifier.py must import config via relative import.
+
+    Regression for PR #773. The absolute form `from scripts.common.config`
+    fails with ModuleNotFoundError when collect_regulatory.py invokes
+    summarizer.py which lazy-imports risk_classifier in package context
+    (the `scripts` namespace is not on sys.path at that point).
+    """
+    src_path = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "common"
+        / "risk_classifier.py"
+    )
+    content = src_path.read_text(encoding="utf-8")
+    assert "from scripts.common" not in content, (
+        "risk_classifier.py must use relative imports (regression for #773)"
+    )
+    assert "from .config import" in content, (
+        "risk_classifier.py must import config via relative import (from .config)"
+    )
+
+
+def test_risk_classifier_lazy_import_chain_works():
+    """Exercise summarizer's lazy `from .risk_classifier import classify_risk`.
+
+    Regression for #773. The production failure chain was:
+        collect_regulatory.py
+          → ThemeSummarizer.generate_executive_summary()
+            → self._assess_risk_level(priority_items)
+              → `from .risk_classifier import classify_risk`  # lazy
+                → risk_classifier.py top-level `from scripts.common.config …`
+                → ModuleNotFoundError: No module named 'scripts'
+
+    If risk_classifier ever re-acquires an absolute `scripts.*` import,
+    re-importing it here will raise ModuleNotFoundError and fail this test.
+    """
+    import importlib
+    import sys
+
+    # Drop cached risk_classifier so its top-level imports are re-executed.
+    sys.modules.pop("scripts.common.risk_classifier", None)
+
+    # Summarizer lazy-imports risk_classifier from inside _assess_risk_level.
+    from scripts.common import summarizer as _summarizer  # noqa: F401
+
+    module = importlib.import_module("scripts.common.risk_classifier")
+    assert callable(module.classify_risk)
+
+    verdict = module.classify_risk(items=[], priority_items={})
+    assert verdict.level in {"critical", "elevated", "normal", "low"}
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures


### PR DESCRIPTION
## Summary
- `collect-regulatory.yml`: **3회 연속 실패 감지 시 Slack 알림** job 추가 — 2026-04-21~23에 `risk_classifier` import 오류로 6일간 장애가 무감지로 이어진 사고 재발 방지
- `enrichment.py` + `check_description_quality.py`: `(세계 최대|글로벌 리더|세계적인 리더)` 정규식에 end-of-string copula(`입니다`/`제공합니다`) 앵커 추가 → 뉴스 본문 인용("세계 최대 생산업체인 카렉스…") 오탐 제거
- `test_enrichment.py`: 사실 인용 vs 사이트 자기홍보 구분 회귀 테스트 3건 추가
- `test_risk_classifier.py`: #773 relative-import 회귀 테스트 2건 추가 (absolute 경로 감지 + lazy-import 체인 검증)

## Impact
- Description 품질: **96.9% → 100%** (32/32 real content, 최근 3일)
- Regulatory 수집 연속 실패 시 Slack에 즉시 경고 → 장애 인지 시간 단축

## Test plan
- [x] `pytest tests/test_enrichment.py tests/test_risk_classifier.py tests/test_check_description_quality.py` 462 passed
- [x] `ruff check` 수정된 4개 Python 파일 모두 clean
- [x] `python scripts/check_description_quality.py --days 3` → 100% real content 확인
- [x] `yaml.safe_load(.github/workflows/collect-regulatory.yml)` syntax OK
- [ ] (배포 후) Regulatory workflow 정기 실행 시 정상 동작 확인
- [ ] (배포 후) 테스트용 의도적 실패 시 Slack 알림 수신 확인 (선택)