### PR TITLE
perf(ci): code-quality paths-ignore + ops-10am-digest pip cache

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,6 +3,13 @@ name: Code Quality
 on:
   push:
     branches: [main]
+    # 수집기 자동 커밋(_state/, assets/images/generated/) 만의 변경에는 풀
+    # Code Quality 실행이 의미 없음 (코드 변경 없음). 4000+ 테스트 + ruff +
+    # pre-commit 풀 스위트가 매 collector 커밋마다 도는 운영 노이즈 제거.
+    # _posts/** 는 Jekyll 콘텐츠 변경이므로 trigger 유지.
+    paths-ignore:
+      - '_state/**'
+      - 'assets/images/generated/**'
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/ops-10am-digest.yml
+++ b/.github/workflows/ops-10am-digest.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: scripts/requirements.txt
 
       - name: Install Python dependencies
         run: pip install -r scripts/requirements.txt


### PR DESCRIPTION
## Summary

운영 노이즈 / CI 피드백 속도 개선 2건. (PUBLIC repo → Actions 무료지만 Actions 탭 노이즈와 큐 점유 감소.)

### 1. code-quality.yml — `paths-ignore` on push trigger

수집기 자동 커밋(\`_state/\`, \`assets/images/generated/\`) **만의** 변경은 코드 변경이 없는데 풀 Code Quality 실행(ruff + pre-commit + 4000+ pytest) 이 매번 트리거됨. 매일 발생하는 collector 커밋 다수가 이 패턴.

```yaml
paths-ignore:
  - '_state/**'
  - 'assets/images/generated/**'
```

\`_posts/**\` 는 Jekyll 콘텐츠 변경이므로 trigger 유지. PR / schedule / workflow_dispatch 도 영향 없음.

### 2. ops-10am-digest.yml — `cache: 'pip'` on setup-python

\`scripts/requirements.txt\` 기반 pip install (~30-60s 콜드) → 매일 KST 10:00 cron 이므로 cache hit 거의 보장.

## Why broader cleanup not included

| 후보 | 결정 | 이유 |
|------|------|------|
| watchdog-zero-job-runs `*/5` cron | skip | 주석에 "trade-off ... avoids 30 API calls per 5-min tick" 명시 — 의도된 safety net |
| artifact retention | skip | 이미 14/30/7d 등 합리적 |
| security-scan bandit cache | skip | 단일 5MB 패키지 — 캐시 오버헤드 ≈ 절감, 순효과 0 |
| check-post-summary / coverage-comment / deploy-pages / indexnow-submit cache | skip | 실제 pip install 안 함 (인라인 스크립트 목적) |

## Test plan

- [x] \`actionlint .github/workflows/code-quality.yml ops-10am-digest.yml\` → exit 0
- [ ] CI Code Quality 잡 green (이 PR 자체는 \`.github/workflows/**\` 변경이므로 paths-ignore 제외 — 정상 실행 확인)
- [ ] (간접 검증) 머지 후 다음 collector 자동 커밋에서 Code Quality 가 skip 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)