### PR TITLE
refactor(summary-quality): GENERIC_DESC_PATTERNS facade SSoT + parity 테스트

### DIFF
--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -163,59 +163,23 @@ def _generate_title_based_desc(title: str, theme_key: str) -> str:
     return f"{clean}. {ctx}"
 
 
-_GENERIC_DESC_PATTERNS = [
-    re.compile(r"에서 보도한 뉴스입니다\.?$"),
-    re.compile(r"에서 보도한 소식입니다\.?$"),
-    re.compile(r"관련 소식을 전했습니다\.?$"),
-    re.compile(r"원문에서 세부 내용을 확인하세요\.?$"),
-    re.compile(r"거래소 공지사항입니다\.?\s*$"),
-    re.compile(r"please enable javascript", re.I),
-    re.compile(r"^AMENDMENT NO\.", re.I),
-    re.compile(r"^FORM\s+\d", re.I),
-    re.compile(r"^access denied", re.I),
-    re.compile(r"^403 forbidden", re.I),
-    re.compile(r"^Your (?:privacy|cookie)", re.I),
-    re.compile(r"^We use cookies", re.I),
-    re.compile(r"^Subscribe to", re.I),
-    re.compile(r"^Sign up (?:for|to)", re.I),
-    re.compile(r"^JavaScript (?:is )?(?:required|must)", re.I),
-    re.compile(r"^This (?:page|site|website) (?:uses|requires)", re.I),
-    re.compile(r"^Loading\.\.\.", re.I),
-    re.compile(r"에서 확인하세요\.?\s*$"),
-    re.compile(r"^업데이트[\s:.]", re.I),
-    re.compile(r"관련 소식$"),
-    re.compile(r"^Read more", re.I),
-    re.compile(r"^Click here", re.I),
-    re.compile(r"^Continue reading", re.I),
-    re.compile(r"^This article", re.I),
-    re.compile(r"^The post .+ appeared first", re.I),
-    # Synced with enrichment.py _SYNTHETIC_MARKERS
-    re.compile(r"주시해야 합니다\.?\s*$"),
-    re.compile(r"확인하세요\.?\s*$"),
-    re.compile(r"관련 시장 동향입니다\.?\s*$"),
-    re.compile(r"관련 세부 내용은"),
-    re.compile(r"관련 변경사항을"),
-    re.compile(r"시장 심리와 가격"),
-    re.compile(r"투자 시사점을"),
-    re.compile(r"관련 소식입니다\.?\s*$"),
-    re.compile(r"거래소 공지사항"),
-    re.compile(r"산업 동향"),
-    re.compile(r"면밀히 분석해야 합니다"),
-    re.compile(r"함께 고려해야 합니다"),
-    re.compile(r"투자 판단 시"),
-    re.compile(r"관련 시장 뉴스입니다"),
-    re.compile(r"원문 기사의 세부 내용을 확인하세요"),
-    # New-style synthetic descriptions (fact-based with "보도" suffix)
-    re.compile(r"관련 보도\.?\s*$"),
-    re.compile(r"섹터 보도\.?\s*$"),
-    re.compile(r"산업 보도\.?\s*$"),
-    re.compile(r"시장 보도\.?\s*$"),
-]
+# Generic/synthetic description detection now lives in common.summary_quality.
+# The canonical list is ``summary_quality.GENERIC_DESC_PATTERNS`` — do not
+# redefine here. Attribute access via the module reference keeps the
+# circular import (summary_quality ↔ summarizer) safe by deferring lookup
+# to call time.
+from . import summary_quality as _summary_quality_mod  # noqa: E402
 
 
 def _is_generic_desc(desc: str) -> bool:
-    """Return True if description is a generic/synthetic placeholder with no real info."""
-    return any(p.search(desc.strip()) for p in _GENERIC_DESC_PATTERNS)
+    """Thin backward-compat wrapper around the facade's ``is_generic_desc``.
+
+    Existing internal callers (e.g. line 596 in this module) and the
+    ``summary_quality.is_boilerplate`` orchestrator both reach the facade
+    through this name. Future code should call
+    ``summary_quality.is_generic_desc(desc)`` directly.
+    """
+    return _summary_quality_mod.is_generic_desc(desc)
 
 
 # Known site boilerplate phrases that leak through translation

--- a/scripts/common/summary_quality.py
+++ b/scripts/common/summary_quality.py
@@ -4,20 +4,25 @@ Public API:
   - ``ARTICLE_SPECIFIC_RE`` — canonical positive-signal pattern. Both
     ``common.enrichment`` and ``scripts.fix_post_descriptions`` import it
     from here, so a pattern update lands in one place.
-  - ``is_boilerplate(desc)`` — orchestrates the three boilerplate detectors
-    (``common.enrichment._is_site_boilerplate``,
-    ``common.summarizer._is_generic_desc``,
-    ``common.summarizer._is_boilerplate_desc``).
+  - ``GENERIC_DESC_PATTERNS`` — canonical list of generic/synthetic
+    description regexes. ``common.summarizer`` consumes via the facade
+    so the patterns live in exactly one location.
   - ``has_positive_signal(body)`` — True if body carries a real-content
     token (number, currency, acronym, headline lead-in).
+  - ``is_generic_desc(desc)`` — True if desc matches any generic /
+    synthetic placeholder pattern. Single SSoT for generic-desc detection.
+  - ``is_boilerplate(desc)`` — orchestrates the three boilerplate detectors
+    (``common.enrichment._is_site_boilerplate``,
+    ``is_generic_desc`` defined here,
+    ``common.summarizer._is_boilerplate_desc``).
 
 Circular-import resolution: this module is imported both as a consumer
 (needs detectors from enrichment/summarizer) and as a provider (enrichment
-needs ARTICLE_SPECIFIC_RE). We bind sibling modules with
-``from . import <name> as _<name>_mod`` so each side only resolves the
-other's attributes lazily inside function bodies. ARTICLE_SPECIFIC_RE is
-defined BEFORE the sibling imports so partial-module access from
-enrichment during its own load finds the pattern.
+needs ARTICLE_SPECIFIC_RE; summarizer needs GENERIC_DESC_PATTERNS). We bind
+sibling modules with ``from . import <name> as _<name>_mod`` so each side
+only resolves the other's attributes lazily inside function bodies.
+Canonical patterns are defined BEFORE the sibling imports so partial-module
+access from enrichment/summarizer during their own load finds the patterns.
 
 Lookaround over ``\\b``: in Python 3 ``\\w`` includes Hangul, so
 ``\\b\\d{4}\\b`` does NOT match ``2026년`` (no boundary between ``6`` and
@@ -30,8 +35,10 @@ import re
 
 __all__ = [
     "ARTICLE_SPECIFIC_RE",
+    "GENERIC_DESC_PATTERNS",
     "has_positive_signal",
     "is_boilerplate",
+    "is_generic_desc",
 ]
 
 
@@ -63,6 +70,76 @@ def has_positive_signal(body: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Canonical generic/synthetic description patterns.
+# Migrated 2026-05-28 from ``common.summarizer._GENERIC_DESC_PATTERNS`` to
+# establish a single SSoT (PR #947 facade pattern extension). summarizer.py
+# now imports this list via the facade rather than redefining locally.
+# Defined BEFORE the sibling imports so summarizer.py can read it from a
+# partial summary_quality module during its own load.
+# ---------------------------------------------------------------------------
+GENERIC_DESC_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"에서 보도한 뉴스입니다\.?$"),
+    re.compile(r"에서 보도한 소식입니다\.?$"),
+    re.compile(r"관련 소식을 전했습니다\.?$"),
+    re.compile(r"원문에서 세부 내용을 확인하세요\.?$"),
+    re.compile(r"거래소 공지사항입니다\.?\s*$"),
+    re.compile(r"please enable javascript", re.I),
+    re.compile(r"^AMENDMENT NO\.", re.I),
+    re.compile(r"^FORM\s+\d", re.I),
+    re.compile(r"^access denied", re.I),
+    re.compile(r"^403 forbidden", re.I),
+    re.compile(r"^Your (?:privacy|cookie)", re.I),
+    re.compile(r"^We use cookies", re.I),
+    re.compile(r"^Subscribe to", re.I),
+    re.compile(r"^Sign up (?:for|to)", re.I),
+    re.compile(r"^JavaScript (?:is )?(?:required|must)", re.I),
+    re.compile(r"^This (?:page|site|website) (?:uses|requires)", re.I),
+    re.compile(r"^Loading\.\.\.", re.I),
+    re.compile(r"에서 확인하세요\.?\s*$"),
+    re.compile(r"^업데이트[\s:.]", re.I),
+    re.compile(r"관련 소식$"),
+    re.compile(r"^Read more", re.I),
+    re.compile(r"^Click here", re.I),
+    re.compile(r"^Continue reading", re.I),
+    re.compile(r"^This article", re.I),
+    re.compile(r"^The post .+ appeared first", re.I),
+    # Synced with enrichment.py _SYNTHETIC_MARKERS
+    re.compile(r"주시해야 합니다\.?\s*$"),
+    re.compile(r"확인하세요\.?\s*$"),
+    re.compile(r"관련 시장 동향입니다\.?\s*$"),
+    re.compile(r"관련 세부 내용은"),
+    re.compile(r"관련 변경사항을"),
+    re.compile(r"시장 심리와 가격"),
+    re.compile(r"투자 시사점을"),
+    re.compile(r"관련 소식입니다\.?\s*$"),
+    re.compile(r"거래소 공지사항"),
+    re.compile(r"산업 동향"),
+    re.compile(r"면밀히 분석해야 합니다"),
+    re.compile(r"함께 고려해야 합니다"),
+    re.compile(r"투자 판단 시"),
+    re.compile(r"관련 시장 뉴스입니다"),
+    re.compile(r"원문 기사의 세부 내용을 확인하세요"),
+    # New-style synthetic descriptions (fact-based with "보도" suffix)
+    re.compile(r"관련 보도\.?\s*$"),
+    re.compile(r"섹터 보도\.?\s*$"),
+    re.compile(r"산업 보도\.?\s*$"),
+    re.compile(r"시장 보도\.?\s*$"),
+]
+
+
+def is_generic_desc(desc: str) -> bool:
+    """Return True if desc matches any generic/synthetic placeholder pattern.
+
+    Single SSoT consumed by ``common.summarizer._is_generic_desc`` (kept as a
+    thin backward-compat wrapper) and by ``is_boilerplate`` orchestrator.
+    """
+    if not desc:
+        return False
+    body = desc.strip()
+    return any(p.search(body) for p in GENERIC_DESC_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
 # Sibling-module references for boilerplate orchestration.
 # Module-level bindings (``from . import X as _X_mod``) tolerate the cycle
 # because attribute lookup happens at call time, not load time.
@@ -74,15 +151,16 @@ from . import summarizer as _summarizer_mod  # noqa: E402
 def is_boilerplate(desc: str) -> bool:
     """Return True if desc matches any boilerplate / generic detector.
 
-    Orchestrates the three canonical detectors in ``common.enrichment`` /
-    ``common.summarizer``. This function is the single dependency that
-    consumers should import.
+    Orchestrates the three canonical detectors: site-level boilerplate
+    (``common.enrichment._is_site_boilerplate``), generic-desc patterns
+    (``is_generic_desc`` defined above), and the phrase-list filter
+    (``common.summarizer._is_boilerplate_desc``).
     """
     if not desc:
         return False
     if _enrichment_mod._is_site_boilerplate(desc):
         return True
-    if _summarizer_mod._is_generic_desc(desc):
+    if is_generic_desc(desc):
         return True
     if _summarizer_mod._is_boilerplate_desc(desc):
         return True

--- a/tests/test_generic_desc_parity.py
+++ b/tests/test_generic_desc_parity.py
@@ -1,0 +1,198 @@
+"""Pattern parity regression tests for the GENERIC_DESC_PATTERNS facade.
+
+Pins the contract that ``scripts/common/summary_quality.GENERIC_DESC_PATTERNS``
+is the **single source of truth** for generic / synthetic description
+detection. The only consumer ``scripts/common/summarizer._is_generic_desc``
+must delegate to the facade rather than maintaining a local pattern list.
+
+If a stale local ``_GENERIC_DESC_PATTERNS = [...]`` re-appears in any
+consumer module, these tests fail loudly. The 30-sample regression matrix
+also pins the matching behavior so accidental tightening or relaxation
+surfaces immediately.
+
+Mirrors ``tests/test_pattern_parity.py`` (ARTICLE_SPECIFIC_RE parity) — same
+pattern, different facade artifact.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from common import summarizer as _summarizer_mod  # noqa: E402
+from common import summary_quality as _summary_quality_mod  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# 30-sample regression matrix.
+# Each tuple: (label, sample, expected_match).
+# Covers every category of GENERIC_DESC_PATTERNS:
+#   - Korean "보도/소식/공지" sentence-ending fillers
+#   - HTTP error pages (access denied, 403, etc.)
+#   - JS/cookie/subscribe boilerplate
+#   - SEC form / amendment headers
+#   - Synthetic markers from enrichment.py (확인하세요, 주시해야, etc.)
+#   - New-style fact-based "보도" suffix
+#   - Plus negative samples carrying real content so the pattern cannot
+#     silently broaden into matching real news bodies.
+# ---------------------------------------------------------------------------
+SAMPLES: list[tuple[str, str, bool]] = [
+    # --- Korean sentence-ending fillers ---
+    ("filler-bodo-news", "한국경제에서 보도한 뉴스입니다.", True),
+    ("filler-bodo-sosik", "연합뉴스에서 보도한 소식입니다.", True),
+    ("filler-jeonhaem", "관련 소식을 전했습니다.", True),
+    ("filler-wonmun-detail", "원문에서 세부 내용을 확인하세요.", True),
+    ("filler-gyeocaeso", "거래소 공지사항입니다.", True),
+    ("filler-confirm-here", "공식 사이트에서 확인하세요.", True),
+    ("filler-bare-sosik", "관련 소식", True),
+    # --- HTTP / JS / cookie boilerplate (English) ---
+    ("http-403", "403 Forbidden access", True),
+    ("http-access-denied", "Access denied to this resource", True),
+    ("http-please-js", "Please enable JavaScript to view this page.", True),
+    ("http-cookie-notice", "We use cookies to improve experience.", True),
+    ("http-subscribe", "Subscribe to our newsletter today!", True),
+    ("http-signup", "Sign up for the latest updates.", True),
+    ("http-js-required", "JavaScript is required to run this app.", True),
+    ("http-loading", "Loading... please wait.", True),
+    # --- SEC / form headers ---
+    ("sec-amendment", "AMENDMENT NO. 3 filed 2026-05-15", True),
+    ("sec-form", "FORM 10-K Annual Report", True),
+    # --- Read-more / click-here ---
+    ("clickbait-read-more", "Read more about the latest research", True),
+    ("clickbait-click-here", "Click here for full coverage", True),
+    ("clickbait-this-article", "This article is reserved for premium readers.", True),
+    # --- Synthetic markers (from enrichment.py) ---
+    ("synth-watch", "관련 동향을 주시해야 합니다.", True),
+    ("synth-market", "시장 심리와 가격이 동행합니다.", True),
+    ("synth-investment-implication", "투자 시사점을 신중히 검토해야 합니다.", True),
+    ("synth-tradition", "관련 시장 뉴스입니다.", True),
+    # --- New-style "보도" suffix ---
+    ("bodo-related", "이슈 관련 보도.", True),
+    ("bodo-sector", "반도체 섹터 보도.", True),
+    ("bodo-industry", "에너지 산업 보도.", True),
+    # --- Negatives: real news bodies must NOT match ---
+    ("neg-empty", "", False),
+    ("neg-real-news-kr", "삼성전자가 2026년 1분기에 매출 71조원을 기록했다.", False),
+    ("neg-real-news-en", "Apple announced record iPhone shipments in Q1 2026.", False),
+]
+
+_SAMPLE_IDS = [s[0] for s in SAMPLES]
+
+
+# ---------------------------------------------------------------------------
+# 1. Identity: the canonical patterns object lives in summary_quality.
+# ---------------------------------------------------------------------------
+def test_facade_exposes_canonical_pattern_list() -> None:
+    """summary_quality must export ``GENERIC_DESC_PATTERNS`` as a list of compiled regexes."""
+    patterns = _summary_quality_mod.GENERIC_DESC_PATTERNS
+    assert isinstance(patterns, list), "GENERIC_DESC_PATTERNS must be a list"
+    assert len(patterns) >= 30, f"expected ≥30 patterns, got {len(patterns)}"
+    import re
+
+    assert all(isinstance(p, re.Pattern) for p in patterns), "all entries must be compiled re.Pattern objects"
+
+
+def test_summarizer_is_generic_desc_delegates_to_facade() -> None:
+    """summarizer._is_generic_desc must call into the facade, not a local list."""
+    # The wrapper's body should reach into _summary_quality_mod. The cleanest
+    # contract check: the wrapper and facade produce identical results across
+    # the full sample matrix (covered by test_consumers_match below). Here we
+    # add a structural check that the summarizer module no longer carries a
+    # local pattern list.
+    assert not hasattr(_summarizer_mod, "_GENERIC_DESC_PATTERNS"), (
+        "summarizer._GENERIC_DESC_PATTERNS still exists — facade SSoT broken."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Static AST guard: no module outside summary_quality.py may assign a
+#    *GENERIC_DESC_PATTERNS list literal containing re.compile(...) entries.
+# ---------------------------------------------------------------------------
+_FORBIDDEN_REDEFINITION_PATHS = [
+    _SCRIPTS_DIR / "common" / "summarizer.py",
+    _SCRIPTS_DIR / "common" / "enrichment.py",
+    _SCRIPTS_DIR / "fix_post_descriptions.py",
+    _SCRIPTS_DIR / "check_description_quality.py",
+    _SCRIPTS_DIR / "check_post_summary.py",
+]
+
+
+@pytest.mark.parametrize(
+    "path",
+    _FORBIDDEN_REDEFINITION_PATHS,
+    ids=lambda p: p.relative_to(_REPO_ROOT).as_posix(),
+)
+def test_no_local_generic_desc_pattern_list(path: Path) -> None:
+    """AST-walk consumer module: refuse any *GENERIC_DESC_PATTERNS list literal."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id.endswith("GENERIC_DESC_PATTERNS"):
+                if isinstance(node.value, (ast.List, ast.Tuple)):
+                    offenders.append(f"line {node.lineno}: {target.id} = [...]")
+    assert not offenders, (
+        f"{path.relative_to(_REPO_ROOT)} re-introduced a local GENERIC_DESC_PATTERNS "
+        f"definition — facade SSoT broken:\n  " + "\n  ".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. 30-sample expected-match regression — facade direct path.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(("label", "sample", "expected"), SAMPLES, ids=_SAMPLE_IDS)
+def test_facade_is_generic_desc(label: str, sample: str, expected: bool) -> None:
+    """Pin per-branch matching behavior of summary_quality.is_generic_desc."""
+    actual = _summary_quality_mod.is_generic_desc(sample)
+    assert actual is expected, f"[{label}] expected match={expected} got {actual}: {sample!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Parity: facade ⇔ summarizer wrapper must agree on every sample.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(("label", "sample", "expected"), SAMPLES, ids=_SAMPLE_IDS)
+def test_facade_and_summarizer_wrapper_match(label: str, sample: str, expected: bool) -> None:
+    """Facade and summarizer._is_generic_desc must agree on every sample."""
+    via_facade = _summary_quality_mod.is_generic_desc(sample)
+    via_wrapper = _summarizer_mod._is_generic_desc(sample)
+    assert via_facade == via_wrapper, (
+        f"[{label}] parity broken — facade={via_facade}, wrapper={via_wrapper}: {sample!r}"
+    )
+    assert via_facade is expected
+
+
+# ---------------------------------------------------------------------------
+# 5. is_boilerplate orchestrator must classify every positive generic sample
+#    as boilerplate (since is_generic_desc is one of its 3 detectors).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("label", "sample"),
+    [(s[0], s[1]) for s in SAMPLES if s[2]],
+    ids=[s[0] for s in SAMPLES if s[2]],
+)
+def test_is_boilerplate_subsumes_generic_desc(label: str, sample: str) -> None:
+    """Every generic-desc positive must also be flagged by is_boilerplate."""
+    assert _summary_quality_mod.is_boilerplate(sample), (
+        f"[{label}] is_generic_desc=True but is_boilerplate=False: {sample!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Coverage guard.
+# ---------------------------------------------------------------------------
+def test_sample_matrix_has_balanced_polarities() -> None:
+    """Matrix must include both positive and negative samples (no all-True drift)."""
+    positives = sum(1 for _, _, exp in SAMPLES if exp)
+    negatives = sum(1 for _, _, exp in SAMPLES if not exp)
+    assert positives >= 24, f"expected ≥24 positive samples, got {positives}"
+    assert negatives >= 3, f"expected ≥3 negative samples, got {negatives}"
+    assert len(SAMPLES) == 30, f"matrix must have exactly 30 samples, got {len(SAMPLES)}"


### PR DESCRIPTION
## Summary

PR #947 의 `ARTICLE_SPECIFIC_RE` facade 패턴을 **`GENERIC_DESC_PATTERNS`** (44개 정규식 리스트) 에 동일 확장. SSoT는 `scripts/common/summary_quality.py` 단일 모듈.

### 변경

- `scripts/common/summary_quality.py` — `GENERIC_DESC_PATTERNS` (public) + `is_generic_desc()` (public) canonical 정의. orchestrator `is_boilerplate()` 가 직접 `is_generic_desc()` 호출하도록 변경 (이전: `_summarizer_mod._is_generic_desc()` 우회).
- `scripts/common/summarizer.py` — 로컬 `_GENERIC_DESC_PATTERNS` 리스트 (45 줄) 삭제. `_is_generic_desc()` 는 facade 로 위임하는 thin wrapper.
- `tests/test_generic_desc_parity.py` — 신규 회귀 가드 95 tests.

### 순환 import 처리

ARTICLE_SPECIFIC_RE 와 동일한 lazy-binding 패턴:
- `summary_quality.py` 가 `GENERIC_DESC_PATTERNS` / `is_generic_desc` 정의 → BEFORE `from . import summarizer as _summarizer_mod`
- `summarizer.py` 가 `from . import summary_quality as _summary_quality_mod` → call 시점에 속성 lookup

### Regression guard 6 layers

| 레이어 | 목적 |
|--------|------|
| **facade exposure** | `GENERIC_DESC_PATTERNS` 가 public 리스트 of compiled regex |
| **structural** | summarizer.py 에 `_GENERIC_DESC_PATTERNS` attribute 부재 |
| **AST guard** | 5개 consumer 모듈 (summarizer / enrichment / fix_post / check_desc / check_post) 에 `*GENERIC_DESC_PATTERNS` 리스트 정의 시 즉시 fail |
| **30-sample matrix** | filler / HTTP / SEC / synthetic / "보도" suffix / negatives |
| **wrapper parity** | facade ⇔ summarizer wrapper 30 표본 100% 일치 |
| **orchestrator subsumption** | 27 positive 모두 `is_boilerplate=True` |

### Test plan

- [x] `pytest tests/test_generic_desc_parity.py` → 95 passed
- [x] `pytest tests/` (전체 회귀) → 4485 passed, 77 skipped, 0 failed
- [x] `ruff check + format` → clean
- [x] `pre-commit run` → all hooks Passed
- [ ] CI Code Quality green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)