### PR TITLE
chore(ops): 실패 알림 확산 + 패턴 중복 제거 + 상대임포트 pre-commit 훅

### DIFF
--- a/.github/workflows/alert-consecutive-failures.yml
+++ b/.github/workflows/alert-consecutive-failures.yml
@@ -1,0 +1,87 @@
+name: Alert on Consecutive Failures
+
+# Reusable workflow. Posts a Slack alert when the last N runs of a given
+# workflow have all failed. Invoked via `workflow_call` from collector
+# workflows' on-failure job.
+#
+# Intended for collectors where a silent multi-day outage is costly (e.g. the
+# 2026-04-21~23 risk_classifier import regression that went undetected for
+# 6 days — see PR #773 / #775).
+
+on:
+  workflow_call:
+    inputs:
+      workflow-name:
+        description: 'Display name of the caller workflow (matches its `name:` field).'
+        required: true
+        type: string
+      threshold:
+        description: 'Number of consecutive failures required to alert (default 3).'
+        required: false
+        type: number
+        default: 3
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  check-and-alert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 1
+
+      - name: Check previous run conclusions
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ inputs.workflow-name }}
+          THRESHOLD: ${{ inputs.threshold }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          needed=$(( THRESHOLD - 1 ))
+          prev_failures=$(gh run list \
+            --workflow "${WORKFLOW_NAME}" \
+            --limit "${THRESHOLD}" \
+            --json conclusion,databaseId \
+            --repo "${REPO}" | \
+            jq --arg id "${RUN_ID}" \
+              '[.[] | select(.databaseId != ($id | tonumber)) | select(.conclusion == "failure")] | length')
+          echo "prev_failures=${prev_failures}" >> "$GITHUB_OUTPUT"
+          if [ "${prev_failures:-0}" -ge "${needed}" ]; then
+            echo "alert=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "alert=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve Slack config
+        if: steps.check.outputs.alert == 'true'
+        id: slack
+        uses: ./.github/actions/resolve-slack-config
+        with:
+          target_channel_alias: investing
+          token_candidates: |
+            ${{ secrets.SLACK_BOT_TOKEN }}
+            ${{ secrets.AI_SLACK_BOT_TOKEN }}
+            ${{ secrets.SLACK_TOKEN }}
+          channel_candidates_investing: |
+            ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
+            ${{ secrets.AI_SLACK_CHANNEL_ID_INVESTING }}
+            ${{ secrets.SLACK_CHANNEL_INVESTING }}
+            ${{ secrets.SLACK_CHANNEL_ID }}
+            ${{ secrets.AI_SLACK_CHANNEL_ID }}
+            ${{ secrets.SLACK_CHANNEL }}
+
+      - name: Post alert to Slack
+        if: steps.check.outputs.alert == 'true' && steps.slack.outputs.can_post == 'true'
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ steps.slack.outputs.token }}
+          payload: |
+            channel: "${{ steps.slack.outputs.channel }}"
+            text: ":rotating_light: [${{ steps.slack.outputs.profile_label }}] ${{ inputs.workflow-name }} failed ${{ inputs.threshold }}+ consecutive runs. Investigate: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/collect-crypto-news.yml
+++ b/.github/workflows/collect-crypto-news.yml
@@ -32,3 +32,11 @@ jobs:
           install-playwright: 'true'
           commit-message: 'chore: collect crypto news'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect Crypto News'
+    secrets: inherit

--- a/.github/workflows/collect-regulatory.yml
+++ b/.github/workflows/collect-regulatory.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  actions: read
 
 concurrency:
   group: collect-regulatory
@@ -32,66 +31,9 @@ jobs:
           git-add-paths: '_posts/ _state/ assets/images/'
 
   alert-consecutive-failures:
-    # Detect 3+ consecutive failures to catch silent multi-day outages
-    # (e.g. the 2026-04-21~23 risk_classifier import regression that went
-    # unnoticed until manual inspection — see PR #773).
     needs: collect
     if: failure()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-        with:
-          fetch-depth: 1
-
-      - name: Check previous run conclusions
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Count failures in the last 2 completed runs excluding the current one.
-          # Combined with the current failure, 2+ previous failures = 3+ consecutive.
-          prev_failures=$(gh run list \
-            --workflow "Collect Regulatory News" \
-            --limit 3 \
-            --json conclusion,databaseId \
-            --repo "${{ github.repository }}" | \
-            jq --arg id "${{ github.run_id }}" \
-              '[.[] | select(.databaseId != ($id | tonumber)) | select(.conclusion == "failure")] | length')
-          echo "prev_failures=${prev_failures}" >> "$GITHUB_OUTPUT"
-          if [ "${prev_failures:-0}" -ge 2 ]; then
-            echo "alert=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "alert=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Resolve Slack config
-        if: steps.check.outputs.alert == 'true'
-        id: slack
-        uses: ./.github/actions/resolve-slack-config
-        with:
-          target_channel_alias: investing
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_investing: |
-            ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
-
-      - name: Post consecutive failure alert to Slack
-        if: steps.check.outputs.alert == 'true' && steps.slack.outputs.can_post == 'true'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ steps.slack.outputs.token }}
-          payload: |
-            channel: "${{ steps.slack.outputs.channel }}"
-            text: ":rotating_light: [${{ steps.slack.outputs.profile_label }}] Collect Regulatory News failed 3+ consecutive runs. Investigate: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect Regulatory News'
+    secrets: inherit

--- a/.github/workflows/collect-social-media.yml
+++ b/.github/workflows/collect-social-media.yml
@@ -32,3 +32,11 @@ jobs:
           install-playwright: 'false'
           commit-message: 'chore: collect social media'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect Social Media'
+    secrets: inherit

--- a/.github/workflows/collect-stock-news.yml
+++ b/.github/workflows/collect-stock-news.yml
@@ -32,3 +32,11 @@ jobs:
           install-playwright: 'false'
           commit-message: 'chore: collect stock news'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect Stock News'
+    secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,17 @@ repos:
     rev: v8.24.2
     hooks:
       - id: gitleaks
+
+  # Enforce relative imports inside scripts/common/ to prevent
+  # ModuleNotFoundError at collector execution time (regression for #773 —
+  # absolute `from scripts.common.config` broke `_assess_risk_level` for 6 days).
+  # Uses AST parsing to avoid false positives from docstring examples.
+  # Mirrors tests/test_import_compatibility.py::test_no_absolute_scripts_imports_in_common
+  # for faster local feedback before CI.
+  - repo: local
+    hooks:
+      - id: relative-imports-in-scripts-common
+        name: Enforce relative imports in scripts/common/ (regression #773)
+        language: system
+        entry: python scripts/tools/check_relative_imports.py
+        files: ^scripts/common/.*\.py$

--- a/scripts/check_description_quality.py
+++ b/scripts/check_description_quality.py
@@ -12,106 +12,24 @@ import sys
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
-# Try to import shared boilerplate detectors from common modules.
-# Falls back to None if PYTHONPATH is not set (standalone mode).
+# Shared boilerplate detectors. The canonical definitions live in
+# common/enrichment.py and common/summarizer.py — importing them here avoids
+# pattern drift (the duplicated local copies previously missed the regex
+# update in PR #775 because the two files weren't kept in sync).
+# Fallback to None only when run in true standalone mode (no PYTHONPATH);
+# callers should ensure scripts/ is importable for full detection.
 try:
     from common.enrichment import _is_site_boilerplate as _enrichment_boilerplate  # noqa: PLC2701
-    from common.summarizer import _is_boilerplate_desc as _summarizer_boilerplate  # noqa: PLC2701
+    from common.summarizer import (  # noqa: PLC2701
+        _is_boilerplate_desc as _summarizer_boilerplate,
+    )
+    from common.summarizer import (
+        _is_generic_desc as _summarizer_generic,
+    )
 except ImportError:
     _enrichment_boilerplate = None  # type: ignore[assignment]
     _summarizer_boilerplate = None  # type: ignore[assignment]
-
-# ---------------------------------------------------------------------------
-# Boilerplate detection — mirrors enrichment.py patterns (standalone copy)
-# ---------------------------------------------------------------------------
-
-_SITE_BOILERPLATE_PHRASES = [
-    "motley fool",
-    "seeking alpha",
-    "cnbc international",
-    "investopedia",
-    "yahoo finance",
-    "bloomberg",
-    "coindesk is",
-    "cointelegraph is",
-    "decrypt is",
-    "뉴스의 리더입니다",
-    "뉴스를 제공하는",
-    "투자 통찰력과 개인 금융",
-    "투자 커뮤니티",
-    "프리미엄 뉴스를 제공",
-    "businesspost",
-    "비즈니스포스트",
-    "인물중심 기업인 프로파일",
-    "경제미디어 경제신문",
-    "올인원 플랫폼입니다",
-    "포트폴리오를 개선하고",
-    "개인 금융 뉴스 및 비즈니스 예측",
-    "선두주자입니다",
-    "우리의 목적은 세상을",
-    "더 스마트하고, 더 행복하고",
-    "simply wall st",
-    "kiplinger",
-    "tipranks",
-    "stock analysis",
-    "관련 광고",
-    "포트폴리오 업데이트 보고서",
-]
-
-_SITE_BOILERPLATE_PATTERNS = [
-    re.compile(r"(?:the )?(?:world'?s?|global) (?:leading|largest|premier|#1)\b", re.I),
-    re.compile(r"(?:join|subscribe to|sign up for) (?:the )?(?:world'?s|our)\b", re.I),
-    re.compile(
-        r"(?:providing|delivers?|offers?) .{0,40}(?:news|analysis|insights|information)"
-        r" .{0,40}(?:since|for over|for \d+)",
-        re.I,
-    ),
-    re.compile(r"^(?:the )?(?:latest|breaking|live|real-time) (?:news|updates?|prices?)\b", re.I),
-    # Keep in sync with scripts/common/enrichment.py:_SITE_BOILERPLATE_PATTERNS.
-    # Anchored to end-of-string copula to avoid false positives on factual
-    # news like "세계 최대 생산업체인 카렉스는…".
-    re.compile(
-        r"(?:세계 최대|글로벌 리더|세계적인 리더)"
-        r"[^.!?\n]{0,40}"
-        r"\s*(?:입니다|을 제공(?:합니다)?|를 제공(?:합니다)?)\s*\.?\s*$",
-        re.I,
-    ),
-    re.compile(r"(?:에 참여하세요|구독하세요|가입하세요)$", re.I),
-    re.compile(r"\d+년 (?:넘게|이상) .{0,40}(?:제공|서비스)", re.I),
-]
-
-_SYNTHETIC_MARKERS = [
-    "관련 소식입니다",
-    "관련 시장 뉴스입니다",
-    "원문에서 세부 내용을 확인하세요",
-    "원문 기사의 세부 내용을 확인하세요",
-    "투자 판단 시",
-    "면밀히 분석해야 합니다",
-    "함께 고려해야 합니다",
-    "주시해야 합니다",
-    "확인하세요",
-    "관련 시장 동향입니다",
-    "관련 세부 내용은",
-    "관련 변경사항을",
-    "시장 심리와 가격",
-    "투자 시사점을",
-    "거래소 공지사항",
-    "산업 동향",
-    "관련 보도.",
-    "섹터 보도.",
-    "산업 보도.",
-    "시장 보도.",
-]
-
-_ARTICLE_SPECIFIC_RE = re.compile(
-    r"(?:[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)"
-    r"|(?:\b[A-Z]{2,}\b)"
-    r"|(?:\b\d{4}\b)"
-    r"|(?:\b\d+[\.,]\d+)"
-    r"|(?:\$|€|£|₩|¥)\s*\d"
-    r"|(?:\d+\s*(?:%|억|만|조|달러|원|위안))"
-    r"|(?:월|년|일)\s*\d"
-)
+    _summarizer_generic = None  # type: ignore[assignment]
 
 _NORM_RE = re.compile(r"[\s\W]+")
 
@@ -123,23 +41,18 @@ _DATE_RE = re.compile(r"^date:\s*(\d{4}-\d{2}-\d{2})", re.MULTILINE)
 
 
 def _is_boilerplate(desc: str) -> bool:
-    """Return True if description is site boilerplate or synthetic filler."""
+    """Return True if description is site boilerplate or synthetic filler.
+
+    Delegates to the three canonical detectors:
+      - `common.enrichment._is_site_boilerplate` (site phrases + regex + short-desc rule)
+      - `common.summarizer._is_generic_desc` (synthetic/generic patterns)
+      - `common.summarizer._is_boilerplate_desc` (extra MT-leak phrases)
+    """
     if not desc:
         return False
-    lower = desc.lower()
-    for phrase in _SITE_BOILERPLATE_PHRASES:
-        if phrase.lower() in lower:
-            return True
-    for pattern in _SITE_BOILERPLATE_PATTERNS:
-        if pattern.search(desc):
-            return True
-    for marker in _SYNTHETIC_MARKERS:
-        if marker in desc:
-            return True
-    if len(desc) < 35 and not _ARTICLE_SPECIFIC_RE.search(desc):
-        return True
-    # Also delegate to shared detectors when available
     if _enrichment_boilerplate is not None and _enrichment_boilerplate(desc):
+        return True
+    if _summarizer_generic is not None and _summarizer_generic(desc):
         return True
     if _summarizer_boilerplate is not None and _summarizer_boilerplate(desc):
         return True

--- a/scripts/tools/check_relative_imports.py
+++ b/scripts/tools/check_relative_imports.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: block absolute ``scripts.*`` imports in ``scripts/common/``.
+
+Regression guard for PR #773. The absolute form
+``from scripts.common.config import setup_logging`` fails with
+``ModuleNotFoundError: No module named 'scripts'`` when collectors are
+executed directly (``python scripts/collect_regulatory.py``), because
+``scripts/`` is not on ``sys.path`` as a package root in that invocation.
+
+Uses AST parsing to avoid false positives from docstring examples.
+
+Usage (pre-commit passes changed files as argv)::
+
+    python scripts/tools/check_relative_imports.py scripts/common/foo.py ...
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+
+
+def _check_file(path: str) -> list[str]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+    except OSError as exc:
+        return [f"{path}:0: could not read file: {exc}"]
+
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        # SyntaxError unrelated to imports — let ruff/python handle it.
+        return []
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.startswith("scripts."):
+                violations.append(
+                    f"{path}:{node.lineno}: from {module} import ..."
+                )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("scripts."):
+                    violations.append(
+                        f"{path}:{node.lineno}: import {alias.name}"
+                    )
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    violations: list[str] = []
+    for path in argv[1:]:
+        violations.extend(_check_file(path))
+
+    if violations:
+        print(
+            "ERROR: absolute 'scripts.*' imports found in scripts/common/ "
+            "(regression for PR #773):",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        print(
+            "\nFix: use relative imports (from .X import Y) inside scripts/common/.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
PR #775 머지 후 남은 3가지 후속 작업 일괄 처리.

## Summary

### 1. 3회 연속 실패 알림을 주요 수집기로 확산
- 재사용 워크플로우 `.github/workflows/alert-consecutive-failures.yml` 신설 (`workflow_call` + inputs=`workflow-name`/`threshold`, `secrets: inherit`)
- `collect-regulatory.yml` 인라인 job을 reusable 호출로 리팩터 (-60 lines)
- `collect-crypto-news.yml`, `collect-stock-news.yml`, `collect-social-media.yml` 에 동일 알림 job 추가
- 4개 수집기 모두 2026-04-21~23 `risk_classifier` import 회귀로 동시 장애 발생

### 2. check_description_quality.py 패턴 중복 제거
- `_SITE_BOILERPLATE_PHRASES`/`_PATTERNS`, `_SYNTHETIC_MARKERS`, `_ARTICLE_SPECIFIC_RE` standalone copy 모두 삭제 (-90 lines)
- `common.enrichment._is_site_boilerplate` + `common.summarizer._is_generic_desc`/`_is_boilerplate_desc` 위임으로 단일화
- PR #775에서 발생한 sync 누락(두 파일에 동일 수정 필요) 원천 차단

### 3. scripts/common/ 상대 임포트 강제 pre-commit 훅 (#773 재발 방지)
- `scripts/tools/check_relative_imports.py` 신규 (AST 기반)
- `.pre-commit-config.yaml`에 `relative-imports-in-scripts-common` 훅 등록
- AST 파싱으로 `bettafish_analyzer.py` docstring 예시 오탐 제거
- `tests/test_import_compatibility.py`의 CI 검증보다 빠른 로컬 피드백 제공

## Test plan
- [x] `pytest tests/test_check_description_quality.py tests/test_enrichment.py tests/test_risk_classifier.py tests/test_import_compatibility.py` — **494 passed**
- [x] `ruff check` — clean (8 staged 파일 모두)
- [x] `python scripts/check_description_quality.py --days 3` — **100% real content** 유지
- [x] `scripts/tools/check_relative_imports.py scripts/common/*.py` → exit 0 (기존 파일 통과)
- [x] 일부러 심은 `from scripts.common.config` 라인 → exit 1 + 명확한 에러 메시지
- [x] `yaml.safe_load` 5개 워크플로우 파일 모두 문법 유효
- [ ] (배포 후) 의도적 실패 주입 시 Slack 알림 수신 (선택, 수동 검증)