### PR TITLE
chore(ops): 알림 전체 수집기 커버 + CI pre-commit + 알림 메시지 강화

### DIFF
--- a/.github/workflows/alert-consecutive-failures.yml
+++ b/.github/workflows/alert-consecutive-failures.yml
@@ -44,16 +44,24 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           needed=$(( THRESHOLD - 1 ))
-          prev_failures=$(gh run list \
+          runs_json=$(gh run list \
             --workflow "${WORKFLOW_NAME}" \
             --limit "${THRESHOLD}" \
-            --json conclusion,databaseId \
-            --repo "${REPO}" | \
-            jq --arg id "${RUN_ID}" \
-              '[.[] | select(.databaseId != ($id | tonumber)) | select(.conclusion == "failure")] | length')
+            --json conclusion,databaseId,createdAt,url \
+            --repo "${REPO}")
+          prev_failures=$(echo "$runs_json" | jq --arg id "${RUN_ID}" \
+            '[.[] | select(.databaseId != ($id | tonumber)) | select(.conclusion == "failure")] | length')
           echo "prev_failures=${prev_failures}" >> "$GITHUB_OUTPUT"
           if [ "${prev_failures:-0}" -ge "${needed}" ]; then
             echo "alert=true" >> "$GITHUB_OUTPUT"
+            # Build "\n"-separated bullet list of up to 5 recent failure links
+            # for Slack mrkdwn (single-line output, real newlines happen in
+            # Slack via the "\n" escape sequence in the JSON payload).
+            recent=$(echo "$runs_json" | jq -j \
+              'map(select(.conclusion == "failure")) | .[0:5]
+               | map("• <\(.url)|\(.createdAt[0:16]) UTC>")
+               | join("\\n")')
+            echo "recent_failures=${recent}" >> "$GITHUB_OUTPUT"
           else
             echo "alert=false" >> "$GITHUB_OUTPUT"
           fi
@@ -84,4 +92,4 @@ jobs:
           token: ${{ steps.slack.outputs.token }}
           payload: |
             channel: "${{ steps.slack.outputs.channel }}"
-            text: ":rotating_light: [${{ steps.slack.outputs.profile_label }}] ${{ inputs.workflow-name }} failed ${{ inputs.threshold }}+ consecutive runs. Investigate: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: ":rotating_light: [${{ steps.slack.outputs.profile_label }}] *${{ inputs.workflow-name }}* failed ${{ inputs.threshold }}+ consecutive runs\n\n*Recent failed runs:*\n${{ steps.check.outputs.recent_failures }}\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|:link: View current run>"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -40,10 +40,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r scripts/requirements.txt ruff yamllint basedpyright pytest pytest-cov pytest-xdist
+          pip install -r scripts/requirements.txt ruff yamllint basedpyright pytest pytest-cov pytest-xdist pre-commit
           curl -sSL "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
           tar -xzf /tmp/actionlint.tgz -C /tmp
           install /tmp/actionlint /usr/local/bin/actionlint
+
+      - name: Run pre-commit hooks
+        # Enforces .pre-commit-config.yaml rules (gitleaks, relative-imports-in-scripts-common
+        # for #773 regression) even when contributors skip `pre-commit install` locally.
+        run: pre-commit run --all-files --show-diff-on-failure
 
       - name: Run ruff linter (with security rules)
         run: python3 -m ruff check scripts/ tests/ --output-format=github

--- a/.github/workflows/collect-blockchain.yml
+++ b/.github/workflows/collect-blockchain.yml
@@ -31,3 +31,11 @@ jobs:
           git-add-paths: '_posts/ _state/'
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect Blockchain Metrics'
+    secrets: inherit

--- a/.github/workflows/collect-coinmarketcap.yml
+++ b/.github/workflows/collect-coinmarketcap.yml
@@ -32,3 +32,13 @@ jobs:
           install-playwright: 'false'
           commit-message: 'chore: collect coinmarketcap data'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect CoinMarketCap Data'
+      # 4회/일 (6시간 주기) — API rate limit 고려 threshold 완화
+      threshold: 5
+    secrets: inherit

--- a/.github/workflows/collect-defi-llama.yml
+++ b/.github/workflows/collect-defi-llama.yml
@@ -56,3 +56,13 @@ jobs:
           payload: |
             channel: "${{ steps.slack.outputs.channel }}"
             text: "[${{ steps.slack.outputs.profile_label }}] DeFi Llama data collection completed - ${{ github.run_id }}"
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect DeFi Llama Data'
+      # 4회/일 (6시간 주기) — 일시 실패 노이즈 줄이기 위해 threshold 완화
+      threshold: 5
+    secrets: inherit

--- a/.github/workflows/collect-defi-yields.yml
+++ b/.github/workflows/collect-defi-yields.yml
@@ -56,3 +56,13 @@ jobs:
           payload: |
             channel: "${{ steps.slack.outputs.channel }}"
             text: "[${{ steps.slack.outputs.profile_label }}] DeFi Yields data collection completed - ${{ github.run_id }}"
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect DeFi Yields Data'
+      # 4회/일 (6시간 주기) — 일시 실패 노이즈 줄이기 위해 threshold 완화
+      threshold: 5
+    secrets: inherit

--- a/.github/workflows/collect-fmp-calendar.yml
+++ b/.github/workflows/collect-fmp-calendar.yml
@@ -32,3 +32,11 @@ jobs:
           script: scripts/collect_fmp_calendar.py
           commit-message: 'chore: collect FMP calendar'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect FMP Calendar'
+    secrets: inherit

--- a/.github/workflows/collect-worldmonitor-news.yml
+++ b/.github/workflows/collect-worldmonitor-news.yml
@@ -29,3 +29,11 @@ jobs:
           script: scripts/collect_worldmonitor_news.py
           commit-message: 'chore: collect worldmonitor news'
           git-add-paths: '_posts/ _state/ assets/images/'
+
+  alert-consecutive-failures:
+    needs: collect
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collect WorldMonitor News'
+    secrets: inherit

--- a/scripts/tools/check_relative_imports.py
+++ b/scripts/tools/check_relative_imports.py
@@ -38,15 +38,11 @@ def _check_file(path: str) -> list[str]:
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
             if module.startswith("scripts."):
-                violations.append(
-                    f"{path}:{node.lineno}: from {module} import ..."
-                )
+                violations.append(f"{path}:{node.lineno}: from {module} import ...")
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name.startswith("scripts."):
-                    violations.append(
-                        f"{path}:{node.lineno}: import {alias.name}"
-                    )
+                    violations.append(f"{path}:{node.lineno}: import {alias.name}")
     return violations
 
 
@@ -57,8 +53,7 @@ def main(argv: list[str]) -> int:
 
     if violations:
         print(
-            "ERROR: absolute 'scripts.*' imports found in scripts/common/ "
-            "(regression for PR #773):",
+            "ERROR: absolute 'scripts.*' imports found in scripts/common/ (regression for PR #773):",
             file=sys.stderr,
         )
         for v in violations:

--- a/tests/test_risk_classifier.py
+++ b/tests/test_risk_classifier.py
@@ -35,19 +35,10 @@ def test_risk_classifier_uses_relative_imports():
     summarizer.py which lazy-imports risk_classifier in package context
     (the `scripts` namespace is not on sys.path at that point).
     """
-    src_path = (
-        pathlib.Path(__file__).resolve().parent.parent
-        / "scripts"
-        / "common"
-        / "risk_classifier.py"
-    )
+    src_path = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "common" / "risk_classifier.py"
     content = src_path.read_text(encoding="utf-8")
-    assert "from scripts.common" not in content, (
-        "risk_classifier.py must use relative imports (regression for #773)"
-    )
-    assert "from .config import" in content, (
-        "risk_classifier.py must import config via relative import (from .config)"
-    )
+    assert "from scripts.common" not in content, "risk_classifier.py must use relative imports (regression for #773)"
+    assert "from .config import" in content, "risk_classifier.py must import config via relative import (from .config)"
 
 
 def test_risk_classifier_lazy_import_chain_works():
@@ -78,6 +69,7 @@ def test_risk_classifier_lazy_import_chain_works():
 
     verdict = module.classify_risk(items=[], priority_items={})
     assert verdict.level in {"critical", "elevated", "normal", "low"}
+
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures


### PR DESCRIPTION
PR #780 후속 3가지 최종 작업.

## Summary

### 1. 실패 알림 전체 수집기 커버 (13/13)
이제 모든 collector-*.yml 워크플로우가 연속 실패 감지 알림을 갖습니다.

| 수집기 | 빈도 | threshold |
|---|---|---|
| crypto-news | 6x/day | 5 |
| stock-news | 5x/day | 5 |
| social-media | 4x/day | 5 |
| **coinmarketcap** | 4x/day | 5 |
| **defi-llama** | 4x/day | 5 |
| **defi-yields** | 4x/day | 5 |
| regulatory | 3x/day | 3 |
| market-indicators | 2x/day | 3 |
| political-trades | 2x/day | 3 |
| geopolitical | 2x/day | 3 |
| **fmp-calendar** | 2x/day | 3 |
| **worldmonitor-news** | 1x/day | 3 |
| **blockchain** | 1x/day | 3 |

굵은 6개가 이번 PR에서 추가.

### 2. CI에서 pre-commit 실행
`.github/workflows/code-quality.yml`에 step 추가. 로컬 `pre-commit install` 을 안 한 기여자의 PR도 gitleaks + `scripts/common/` 상대 임포트 강제(#773 회귀 방지) 훅 적용받도록.

```yaml
- name: Run pre-commit hooks
  run: pre-commit run --all-files --show-diff-on-failure
```

### 3. Slack 알림 메시지 강화
기존 "failed 3+ consecutive runs" 한 줄 → 최근 5건 실패 링크+타임스탬프 리스트 + mrkdwn 포맷 + "View current run" 링크.

예시 출력:
```
:rotating_light: [investing] Collect Regulatory News failed 3+ consecutive runs

Recent failed runs:
• <https://github.com/.../runs/123|2026-04-23T08:08 UTC>
• <https://github.com/.../runs/456|2026-04-22T23:03 UTC>
• <https://github.com/.../runs/789|2026-04-22T14:05 UTC>

:link: View current run
```

### 4. (부가) 이전 PR #780 squash에서 누락된 ruff format 재반영
`scripts/tools/check_relative_imports.py`, `tests/test_risk_classifier.py` 재포맷.

## Test plan
- [x] `yaml.safe_load` 8개 워크플로우 파일 모두 유효
- [x] `pytest` 96 passed (test_risk_classifier + test_import_compatibility)
- [x] `ruff format --check` clean (166/166)
- [x] `ruff check` clean
- [x] `scripts/tools/check_relative_imports.py scripts/common/*.py` exit 0
- [ ] (배포 후) 실패 수집기 Slack 메시지에 최근 실패 링크 리스트 노출 확인
- [ ] (배포 후) CI pre-commit step이 의도적 위반 PR에서 실패 차단 확인