### PR TITLE
fix(workflows): description-quality-check workflow_run conclusion gate 추가

### DIFF
--- a/.github/workflows/description-quality-check.yml
+++ b/.github/workflows/description-quality-check.yml
@@ -28,6 +28,13 @@ concurrency:
 
 jobs:
   quality-check:
+    # workflow_run 트리거 시 upstream 수집기 잡이 success 인 경우에만 실행.
+    # 이전: collector 실패 후에도 stale _posts 에 대해 quality 검사가 돌아
+    # 가짜 결과(빈 _posts 기반)를 산출 → silent fail. push / pull_request /
+    # workflow_dispatch 트리거는 게이트 우회.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

[2026-05-28 CI health audit](https://github.com/Twodragon0/investing/blob/main/.omc/wiki/2026-05-28-ci-health-audit.md) 가 confirmed 한 silent-fail 패턴 1종 제거.

### Before

`workflow_run` 트리거가 upstream \"Collect Crypto News\" / \"Collect Stock News\" 완료 이벤트에 **conclusion 가드 없이** 반응:

```yaml
workflow_run:
  workflows: [\"Collect Crypto News\", \"Collect Stock News\"]
  types: [completed]
```

→ collector 잡이 **실패** 한 후에도 quality 잡이 실행되어 stale `_posts/` 에 대해 가짜 결과 산출. PR comment 도 workflow_run 이벤트에는 안 나가므로 회귀가 **어느 surface 에도 안 보임**.

### After

quality-check 잡의 `if` 조건에 conclusion 게이트 추가:

```yaml
jobs:
  quality-check:
    if: >-
      github.event_name != 'workflow_run' ||
      github.event.workflow_run.conclusion == 'success'
```

- `workflow_run` 이벤트: upstream **성공** 시에만 실행 (회귀 차단)
- `push` / `pull_request` / `workflow_dispatch`: 영향 없음 (계속 실행)

## Test plan

- [x] \`actionlint .github/workflows/description-quality-check.yml\` → exit 0
- [ ] CI Code Quality green
- [ ] (간접) collector 실패 시 quality 잡 skipped 로 표시되는지 확인 (실 운영 모니터링)

🤖 Generated with [Claude Code](https://claude.com/claude-code)