### PR TITLE
feat(ops): alert-consecutive-failures Slack 실패 시 GitHub issue fallback

### DIFF
--- a/.github/workflows/alert-consecutive-failures.yml
+++ b/.github/workflows/alert-consecutive-failures.yml
@@ -24,6 +24,7 @@ on:
 permissions:
   contents: read
   actions: read
+  issues: write
 
 jobs:
   check-and-alert:
@@ -85,6 +86,7 @@ jobs:
             ${{ secrets.SLACK_CHANNEL }}
 
       - name: Post alert to Slack
+        id: post-slack
         if: steps.check.outputs.alert == 'true' && steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
         with:
@@ -93,3 +95,41 @@ jobs:
           payload: |
             channel: "${{ steps.slack.outputs.channel }}"
             text: ":rotating_light: [${{ steps.slack.outputs.profile_label }}] *${{ inputs.workflow-name }}* failed ${{ inputs.threshold }}+ consecutive runs\n\n*Recent failed runs:*\n${{ steps.check.outputs.recent_failures }}\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|:link: View current run>"
+
+      - name: Fallback — create GitHub issue if Slack post failed
+        if: >-
+          steps.check.outputs.alert == 'true' &&
+          (steps.slack.outputs.can_post != 'true' || steps.post-slack.outcome == 'failure')
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7
+        with:
+          script: |
+            const title = `[alert-delivery-failed] ${{ inputs.workflow-name }} consecutive failures (Slack notify failed)`;
+            const body = [
+              `## Alert delivery failure`,
+              ``,
+              `The primary Slack alert for **${{ inputs.workflow-name }}** could not be delivered.`,
+              ``,
+              `| Field | Value |`,
+              `|-------|-------|`,
+              `| Workflow | \`${{ inputs.workflow-name }}\` |`,
+              `| Threshold | ${{ inputs.threshold }} consecutive failures |`,
+              `| Run | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}> |`,
+              `| Slack can_post | \`${{ steps.slack.outputs.can_post }}\` |`,
+              `| Slack step outcome | \`${{ steps.post-slack.outcome }}\` |`,
+              ``,
+              `**Recent failed runs:**`,
+              `${{ steps.check.outputs.recent_failures }}`,
+              ``,
+              `## What to investigate`,
+              `- Slack token rotation: verify \`SLACK_BOT_TOKEN\` / \`AI_SLACK_BOT_TOKEN\` secrets are current`,
+              `- Channel ID drift: confirm \`SLACK_CHANNEL_ID_INVESTING\` still resolves to the expected channel`,
+              `- If Slack was in outage, close this issue once alerts resume`,
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['alert-delivery-failed', 'ops'],
+            });

--- a/.github/workflows/collect-blockchain.yml
+++ b/.github/workflows/collect-blockchain.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-blockchain

--- a/.github/workflows/collect-coinmarketcap.yml
+++ b/.github/workflows/collect-coinmarketcap.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-coinmarketcap

--- a/.github/workflows/collect-crypto-news.yml
+++ b/.github/workflows/collect-crypto-news.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-crypto-news

--- a/.github/workflows/collect-defi-llama.yml
+++ b/.github/workflows/collect-defi-llama.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-defi-llama

--- a/.github/workflows/collect-defi-yields.yml
+++ b/.github/workflows/collect-defi-yields.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-defi-yields

--- a/.github/workflows/collect-fmp-calendar.yml
+++ b/.github/workflows/collect-fmp-calendar.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-fmp-calendar

--- a/.github/workflows/collect-geopolitical.yml
+++ b/.github/workflows/collect-geopolitical.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-geopolitical

--- a/.github/workflows/collect-market-indicators.yml
+++ b/.github/workflows/collect-market-indicators.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-market-indicators

--- a/.github/workflows/collect-political-trades.yml
+++ b/.github/workflows/collect-political-trades.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-political-trades

--- a/.github/workflows/collect-regulatory.yml
+++ b/.github/workflows/collect-regulatory.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-regulatory

--- a/.github/workflows/collect-social-media.yml
+++ b/.github/workflows/collect-social-media.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-social-media

--- a/.github/workflows/collect-stock-news.yml
+++ b/.github/workflows/collect-stock-news.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-stock-news

--- a/.github/workflows/collect-worldmonitor-news.yml
+++ b/.github/workflows/collect-worldmonitor-news.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: collect-worldmonitor-news

--- a/tests/test_alert_fallback_config.py
+++ b/tests/test_alert_fallback_config.py
@@ -43,9 +43,7 @@ def test_alert_workflow_has_issues_write_permission():
     doc = _load(ALERT_WORKFLOW)
     perms = doc.get("permissions", {})
     assert isinstance(perms, dict), "permissions block must be a mapping"
-    assert perms.get("issues") == "write", (
-        f"alert-consecutive-failures.yml must have 'issues: write', got: {perms}"
-    )
+    assert perms.get("issues") == "write", f"alert-consecutive-failures.yml must have 'issues: write', got: {perms}"
 
 
 def test_alert_workflow_has_fallback_step_on_slack_failure():
@@ -87,9 +85,7 @@ def test_alert_workflow_post_slack_step_has_id():
                 break
         if found:
             break
-    assert found, (
-        "No step with id: post-slack found in alert-consecutive-failures.yml"
-    )
+    assert found, "No step with id: post-slack found in alert-consecutive-failures.yml"
 
 
 @pytest.mark.parametrize("workflow_file", CALLER_WORKFLOWS)

--- a/tests/test_alert_fallback_config.py
+++ b/tests/test_alert_fallback_config.py
@@ -1,0 +1,104 @@
+"""
+Tests for alert-consecutive-failures fallback configuration.
+
+Verifies that:
+1. alert-consecutive-failures.yml has issues: write permission
+2. The fallback step referencing steps.post-slack.outcome == 'failure' exists
+3. All 13 caller workflows have issues: write in their top-level permissions
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS_DIR = Path(__file__).parent.parent / ".github" / "workflows"
+ALERT_WORKFLOW = WORKFLOWS_DIR / "alert-consecutive-failures.yml"
+
+CALLER_WORKFLOWS = [
+    "collect-blockchain.yml",
+    "collect-coinmarketcap.yml",
+    "collect-crypto-news.yml",
+    "collect-defi-llama.yml",
+    "collect-defi-yields.yml",
+    "collect-fmp-calendar.yml",
+    "collect-geopolitical.yml",
+    "collect-market-indicators.yml",
+    "collect-political-trades.yml",
+    "collect-regulatory.yml",
+    "collect-social-media.yml",
+    "collect-stock-news.yml",
+    "collect-worldmonitor-news.yml",
+]
+
+
+def _load(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def test_alert_workflow_has_issues_write_permission():
+    doc = _load(ALERT_WORKFLOW)
+    perms = doc.get("permissions", {})
+    assert isinstance(perms, dict), "permissions block must be a mapping"
+    assert perms.get("issues") == "write", (
+        f"alert-consecutive-failures.yml must have 'issues: write', got: {perms}"
+    )
+
+
+def test_alert_workflow_has_fallback_step_on_slack_failure():
+    """A step must exist whose `if:` condition references steps.post-slack.outcome == 'failure'."""
+    doc = _load(ALERT_WORKFLOW)
+    jobs = doc.get("jobs", {})
+    found = False
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps", []):
+            if not isinstance(step, dict):
+                continue
+            condition = str(step.get("if", ""))
+            if "steps.post-slack.outcome == 'failure'" in condition:
+                found = True
+                break
+        if found:
+            break
+    assert found, (
+        "No step found with if: condition referencing "
+        "steps.post-slack.outcome == 'failure' in alert-consecutive-failures.yml"
+    )
+
+
+def test_alert_workflow_post_slack_step_has_id():
+    """The Slack posting step must have id: post-slack so its outcome can be referenced."""
+    doc = _load(ALERT_WORKFLOW)
+    jobs = doc.get("jobs", {})
+    found = False
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps", []):
+            if not isinstance(step, dict):
+                continue
+            if step.get("id") == "post-slack":
+                found = True
+                break
+        if found:
+            break
+    assert found, (
+        "No step with id: post-slack found in alert-consecutive-failures.yml"
+    )
+
+
+@pytest.mark.parametrize("workflow_file", CALLER_WORKFLOWS)
+def test_caller_workflow_has_issues_write(workflow_file: str):
+    path = WORKFLOWS_DIR / workflow_file
+    assert path.exists(), f"Caller workflow not found: {path}"
+    doc = _load(path)
+    perms = doc.get("permissions", {})
+    assert isinstance(perms, dict), f"{workflow_file}: permissions block must be a mapping"
+    assert perms.get("issues") == "write", (
+        f"{workflow_file} must have 'issues: write' in top-level permissions, got: {perms}"
+    )


### PR DESCRIPTION
## 요약

포스트모템 액션 아이템: `alert-consecutive-failures 자체가 startup_failure일 때의 fallback 알림 채널 추가`

### 설계 근거 — 왜 Option (a) GitHub issue 생성인가?

| Layer | 채널 | 커버하는 실패 모드 | 커버 못하는 실패 모드 |
|-------|------|-------------------|----------------------|
| **Primary** (기존) | Slack (`SLACK_BOT_TOKEN` / channel investing) | 수집기 N회 연속 실패 | Slack 토큰 만료, 채널 ID 변경, Slack 장애, `alert-consecutive-failures` 자체 startup_failure |
| **Secondary** (이번 PR) | GitHub issue (`GITHUB_TOKEN` 내장) | Slack 포스트 실패(`steps.post-slack.outcome == 'failure'`) 또는 Slack 설정 미해결(`can_post != 'true'`) | `alert-consecutive-failures` 자체가 startup_failure로 뜨지 못하는 경우 |
| **Tertiary** (watchdog 기존) | Slack (별도 watchdog 워크플로우) | Primary · Secondary 양쪽의 startup_failure 감지 | watchdog 자신이 startup_failure인 경우 (triple failure) |

**Option (a)를 선택한 이유**: GitHub issue는 GITHUB_TOKEN 내장 권한만 사용하므로 외부 시크릿 의존이 없다. Slack 토큰이 만료되거나 채널 ID가 변경되는 상황에서도 GitHub의 자체 알림 시스템(이메일, 웹 UI)을 통해 메인테이너에게 확실히 전달된다. Option (b)는 두 번째 Slack 토큰이라는 또 다른 시크릿 의존을 추가하고, Option (c)는 PagerDuty/OpsGenie 같은 외부 서비스 설정이 필요해 복잡도만 증가한다.

## 변경 내용

### `alert-consecutive-failures.yml`
- `permissions` 블록에 `issues: write` 추가
- 기존 "Post alert to Slack" 스텝에 `id: post-slack` 부여
- 신규 스텝: **"Fallback — create GitHub issue if Slack post failed"**
  - 조건: `steps.check.outputs.alert == 'true'` AND (`can_post != 'true'` OR `steps.post-slack.outcome == 'failure'`)
  - `actions/github-script@v7`로 issue 생성, 레이블 `alert-delivery-failed`, `ops`
  - 본문에 run URL, workflow명, threshold, recent_failures, 조사 가이드 포함

### 13개 caller workflows (`collect-*.yml`)
- `issues: write` 한 줄씩 추가 (PR #788 교훈: callee 권한 변경 시 caller도 동기화)
- 기존 permissions 블록 구조 유지

### `tests/test_alert_fallback_config.py` (신규)
- 16개 pytest: permissions.issues, id: post-slack, fallback if 조건, 13개 caller 전체 검증

## 검증

- `pytest tests/test_alert_fallback_config.py --no-cov -v` → **16 passed**
- `python3 scripts/tools/check_workflow_permissions.py` → **OK: all caller→callee permissions satisfied**
- YAML parse (40개 워크플로우) → **전체 통과**

## 포스트모템 참조

`docs/postmortem-2026-04-collector-outages.md`:
> "alert-consecutive-failures 자체가 startup_failure일 때의 fallback 알림 채널 추가"

이번 PR은 Slack 포스트 실패 케이스를 커버한다. startup_failure 자체는 기존 watchdog(tertiary)이 담당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)