### PR TITLE
test: 사전 회귀 13건 픽스 (ascii_ratio_high · section auto-number · netloc source)

### DIFF
--- a/tests/test_check_description_quality.py
+++ b/tests/test_check_description_quality.py
@@ -326,6 +326,7 @@ def test_format_text_smoke():
         "title_repeat": [],
         "no_desc": [],
         "translation_issues": [],
+        "ascii_ratio_high": [],
         "mojibake": [],
     }
     output = cdq.format_text(stats, days=7)
@@ -344,6 +345,7 @@ def test_format_text_includes_boilerplate_section():
         "title_repeat": [],
         "no_desc": [],
         "translation_issues": [],
+        "ascii_ratio_high": [],
         "mojibake": [],
     }
     output = cdq.format_text(stats, days=1)
@@ -361,6 +363,7 @@ def test_format_text_includes_title_repeat_section():
         "title_repeat": [post],
         "no_desc": [],
         "translation_issues": [],
+        "ascii_ratio_high": [],
         "mojibake": [],
     }
     output = cdq.format_text(stats, days=1)
@@ -377,6 +380,7 @@ def test_format_text_includes_translation_issue_section():
         "title_repeat": [],
         "no_desc": [],
         "translation_issues": [post],
+        "ascii_ratio_high": [],
         "mojibake": [],
     }
     output = cdq.format_text(stats, days=1)
@@ -396,6 +400,7 @@ def test_format_markdown_smoke():
         "title_repeat": [],
         "no_desc": [],
         "translation_issues": [],
+        "ascii_ratio_high": [],
         "mojibake": [],
     }
     output = cdq.format_markdown(stats, days=7)
@@ -417,6 +422,7 @@ def test_format_markdown_shows_warning_when_boilerplate_high():
         "title_repeat": [],
         "no_desc": [],
         "translation_issues": [],
+        "ascii_ratio_high": [],
         "mojibake": [],
     }
     output = cdq.format_markdown(stats, days=1)
@@ -431,6 +437,7 @@ def test_format_markdown_uses_checkmark_when_clean():
         "title_repeat": [],
         "no_desc": [],
         "translation_issues": [],
+        "ascii_ratio_high": [],
         "mojibake": [],
     }
     output = cdq.format_markdown(stats, days=7)
@@ -446,6 +453,7 @@ def test_format_markdown_uses_error_icon_when_mojibake():
         "title_repeat": [],
         "no_desc": [],
         "translation_issues": [],
+        "ascii_ratio_high": [],
         "mojibake": [post],
     }
     output = cdq.format_markdown(stats, days=1)
@@ -485,8 +493,8 @@ def test_main_returns_0_for_clean_posts(tmp_path, monkeypatch, capsys):
         tmp_path,
         f"{today}-clean.md",
         str(today),
-        title="Bitcoin Rally Q1 2026",
-        description="Bitcoin surged to $90,000 in Q1 2026 amid strong institutional demand.",
+        title="비트코인 2026년 1분기 랠리",
+        description="비트코인은 2026년 1분기에 강력한 기관 수요로 $90,000까지 상승했습니다.",
     )
     monkeypatch.setattr(
         sys,
@@ -538,7 +546,7 @@ def test_main_markdown_format(tmp_path, monkeypatch, capsys):
         tmp_path,
         f"{today}-md.md",
         str(today),
-        description="Bitcoin hit all-time high of $95,000 driven by ETF inflows in 2026.",
+        description="비트코인은 2026년 ETF 자금 유입에 힘입어 $95,000 사상 최고치를 기록했습니다.",
     )
     monkeypatch.setattr(
         sys,

--- a/tests/test_collector_integration.py
+++ b/tests/test_collector_integration.py
@@ -6,6 +6,7 @@ All external network calls are mocked — zero real HTTP requests are made.
 from __future__ import annotations
 
 import os
+import re
 import sys
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
@@ -1140,7 +1141,10 @@ class TestRegulatoryCollectorIntegration:
 
         kwargs = post_gen.create_post.call_args.kwargs
         assert kwargs["title"] == "글로벌 규제 동향 리포트 - 2026-03-29"
-        assert "## 미국 규제 동향" in kwargs["content"]
+        # Region sections are auto-numbered ("## 1. 미국 규제 동향", ...) since the
+        # 2026-05-22 Designer audit.
+        assert "미국 규제 동향" in kwargs["content"]
+        assert re.search(r"## \d+\. 미국 규제 동향", kwargs["content"])
         assert "## 규제 테마 분석" in kwargs["content"]
         dedup.save.assert_called_once()
 
@@ -1205,8 +1209,9 @@ class TestPoliticalTradesCollectorIntegration:
         assert kwargs["slug"] == "daily-political-trades-report"
         assert kwargs["image"].endswith("news-briefing-political-2026-03-29.png")
         assert "![news-briefing-political]" in kwargs["content"]
-        assert "## 미국 의회 거래 동향" in kwargs["content"]
-        assert "## 정책 영향 분석" in kwargs["content"]
+        # Section headings are auto-numbered ("## N. 미국 의회 거래 동향").
+        assert re.search(r"## \d+\. 미국 의회 거래 동향", kwargs["content"])
+        assert re.search(r"## \d+\. 정책 영향 분석", kwargs["content"])
         assert dedup.mark_seen.call_count == 6
         dedup.save.assert_called_once()
 

--- a/tests/test_tune_risk_threshold.py
+++ b/tests/test_tune_risk_threshold.py
@@ -43,13 +43,17 @@ date: {date_str} 09:00:00 +0900
 
 
 def test_parse_post_extracts_priority_items():
-    """Sample post body → P0 list items are extracted correctly."""
+    """Sample post body → P0 list items are extracted correctly.
+
+    ``source`` is derived from the link's netloc so risk_classifier source
+    weights apply to the real publisher (not always "google news").
+    """
     text = """
 <div class="alert-box alert-urgent">
 <strong>긴급 알림</strong>
 <ul>
 <li><a href="https://example.com/1">Bitcoin crashes 20%</a> <span class="p0-desc">Bitcoin fell sharply amid macro fears.</span></li>
-<li><a href="https://example.com/2">SEC files lawsuit</a> <span class="p0-desc">SEC sues major exchange for fraud.</span></li>
+<li><a href="https://news.google.com/articles/abc">SEC files lawsuit</a> <span class="p0-desc">SEC sues major exchange for fraud.</span></li>
 </ul>
 </div>
 """
@@ -57,8 +61,9 @@ def test_parse_post_extracts_priority_items():
     assert len(items) == 2
     assert items[0]["title"] == "Bitcoin crashes 20%"
     assert items[0]["description"] == "Bitcoin fell sharply amid macro fears."
-    assert items[0]["source"] == "google news"
+    assert items[0]["source"] == "example.com"
     assert items[1]["title"] == "SEC files lawsuit"
+    assert items[1]["source"] == "google news"
 
 
 def test_parse_priority_items_returns_empty_when_no_urgent_block():


### PR DESCRIPTION
## Summary

main 브랜치에서 누적된 13건의 사전 회귀 테스트 일괄 픽스.
모두 production 코드는 정상이고 테스트만 stale 상태.

## Pre-existing failures (before)

| Module | Failures | Root cause |
|---|---:|---|
| `test_check_description_quality.py` | 10 | `stats["ascii_ratio_high"]` 키 누락 + 영문-only desc가 ASCII 과다 규칙에 걸림 |
| `test_collector_integration.py` | 2 | 섹션 헤딩이 `## N. <title>` auto-number로 변경됨 (2026-05-22 Designer audit) |
| `test_tune_risk_threshold.py` | 1 | `parse_priority_items.source`가 legacy "google news" 고정 → netloc 기반 |

## Changes

### `tests/test_check_description_quality.py`
- 8개 stats dict에 `"ascii_ratio_high": []` 추가 (production이 참조하는 키)
- `test_main_returns_0_for_clean_posts` / `test_main_markdown_format`: 영문-only description → 한국어+숫자 혼합 (Korean-first 원칙 반영)

### `tests/test_collector_integration.py`
- `assert "## 미국 규제 동향" in content` → `re.search(r"## \d+\. 미국 규제 동향", content)`
- 정치 거래 collector도 동일 패턴
- `import re` 추가

### `tests/test_tune_risk_threshold.py`
- legacy `source == "google news"` assertion 폐기
- `example.com` netloc 결과 + 별도 `news.google.com` URL 추가로 양쪽 동작 검증

## Test plan

- [x] `python3 -m ruff check tests/test_check_description_quality.py tests/test_collector_integration.py tests/test_tune_risk_threshold.py` → All checks passed
- [x] `python3 -m pytest tests/test_check_description_quality.py tests/test_collector_integration.py tests/test_tune_risk_threshold.py --no-cov -q` → 115 passed
- [x] 전체 스위트: `4213 passed, 0 failed` (PR #947와 독립적, main 기준)

## Out of scope

- Production code 변경 없음 (테스트만)
- PR #947(`feat/summary-quality-facade-and-positive-validation`)과 독립적 — 어느 쪽 먼저 머지해도 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)