### PR TITLE
fix(security): Bandit / pip-audit silent-fail 제거 — 보안 게이트 실질화

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -31,12 +31,19 @@ jobs:
       - name: Install dependencies
         run: pip install -r scripts/requirements.txt pip-audit
 
+      # 게이트 설계:
+      #   - pip-audit 은 발견 시 exit 1. 내부 `|| true` 는 JSON 추출이 끝까지
+      #     실행되도록 유지 (그렇지 않으면 set -e 로 VULN_COUNT 계산 전 종료).
+      #   - step-level `continue-on-error: true` 는 제거 → JSON 파싱 실패 같은
+      #     run-block 오류는 step 실패로 즉시 표면화.
+      #   - 취약점 발견 시 잡 실패는 마지막 "Fail on vulnerabilities" step 에서
+      #     명시 처리. 이전: continue-on-error + || true 조합으로 step 항상
+      #     success → 이슈만 만들고 CI 통과 → silent fail.
       - name: Run pip-audit
         id: audit
-        continue-on-error: true
         run: |
           pip-audit -r scripts/requirements.txt --format=json --output=audit-report.json 2>&1 || true
-          pip-audit -r scripts/requirements.txt 2>&1 | tee audit-report.txt
+          pip-audit -r scripts/requirements.txt 2>&1 | tee audit-report.txt || true
 
           VULN_COUNT=$(python3 -c "
           import json
@@ -91,3 +98,9 @@ jobs:
             }
         env:
           VULN_COUNT: ${{ steps.audit.outputs.vuln_count }}
+
+      - name: Fail on vulnerabilities
+        if: steps.audit.outputs.vuln_count != '0'
+        run: |
+          echo "::error title=pip-audit findings::pip-audit 가 ${{ steps.audit.outputs.vuln_count }} 건의 취약점을 발견했습니다. audit-report.txt 와 자동 생성된 이슈를 확인하세요."
+          exit 1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -42,15 +42,22 @@ jobs:
       - name: Install bandit
         run: pip install bandit[sarif]
 
+      # 게이트 설계:
+      #   - bandit 은 medium+ severity/confidence 에서 발견 시 exit 1.
+      #   - SARIF 업로드는 항상 수행 (GitHub Security 탭에 트렌드 보존) → upload
+      #     step 에 `if: always()`.
+      #   - 잡 실패는 마지막 "Fail on bandit findings" step 에서 명시적으로 처리.
+      #     이전: `|| true` 로 즉시 swallow → 발견되어도 잡 success → silent fail.
       - name: Run bandit security scan
+        id: bandit-sarif
+        continue-on-error: true
         run: |
           bandit -r scripts/ \
             -f sarif \
             -o bandit-results.sarif \
             --severity-level medium \
             --confidence-level medium \
-            -x scripts/verify_rendered_fixtures.py,scripts/validate_collector_summary_contract.py \
-            || true
+            -x scripts/verify_rendered_fixtures.py,scripts/validate_collector_summary_contract.py
 
       - name: Upload SARIF to GitHub Security
         if: always()
@@ -60,6 +67,8 @@ jobs:
           category: bandit
 
       - name: Run bandit (human-readable)
+        id: bandit-summary
+        continue-on-error: true
         run: |
           echo "## Bandit Security Report" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
@@ -67,8 +76,19 @@ jobs:
             --severity-level medium \
             --confidence-level medium \
             -x scripts/verify_rendered_fixtures.py,scripts/validate_collector_summary_contract.py \
-            2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+            2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          PIPE_STATUS=("${PIPESTATUS[@]}")
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # bandit exit (PIPESTATUS[0]) 가 0 이 아니면 step outcome = failure.
+          exit "${PIPE_STATUS[0]}"
+
+      - name: Fail on bandit findings
+        if: steps.bandit-sarif.outcome == 'failure' || steps.bandit-summary.outcome == 'failure'
+        run: |
+          echo "::error title=Bandit findings::Bandit SAST 가 medium+ 심각도 이슈를 발견했습니다. SARIF 업로드 결과를 GitHub Security 탭에서 확인하세요."
+          echo "  - bandit-sarif outcome: ${{ steps.bandit-sarif.outcome }}"
+          echo "  - bandit-summary outcome: ${{ steps.bandit-summary.outcome }}"
+          exit 1
 
   gitleaks:
     name: Secret Detection


### PR DESCRIPTION
## Summary

[2026-05-28 CI health audit](https://github.com/Twodragon0/investing/blob/main/.omc/wiki/2026-05-28-ci-health-audit.md) 가 confirmed 한 silent-fail 패턴 2종 제거.

### Before

| 워크플로우 | 라인 | 패턴 | 결과 |
|----------|-----|------|------|
| `security-scan.yml:53` | bandit SARIF | `\| \| true` | medium+ 발견해도 step success → 잡 통과 |
| `security-scan.yml:70` | bandit human-readable | `\| \| true` + pipe to tee | 동일 (tee 가 0) |
| `dependency-check.yml:36` | `Run pip-audit` | `continue-on-error: true` + 내부 `\| \| true` 이중 | 취약점 발견해도 step 항상 success |

### After (capture + explicit gate)

1. bandit SARIF — `continue-on-error: true` + `id: bandit-sarif`. SARIF 업로드는 기존대로 `if: always()` (Security 탭 트렌드 유지).
2. bandit human-readable — `PIPESTATUS[0]` 로 bandit 본체 exit 캡처 후 `exit \"\${PIPE_STATUS[0]}\"` (tee 가 0 인 문제 해소). `continue-on-error: true` + `id: bandit-summary`.
3. 새 step "Fail on bandit findings" 가 두 outcome 중 하나라도 failure 면 명시 exit 1.
4. pip-audit — step-level `continue-on-error: true` 제거. 내부 `\| \| true` 는 VULN_COUNT 계산까지 set -e 가 끊지 않도록 유지. 새 step "Fail on vulnerabilities" 가 `vuln_count != '0'` 일 때 명시 exit 1.

이슈 자동 생성(dependency-check) 은 그대로 유지 → 잡 fail 과 issue 가 동시 발생.

## Why

- Audit 가 명시한 confirmed silent-fail. 회귀가 main 에 들어와도 CI 가 green → 가시화 zero.
- 본 PR 이후: 회귀 시 CI red + 이슈 자동 생성 + Security 탭 SARIF 트렌드 보존.

## Test plan

- [x] \`actionlint .github/workflows/security-scan.yml dependency-check.yml\` → exit 0
- [x] \`pre-commit run --files ...\` → all hooks Passed
- [ ] CI Code Quality + Security Scan + Dependency Security Check 잡이 main 코드에서 green (실제 취약점 없음 가정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)