### PR TITLE
chore(ops): 실패 알림 3개 수집기 확산 + threshold 차등 + pre-commit 설치 안내

### DIFF
--- a/.github/workflows/collect-crypto-news.yml
+++ b/.github/workflows/collect-crypto-news.yml
@@ -39,4 +39,6 @@ jobs:
     uses: ./.github/workflows/alert-consecutive-failures.yml
     with:
       workflow-name: 'Collect Crypto News'
+      # 6회/일(4시간 주기)로 단발 실패가 잦아 threshold 완화
+      threshold: 5
     secrets: inherit

--- a/.github/workflows/collect-geopolitical.yml
+++ b/.github/workflows/collect-geopolitical.yml
@@ -29,3 +29,11 @@ jobs:
           script: scripts/collect_geopolitical.py
           commit-message: 'chore: collect geopolitical risk data'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect Geopolitical Risk Data'
+    secrets: inherit

--- a/.github/workflows/collect-market-indicators.yml
+++ b/.github/workflows/collect-market-indicators.yml
@@ -31,3 +31,11 @@ jobs:
           script: scripts/collect_market_indicators.py
           commit-message: 'chore: collect market indicators'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect Market Indicators'
+    secrets: inherit

--- a/.github/workflows/collect-political-trades.yml
+++ b/.github/workflows/collect-political-trades.yml
@@ -29,3 +29,11 @@ jobs:
           script: scripts/collect_political_trades.py
           commit-message: 'chore: collect political trades'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect Political Trades'
+    secrets: inherit

--- a/.github/workflows/collect-social-media.yml
+++ b/.github/workflows/collect-social-media.yml
@@ -39,4 +39,6 @@ jobs:
     uses: ./.github/workflows/alert-consecutive-failures.yml
     with:
       workflow-name: 'Collect Social Media'
+      # 4회/일(6시간 주기)로 API rate limit 발생 가능성 고려해 threshold 완화
+      threshold: 5
     secrets: inherit

--- a/.github/workflows/collect-stock-news.yml
+++ b/.github/workflows/collect-stock-news.yml
@@ -39,4 +39,6 @@ jobs:
     uses: ./.github/workflows/alert-consecutive-failures.yml
     with:
       workflow-name: 'Collect Stock News'
+      # 5회/일로 단발 실패 발생률이 높아 threshold 완화
+      threshold: 5
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ python scripts/generate_market_summary.py
 python scripts/generate_daily_summary.py
 ```
 
+### 2.1 Pre-commit 훅 설치 (권장)
+
+저장소는 gitleaks(시크릿 탐지)와 `scripts/common/` 상대 임포트 강제(#773 회귀 방지) 훅을 `.pre-commit-config.yaml` 에 등록해 두었습니다. 로컬에서 실제 동작하려면 **최초 1회 설치**가 필요합니다.
+
+```bash
+pip install pre-commit       # 또는 brew install pre-commit
+pre-commit install           # .git/hooks/pre-commit 에 자동 연결
+
+# (선택) 전체 파일에 한 번 돌려 상태 확인
+pre-commit run --all-files
+```
+
+설치하지 않으면 CI에서만 검증되고 로컬 커밋 시에는 차단되지 않으므로, 클론 직후 바로 실행해 두는 것을 권장합니다.
+
 ### 2.5 Hybrid Scheduler (GitHub Actions + Server Cron)
 
 GitHub Actions는 분산 수집/검증을 유지하고, 상시 켜진 서버는 오전 9시 10분(KST) 자동 포스팅/품질 보정을 담당하도록 구성할 수 있습니다.


### PR DESCRIPTION
PR #777 후속 3가지 개선 일괄 반영.

## Summary

### 1. 저빈도 포스트 수집기 3종에 실패 알림 확산 (threshold=3 기본값)
- `collect-market-indicators.yml` (평일 2회/일)
- `collect-geopolitical.yml` (2회/일)
- `collect-political-trades.yml` (2회/일)

포스트 직결 수집기로, 장애 시 당일 포스트가 누락되므로 기본 threshold=3을 그대로 사용 → **약 1일 이내 Slack 감지**.

### 2. 고빈도 수집기 threshold=5로 완화
- `collect-crypto-news.yml` (6회/일, 4시간 주기)
- `collect-stock-news.yml` (5회/일)
- `collect-social-media.yml` (4회/일, 6시간 주기)

API rate limit 등 일시 실패로 생기는 단발 알림을 줄이고, 실제 지속적 장애만 알림이 울리도록 조정 → **약 20시간 이내 감지** (하루에 1번은 확실히 울림).

### 3. README에 pre-commit 설치 안내 추가
- §2.1 "Pre-commit 훅 설치" 섹션 신설
- `pip install pre-commit` + `pre-commit install` 명령 명시
- gitleaks + scripts/common/ 상대 임포트 강제 훅 설명
- 미설치 시 CI에서만 차단된다는 경고 포함

## Threshold 설계
| 빈도 | 수집기 | threshold | 감지 시간 |
|---|---|---|---|
| 6회/일 | crypto-news | 5 | ~20h |
| 5회/일 | stock-news | 5 | ~24h |
| 4회/일 | social-media | 5 | ~30h |
| 3회/일 | regulatory | 3 (기본) | ~24h |
| 2회/일 | market-indicators, geopolitical, political-trades | 3 (기본) | ~1.5일 |

## Test plan
- [x] `yaml.safe_load` 8개 워크플로우 파일 모두 유효
- [x] reusable 워크플로우 `threshold: 5` 파라미터 override 경로 확인 (input 기본값 3 유지, caller override 가능)
- [ ] (배포 후) 저빈도 수집기 의도적 실패 주입 시 3회 연속 Slack 알림 수신
- [ ] (배포 후) 고빈도 수집기 4회 연속 실패 시 **알림 없음**, 5회째 **알림 울림** 확인