### PR TITLE
feat(slack): resolve-slack-config v2 additive + naming unification design

### DIFF
--- a/.github/actions/resolve-slack-config/action.yml
+++ b/.github/actions/resolve-slack-config/action.yml
@@ -1,37 +1,49 @@
 name: Resolve Slack Config
-description: Resolve Slack bot token and channel from candidate secrets
+description: Resolve Slack bot token and channel from canonical env or legacy candidate inputs.
+
+# v2 — additive migration. Accepts both:
+#   - New interface: target_channel_alias + bot, channel/token values from env (canonical names)
+#   - Legacy interface (v1): token_candidates + channel_candidates_<alias> input strings
+# Precedence: new env-based lookup wins; legacy inputs are fallback only.
+# Design: docs/slack-secret-naming-unification.md § 5
 
 inputs:
   target_channel_alias:
-    description: Channel alias (ops/dev/security/openclaw/investing)
+    description: Channel alias (ops|dev|security|openclaw|ai|investing). Unknown → default.
     required: false
     default: investing
+  bot:
+    description: Bot variant (default|ai|openclaw). Unknown → step fails (fail-loud).
+    required: false
+    default: default
+
+  # --- Legacy v1 inputs (kept for backward compatibility through Phase 4) ---
   token_candidates:
-    description: Newline-separated token candidates in priority order
+    description: "[legacy] Newline-separated bot token candidates in priority order"
     required: false
     default: ""
   channel_candidates_default:
-    description: Newline-separated default channel candidates
+    description: "[legacy] Newline-separated default channel candidates"
     required: false
     default: ""
   channel_candidates_ops:
-    description: Newline-separated ops channel candidates
+    description: "[legacy] Newline-separated ops channel candidates"
     required: false
     default: ""
   channel_candidates_dev:
-    description: Newline-separated dev channel candidates
+    description: "[legacy] Newline-separated dev channel candidates"
     required: false
     default: ""
   channel_candidates_security:
-    description: Newline-separated security channel candidates
+    description: "[legacy] Newline-separated security channel candidates"
     required: false
     default: ""
   channel_candidates_openclaw:
-    description: Newline-separated openclaw channel candidates
+    description: "[legacy] Newline-separated openclaw channel candidates"
     required: false
     default: ""
   channel_candidates_investing:
-    description: Newline-separated investing channel candidates
+    description: "[legacy] Newline-separated investing channel candidates"
     required: false
     default: ""
 
@@ -40,10 +52,10 @@ outputs:
     description: True when token and channel are both resolved
     value: ${{ steps.resolve.outputs.can_post }}
   token:
-    description: Resolved Slack bot token
+    description: Resolved Slack bot token (masked in logs via ::add-mask::)
     value: ${{ steps.resolve.outputs.token }}
   channel:
-    description: Resolved Slack channel ID/name
+    description: Resolved Slack channel ID/name (NOT masked — public identifier per Slack model)
     value: ${{ steps.resolve.outputs.channel }}
   alias:
     description: Normalized target alias
@@ -59,7 +71,10 @@ runs:
       id: resolve
       shell: bash
       env:
+        # New interface inputs
         INPUT_TARGET_ALIAS: ${{ inputs.target_channel_alias }}
+        INPUT_BOT: ${{ inputs.bot }}
+        # Legacy v1 inputs
         INPUT_TOKEN_CANDIDATES: ${{ inputs.token_candidates }}
         INPUT_CHANNEL_DEFAULT: ${{ inputs.channel_candidates_default }}
         INPUT_CHANNEL_OPS: ${{ inputs.channel_candidates_ops }}
@@ -81,51 +96,90 @@ runs:
           return 1
         }
 
+        # --- 1) Normalize alias (whitelist + default fallback for unknown) ---
         alias="$(printf '%s' "${INPUT_TARGET_ALIAS:-investing}" | tr '[:upper:]' '[:lower:]')"
         case "$alias" in
-          ops|dev|security|openclaw|investing) ;;
+          ops|dev|security|openclaw|ai|investing) ;;
           *) alias="investing" ;;
         esac
 
-        token=""
-        if token_candidate="$(printf '%s\n' "${INPUT_TOKEN_CANDIDATES:-}" | first_non_empty 2>/dev/null)"; then
-          token="$token_candidate"
-        fi
-
-        channel_candidates="${INPUT_CHANNEL_DEFAULT:-}"
-        case "$alias" in
-          ops)
-            if [ -n "${INPUT_CHANNEL_OPS:-}" ]; then channel_candidates="${INPUT_CHANNEL_OPS}"; fi
-            ;;
-          dev)
-            if [ -n "${INPUT_CHANNEL_DEV:-}" ]; then channel_candidates="${INPUT_CHANNEL_DEV}"; fi
-            ;;
-          security)
-            if [ -n "${INPUT_CHANNEL_SECURITY:-}" ]; then channel_candidates="${INPUT_CHANNEL_SECURITY}"; fi
-            ;;
-          openclaw)
-            if [ -n "${INPUT_CHANNEL_OPENCLAW:-}" ]; then channel_candidates="${INPUT_CHANNEL_OPENCLAW}"; fi
-            ;;
-          investing)
-            if [ -n "${INPUT_CHANNEL_INVESTING:-}" ]; then channel_candidates="${INPUT_CHANNEL_INVESTING}"; fi
+        # --- 2) Normalize bot (whitelist, FAIL-LOUD on unknown) ---
+        bot="$(printf '%s' "${INPUT_BOT:-default}" | tr '[:upper:]' '[:lower:]')"
+        case "$bot" in
+          default|ai|openclaw) ;;
+          *)
+            echo "::error::unknown bot=${INPUT_BOT}; allowed: default|ai|openclaw"
+            exit 1
             ;;
         esac
 
+        # --- 3) Token resolution via case (set -u safe, no indirect expansion) ---
+        token=""
+        case "$bot" in
+          default)  token="${SLACK_BOT_TOKEN:-}" ;;
+          ai)       token="${SLACK_AI_BOT_TOKEN:-}" ;;
+          openclaw) token="${SLACK_OPENCLAW_BOT_TOKEN:-}" ;;
+        esac
+
+        # --- 4) Channel resolution via case (set -u safe) ---
         channel=""
-        if channel_candidate="$(printf '%s\n' "${channel_candidates:-}" | first_non_empty 2>/dev/null)"; then
-          channel="$channel_candidate"
+        case "$alias" in
+          ops)        channel="${SLACK_CHANNEL_ID_OPS:-}" ;;
+          dev)        channel="${SLACK_CHANNEL_ID_DEV:-}" ;;
+          security)   channel="${SLACK_CHANNEL_ID_SECURITY:-}" ;;
+          openclaw)   channel="${SLACK_CHANNEL_ID_OPENCLAW:-}" ;;
+          ai)         channel="${SLACK_CHANNEL_ID_AI:-}" ;;
+          investing)  channel="${SLACK_CHANNEL_ID_INVESTING:-}" ;;
+        esac
+
+        # --- 5) Channel default fallback ---
+        if [ -z "$channel" ]; then
+          channel="${SLACK_CHANNEL_ID:-}"
         fi
 
+        # --- 6) Legacy v1 token fallback (only if new lookup yielded empty) ---
+        if [ -z "$token" ] && [ -n "${INPUT_TOKEN_CANDIDATES:-}" ]; then
+          if cand="$(printf '%s\n' "$INPUT_TOKEN_CANDIDATES" | first_non_empty 2>/dev/null)"; then
+            token="$cand"
+          fi
+        fi
+
+        # --- 7) Legacy v1 channel fallback (alias-specific input → default input) ---
+        if [ -z "$channel" ]; then
+          legacy_list=""
+          case "$alias" in
+            ops)        legacy_list="${INPUT_CHANNEL_OPS:-}" ;;
+            dev)        legacy_list="${INPUT_CHANNEL_DEV:-}" ;;
+            security)   legacy_list="${INPUT_CHANNEL_SECURITY:-}" ;;
+            openclaw)   legacy_list="${INPUT_CHANNEL_OPENCLAW:-}" ;;
+            investing)  legacy_list="${INPUT_CHANNEL_INVESTING:-}" ;;
+            *)          legacy_list="" ;;
+          esac
+          if [ -z "$legacy_list" ]; then
+            legacy_list="${INPUT_CHANNEL_DEFAULT:-}"
+          fi
+          if [ -n "$legacy_list" ]; then
+            if cand="$(printf '%s\n' "$legacy_list" | first_non_empty 2>/dev/null)"; then
+              channel="$cand"
+            fi
+          fi
+        fi
+
+        # --- 8) Whitespace trim (preserve v1 hardening — Reviewer B MINOR) ---
+        token="$(printf '%s' "$token" | xargs || printf '')"
+        channel="$(printf '%s' "$channel" | xargs || printf '')"
+
+        # --- 9) Compute can_post, mask token ---
         can_post="true"
         if [ -z "$token" ] || [ -z "$channel" ]; then
           can_post="false"
         fi
 
-        profile_label="${alias}-agent"
-
         if [ -n "$token" ]; then
           echo "::add-mask::$token"
         fi
+
+        profile_label="${alias}-agent"
 
         {
           echo "can_post=$can_post"

--- a/docs/runbook-slack-vault-snapshot.md
+++ b/docs/runbook-slack-vault-snapshot.md
@@ -1,0 +1,184 @@
+# Runbook — Slack Legacy Token Vault Snapshot (Phase 0.5)
+
+> Status: **Runbook (executable)**
+> Owner: investing platform
+> Related design: `docs/slack-secret-naming-unification.md` § 6 Phase 0.5
+> Last updated: 2026-06-01
+
+## 0. Why this exists
+
+`docs/slack-secret-naming-unification.md` Phase 4 deletes 2 legacy GitHub
+Actions secrets:
+
+- `AI_SLACK_BOT_TOKEN`
+- `OPENCLAW_SLACK_BOT_TOKEN`
+
+`gh secret delete` is destructive — GitHub does not retain the plaintext value
+after deletion. If we delete before backing up, rollback requires regenerating
+the tokens from the Slack admin console (lossy, requires re-installation, and
+may break running bots if the old token is invalidated).
+
+This runbook captures the values in a durable vault and proves the restore
+path works **before** Phase 4 unblocks.
+
+## 1. Scope
+
+| Item | What | Where |
+|---|---|---|
+| Backup target | 2 token values (legacy names) | GitHub repo secrets → vault |
+| Vault entry name | `gh-investing-<SECRET_NAME>` | namespaced |
+| Verification | 1 restore test (vault → fresh repo secret → delete) | once |
+| Snapshot artifact path | runbook-only memo, value not committed | tracked separately |
+
+Channel ID secrets are out of scope — they are public identifiers (`Cxxxxx`),
+not credentials, and can be recovered from the Slack channel settings.
+
+## 2. Prerequisites
+
+- `gh` CLI authenticated to `Twodragon0/investing` with `repo` scope.
+- One of: 1Password CLI (`op`), SOPS + age, or Bitwarden CLI (`bw`).
+- Operator with admin access to the Slack workspace (recovery path only).
+
+## 3. Procedure
+
+### 3.1 Option A — 1Password CLI
+
+```bash
+# 1) Resolve current value from GitHub (NOT possible — gh does not expose values).
+#    Operator must already hold the token via:
+#      - Slack admin console (App Management → reinstall to view) — last resort
+#      - Existing 1Password / Bitwarden / SOPS entry from when the token was first created
+#      - Operator memory / sealed envelope
+
+# 2) Write to 1Password (no value in shell history — uses stdin)
+op item create \
+  --category="API Credential" \
+  --title="gh-investing-AI_SLACK_BOT_TOKEN" \
+  --vault="Investing" \
+  --tags="github,slack,migration-2026-06" \
+  credential[password]="$(read -rs -p 'paste AI_SLACK_BOT_TOKEN: ' v && echo "$v"; echo >&2)"
+
+op item create \
+  --category="API Credential" \
+  --title="gh-investing-OPENCLAW_SLACK_BOT_TOKEN" \
+  --vault="Investing" \
+  --tags="github,slack,migration-2026-06" \
+  credential[password]="$(read -rs -p 'paste OPENCLAW_SLACK_BOT_TOKEN: ' v && echo "$v"; echo >&2)"
+
+# 3) Verify retrieval works
+op item get "gh-investing-AI_SLACK_BOT_TOKEN" --field credential >/dev/null && echo "OK: AI"
+op item get "gh-investing-OPENCLAW_SLACK_BOT_TOKEN" --field credential >/dev/null && echo "OK: OPENCLAW"
+```
+
+### 3.2 Option B — SOPS + age
+
+```bash
+# 1) Ensure age key exists
+test -f ~/.config/sops/age/keys.txt || age-keygen -o ~/.config/sops/age/keys.txt
+
+# 2) Create encrypted YAML
+cat > /tmp/slack-legacy.yaml.dec <<'YAML'
+AI_SLACK_BOT_TOKEN: ""
+OPENCLAW_SLACK_BOT_TOKEN: ""
+YAML
+
+# Edit with the real values — file is plaintext until encrypted
+${EDITOR:-vi} /tmp/slack-legacy.yaml.dec
+
+# 3) Encrypt in place
+AGE_PUBKEY="$(grep '# public key:' ~/.config/sops/age/keys.txt | awk '{print $4}')"
+sops --encrypt --age "$AGE_PUBKEY" /tmp/slack-legacy.yaml.dec > ~/Documents/vault/slack-legacy-2026-06-01.yaml.enc
+shred -u /tmp/slack-legacy.yaml.dec
+
+# 4) Verify decryption works
+sops --decrypt ~/Documents/vault/slack-legacy-2026-06-01.yaml.enc | head -2
+```
+
+### 3.3 Option C — Bitwarden CLI
+
+```bash
+bw unlock --raw > /tmp/bw.session
+export BW_SESSION="$(cat /tmp/bw.session)"
+
+bw create item "$(jq -n \
+  --arg name "gh-investing-AI_SLACK_BOT_TOKEN" \
+  --arg pw "$(read -rs -p 'paste AI_SLACK_BOT_TOKEN: ' v && echo "$v"; echo >&2)" \
+  '{type:1, name:$name, login:{password:$pw}, notes:"GH Actions legacy token, scheduled for Phase 4 deletion 2026-06-08"}' \
+  | base64)"
+
+# Repeat for OPENCLAW_SLACK_BOT_TOKEN
+```
+
+## 4. Restore Test (mandatory before Phase 4 proceeds)
+
+The goal: prove the round-trip vault → `gh secret set` works for at least
+one of the 2 tokens. This test uses a throwaway secret name so the live
+secrets remain untouched.
+
+```bash
+# 1) Pick one token (e.g. AI_SLACK_BOT_TOKEN) and retrieve from vault
+case "$VAULT_TYPE" in
+  1password) VALUE="$(op item get 'gh-investing-AI_SLACK_BOT_TOKEN' --field credential --reveal)" ;;
+  sops)      VALUE="$(sops --decrypt ~/Documents/vault/slack-legacy-2026-06-01.yaml.enc | yq '.AI_SLACK_BOT_TOKEN')" ;;
+  bitwarden) VALUE="$(bw get password 'gh-investing-AI_SLACK_BOT_TOKEN')" ;;
+esac
+
+# 2) Sanity check value length (Slack bot tokens are typically ~57 chars, prefix xoxb-)
+[ "${#VALUE}" -gt 30 ] && [[ "$VALUE" == xoxb-* ]] && echo "OK: shape looks like Slack bot token"
+
+# 3) Register a TEST secret with a unique name
+TEST_NAME="VAULT_RESTORE_TEST_$(date -u +%Y%m%d%H%M%S)"
+printf '%s' "$VALUE" | gh secret set "$TEST_NAME" --repo Twodragon0/investing --body -
+
+# 4) Confirm secret was created
+gh secret list --repo Twodragon0/investing --json name -q '.[].name' | grep -qx "$TEST_NAME" && echo "OK: test secret created"
+
+# 5) Clean up immediately
+gh secret delete "$TEST_NAME" --repo Twodragon0/investing
+echo "OK: test secret removed"
+
+# 6) Wipe local copy
+unset VALUE
+```
+
+If any step fails → STOP. Phase 4 must not proceed until restore is proven.
+
+## 5. Acceptance Gate for Phase 4
+
+Before running `scripts/migrate_slack_naming.sh --phase=4 --apply`, all of
+the following must be true:
+
+- [ ] Both legacy tokens are stored in vault under `gh-investing-<NAME>`.
+- [ ] At least 1 restore test (§4) completed successfully today.
+- [ ] Snapshot file path (for SOPS) or vault item URLs (for 1Password/Bitwarden) is recorded in the team runbook (not in git).
+- [ ] D+7 has elapsed since Phase 2 merge.
+- [ ] Slack post success rate over the past 7 days ≥ baseline (no regression).
+- [ ] `--vault=PATH` argument points to an existing non-empty file (the migration script enforces this).
+
+## 6. Recovery Path (if Phase 4 destroys data unexpectedly)
+
+```bash
+# 1) Pull value from vault
+VALUE="$(op item get 'gh-investing-AI_SLACK_BOT_TOKEN' --field credential --reveal)"
+
+# 2) Re-register under the LEGACY name (so existing workflows resume)
+printf '%s' "$VALUE" | gh secret set AI_SLACK_BOT_TOKEN --repo Twodragon0/investing --body -
+
+# 3) Verify workflows that previously used this token
+gh workflow run respond-ai-mentions.yml --repo Twodragon0/investing
+gh run watch --repo Twodragon0/investing
+```
+
+If the vault is also lost → fall back to Slack App Management:
+
+1. https://api.slack.com/apps → select "Investing AI" or "OpenClaw" app.
+2. OAuth & Permissions → Reinstall to Workspace.
+3. Copy the new Bot User OAuth Token (starts with `xoxb-`).
+4. Update both the vault entry and the GH secret with the new value.
+5. Note: this invalidates the old token. Any process still using the old token will fail until restarted.
+
+## 7. Cleanup (post Phase 4)
+
+- Keep vault entries for at least 90 days as audit trail.
+- Update entry tags from `migration-2026-06` to `archived-post-cleanup-2026-06`.
+- After 90 days with no incident: delete vault entries.

--- a/docs/slack-secret-naming-unification.md
+++ b/docs/slack-secret-naming-unification.md
@@ -1,0 +1,397 @@
+# Slack Secret Naming Unification + `resolve-slack-config` 단순화
+
+> Status: **Design v2 (review-incorporated, pre-implementation)**
+> Owner: investing platform
+> Last updated: 2026-06-01
+> Review: 2 reviewers, REQUEST CHANGES (3 BLOCKER, 6 MAJOR, 4 MINOR resolved)
+
+## 0. v2 변경 요약
+
+v1 설계를 두 명의 reviewer 가 검토한 결과, **이론적 매트릭스 ≠ 실제 등록 상태**임이 실측 audit (`scripts/migrate_slack_naming.sh --phase=0`)로 드러났다. 이 문서는 그 결과를 반영한 v2이다.
+
+| 변경 | 사유 |
+|---|---|
+| § 2.2 카탈로그를 실측치로 교체 | 워크플로우 YAML 의 fallback 후보 ≠ 실제 등록된 secret. 실측 결과 채널 legacy 22개는 미등록 |
+| § 4 매핑표 단순화 | 미등록 entry 폐기 단계 불필요 → token rename 2건 + canonical 7개 추가만 남음 |
+| § 5 action v2 안전성 보강 | `set -u` × `${!var}` BLOCKER, `bot` 화이트리스트 fail-loud, 출력 계약 명시 |
+| § 5.3 compat-legacy 모드 제거 | 채널 legacy 가 미등록이므로 fallback 자체 불필요. § 6 Phase 2 env 매핑 모순 해소 |
+| § 6 Phase 0.5 Vault snapshot 추가 | Phase 4 destructive 작업의 롤백 가능성 확보 |
+| § 6 Phase 1 overwrite 차단 명시 | 기존 `SLACK_CHANNEL_ID` 등을 실수로 덮어쓰는 사고 방지 |
+| § 6 Phase 2 atomicity 개선 | action.yml 을 additive 로 변경(구/신 input 모두 수락) → 17 워크플로우 점진 마이그레이션 |
+| § 8 Reusable workflow 승격 | 후속 PR 후보 → primary 권장. composite 보다 보일러플레이트 1/4로 축소 |
+
+## 1. 문제
+
+GitHub Actions 워크플로우 17개가 Slack 으로 알림을 보내기 위해 `resolve-slack-config` composite action 을 호출한다. 현재 호출 패턴은 다음 두 문제를 일으킨다:
+
+1. **워크플로우 YAML 보일러플레이트 폭증**: 각 alias 별로 `SLACK_CHANNEL_ID_<X>`, `OPENCLAW_SLACK_CHANNEL_ID_<X>`, `AI_SLACK_CHANNEL_ID_<X>`, `SLACK_CHANNEL_<X>` 4개의 후보를 모두 매핑. 호출 1회당 약 30라인.
+2. **운영자 멘탈 모델 혼란**: 봇별 토큰 분리(`SLACK_BOT_TOKEN` vs `AI_SLACK_BOT_TOKEN` vs `OPENCLAW_SLACK_BOT_TOKEN`)와 채널 prefix 가 섞여, 어느 secret 을 등록해야 하는지 불명확. 실측 결과 OPENCLAW_/AI_ prefix 채널 secret 은 **단 1건도 등록되지 않은 상태**로 운영되고 있었음.
+
+## 2. 현 상태 카탈로그 (실측)
+
+### 2.1. 토큰 (실제 등록 4개)
+
+| 이름 | 상태 | 비고 |
+|---|---|---|
+| `SLACK_BOT_TOKEN` | **등록됨** (canonical) | 주 봇. 이대로 유지 |
+| `AI_SLACK_BOT_TOKEN` | **등록됨** (legacy) | → `SLACK_AI_BOT_TOKEN` 으로 rename |
+| `OPENCLAW_SLACK_BOT_TOKEN` | **등록됨** (legacy) | → `SLACK_OPENCLAW_BOT_TOKEN` 으로 rename |
+| `SLACK_TOKEN` | 미등록 | 일부 워크플로우 token_candidates 마지막 fallback. 폐기 |
+
+### 2.2. 채널 (실제 등록 2개 / 워크플로우 YAML 참조 28개)
+
+`scripts/migrate_slack_naming.sh --phase=0` 실측 결과 (2026-06-01 01:04 UTC):
+
+```
+Canonical present (3/10):
+  - SLACK_BOT_TOKEN  (위에서 분류)
+  - SLACK_CHANNEL_ID_OPENCLAW
+  - SLACK_CHANNEL_ID_AI
+
+Canonical missing (need Phase 1):
+  - SLACK_AI_BOT_TOKEN
+  - SLACK_OPENCLAW_BOT_TOKEN
+  - SLACK_CHANNEL_ID
+  - SLACK_CHANNEL_ID_OPS
+  - SLACK_CHANNEL_ID_DEV
+  - SLACK_CHANNEL_ID_SECURITY
+  - SLACK_CHANNEL_ID_INVESTING
+
+Legacy present (Phase 4 deletion candidates, 2 total):
+  - AI_SLACK_BOT_TOKEN
+  - OPENCLAW_SLACK_BOT_TOKEN
+
+Legacy absent (워크플로우 YAML에만 fallback 으로 등장, 실제 미등록 22개):
+  - OPENCLAW_SLACK_CHANNEL_ID(_OPS,_DEV,_SECURITY,_OPENCLAW,_AI,_INVESTING)  ×7
+  - AI_SLACK_CHANNEL_ID(_OPS,_DEV,_SECURITY,_OPENCLAW,_AI,_INVESTING)        ×7
+  - SLACK_CHANNEL(_OPS,_DEV,_SECURITY,_OPENCLAW,_AI,_INVESTING)              ×7
+  - SLACK_TOKEN                                                              ×1
+```
+
+### 2.3. 워크플로우 사용처 (17개)
+
+`alert-consecutive-failures.yml`, `classify-workflow-failures.yml`, `cleanup-old-images.yml`, `collect-defi-llama.yml`, `collect-defi-yields.yml`, `collector-heartbeat.yml`, `continuous-improvement-loop.yml`, `generate-daily-summary.yml`, `generate-market-summary.yml`, `generate-weekly-report.yml`, `notify-deploy-status.yml`, `ops-10am-digest.yml`, `push-folder-info-to-slack.yml`, `respond-ai-mentions.yml`, `site-health-check.yml`, `watchdog-zero-job-runs.yml`, `weekly-digest.yml`
+
+스크립트 측: `scripts/respond_ai_mentions.py:174-211` 도 동일한 fallback 체인을 갖는다.
+
+### 2.4. 중요 발견
+
+**워크플로우 YAML 의 `channel_candidates_*` 목록 대부분이 dead code 였다.** v1 설계가 가정한 "31개 secret 중 23개 폐기" 는 잘못된 전제였고, 실제로는 token 2개만 rename·삭제하고 channel canonical 5~7개를 추가 등록하면 끝난다.
+
+## 3. 설계 원칙
+
+1. **토큰은 봇별, 채널은 alias별** — 두 축 분리. 채널 ID 는 모든 봇 공유.
+2. **채널 ID 만 사용** — `SLACK_CHANNEL_*` (이름) 표기 폐기. ID 는 rename 내성.
+3. **alias 화이트리스트** — `ops | dev | security | openclaw | ai | investing | default`. 미일치 → `default`.
+4. **bot 화이트리스트 fail-loud** — `default | ai | openclaw` 외 입력 시 step 실패 (Reviewer B MINOR).
+5. **channel ID 미마스킹 명시** — Slack 모델상 공개 식별자. 토큰만 `::add-mask::` (Reviewer B MAJOR).
+6. **action 은 additive 마이그레이션** — 구/신 input 모두 수락하다가 Phase 4 에서 구 input 제거 (Reviewer A MAJOR, Reviewer B MAJOR).
+
+## 4. Canonical 네이밍
+
+### 4.1. 최종 secret 세트 (총 10개)
+
+**토큰 (3):**
+| Canonical | v1 → v2 변경 |
+|---|---|
+| `SLACK_BOT_TOKEN` | 동일 (이미 등록) |
+| `SLACK_AI_BOT_TOKEN` | `AI_SLACK_BOT_TOKEN` 에서 rename (값 동일하게 복사) |
+| `SLACK_OPENCLAW_BOT_TOKEN` | `OPENCLAW_SLACK_BOT_TOKEN` 에서 rename |
+
+**채널 ID (7):**
+| Canonical | 현재 상태 | 의미 |
+|---|---|---|
+| `SLACK_CHANNEL_ID` | 미등록 | default — alias 미지정 시 사용 |
+| `SLACK_CHANNEL_ID_OPS` | 미등록 | 운영 |
+| `SLACK_CHANNEL_ID_DEV` | 미등록 | 개발 |
+| `SLACK_CHANNEL_ID_SECURITY` | 미등록 | 보안 |
+| `SLACK_CHANNEL_ID_OPENCLAW` | **등록됨** | OpenClaw 루프 결과 |
+| `SLACK_CHANNEL_ID_AI` | **등록됨** | AI 답변 |
+| `SLACK_CHANNEL_ID_INVESTING` | 미등록 | 수집/포스트 결과 |
+
+### 4.2. 실제 작업 부피 (Phase 별)
+
+| Phase | 작업 | 부피 |
+|---|---|---|
+| 1 | canonical 등록 (missing 7개) | gh secret set ×7 |
+| 4 | legacy 삭제 (실제 등록된 2 토큰만) | gh secret delete ×2 |
+| 2 | action.yml additive 갱신 + 17 워크플로우 YAML 의 dead fallback 제거 | YAML diff |
+| 3 | `scripts/respond_ai_mentions.py` fallback 체인 단순화 | python diff |
+
+v1 의 "23개 삭제" 는 잘못된 추정. 실제 destructive 작업은 **legacy token 2건 삭제** 뿐.
+
+## 5. `resolve-slack-config` v2
+
+### 5.1. 인터페이스 (additive 마이그레이션)
+
+v2 action.yml 은 **구 input 과 신 input 을 모두 수락**한다. 우선순위: 신 → 구.
+
+**신 인터페이스 (권장):**
+```yaml
+- uses: ./.github/actions/resolve-slack-config
+  id: slack
+  with:
+    target_channel_alias: ops
+    bot: default            # default | ai | openclaw
+  env:
+    SLACK_BOT_TOKEN:            ${{ secrets.SLACK_BOT_TOKEN }}
+    SLACK_AI_BOT_TOKEN:         ${{ secrets.SLACK_AI_BOT_TOKEN }}
+    SLACK_OPENCLAW_BOT_TOKEN:   ${{ secrets.SLACK_OPENCLAW_BOT_TOKEN }}
+    SLACK_CHANNEL_ID:           ${{ secrets.SLACK_CHANNEL_ID }}
+    SLACK_CHANNEL_ID_OPS:       ${{ secrets.SLACK_CHANNEL_ID_OPS }}
+    SLACK_CHANNEL_ID_DEV:       ${{ secrets.SLACK_CHANNEL_ID_DEV }}
+    SLACK_CHANNEL_ID_SECURITY:  ${{ secrets.SLACK_CHANNEL_ID_SECURITY }}
+    SLACK_CHANNEL_ID_OPENCLAW:  ${{ secrets.SLACK_CHANNEL_ID_OPENCLAW }}
+    SLACK_CHANNEL_ID_AI:        ${{ secrets.SLACK_CHANNEL_ID_AI }}
+    SLACK_CHANNEL_ID_INVESTING: ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
+```
+
+**구 인터페이스 (Phase 4 까지 호환):**
+v1 의 `token_candidates`, `channel_candidates_*` 6개를 그대로 수락. 신 input 이 비어있을 때만 구 input 으로 fallback.
+
+### 5.2. 출력 계약 (변경 없음)
+
+| Output | 의미 |
+|---|---|
+| `can_post` | `"true"` / `"false"` |
+| `token` | resolved bot token (`::add-mask::` 처리됨) |
+| `channel` | resolved channel ID (Slack 모델상 공개 식별자 — **의도적으로 마스킹 안 함**) |
+| `alias` | normalized alias (입력 검증 통과 후 lowercase) |
+| `profile_label` | `${alias}-agent` 형식 |
+
+> 보안 노트: `token` 은 `$GITHUB_OUTPUT` 으로 전달되며 GHA 가 후속 step 로그에서도 마스킹한다. 다만 `actions: read` 권한 보유자가 step output API 로 조회 가능하므로, 외부 워크플로우 공유 시 주의.
+
+### 5.3. 액션 내부 로직 (set -u 안전 패턴)
+
+Reviewer B BLOCKER 해결: 직접 변수 indirect expansion 대신 `case` + 명시적 변수 이름 사용.
+
+```bash
+set -euo pipefail
+
+# 1) bot → token 변수 선택 (case 화이트리스트, 미일치 시 fail-loud)
+case "${INPUT_BOT:-default}" in
+  default)  token="${SLACK_BOT_TOKEN:-}" ;;
+  ai)       token="${SLACK_AI_BOT_TOKEN:-}" ;;
+  openclaw) token="${SLACK_OPENCLAW_BOT_TOKEN:-}" ;;
+  *)
+    echo "::error::unknown bot=${INPUT_BOT}; allowed: default|ai|openclaw"
+    exit 1
+    ;;
+esac
+
+# 2) alias → channel 변수 선택 (case 화이트리스트, 미일치 시 default)
+alias_lc="$(printf '%s' "${INPUT_TARGET_ALIAS:-investing}" | tr '[:upper:]' '[:lower:]')"
+case "$alias_lc" in
+  ops)        channel="${SLACK_CHANNEL_ID_OPS:-}" ;;
+  dev)        channel="${SLACK_CHANNEL_ID_DEV:-}" ;;
+  security)   channel="${SLACK_CHANNEL_ID_SECURITY:-}" ;;
+  openclaw)   channel="${SLACK_CHANNEL_ID_OPENCLAW:-}" ;;
+  ai)         channel="${SLACK_CHANNEL_ID_AI:-}" ;;
+  investing)  channel="${SLACK_CHANNEL_ID_INVESTING:-}" ;;
+  *)          alias_lc="default"; channel="" ;;
+esac
+
+# 3) channel default fallback
+if [ -z "$channel" ]; then
+  channel="${SLACK_CHANNEL_ID:-}"
+fi
+
+# 4) 구 인터페이스 fallback (Phase 2~4 호환 기간)
+if [ -z "$token" ] && [ -n "${INPUT_TOKEN_CANDIDATES:-}" ]; then
+  token="$(printf '%s\n' "$INPUT_TOKEN_CANDIDATES" | first_non_empty || printf '')"
+fi
+if [ -z "$channel" ]; then
+  # 구 채널 후보 → 신 변수에 정렬된 input 으로만 fallback (compat-legacy)
+  case "$alias_lc" in
+    ops)        legacy="${INPUT_CHANNEL_OPS:-}" ;;
+    dev)        legacy="${INPUT_CHANNEL_DEV:-}" ;;
+    security)   legacy="${INPUT_CHANNEL_SECURITY:-}" ;;
+    openclaw)   legacy="${INPUT_CHANNEL_OPENCLAW:-}" ;;
+    investing)  legacy="${INPUT_CHANNEL_INVESTING:-}" ;;
+    *)          legacy="" ;;
+  esac
+  [ -z "$legacy" ] && legacy="${INPUT_CHANNEL_DEFAULT:-}"
+  if [ -n "$legacy" ]; then
+    channel="$(printf '%s\n' "$legacy" | first_non_empty || printf '')"
+  fi
+fi
+
+# 5) whitespace trim 보존 (v1 hardening — Reviewer B MINOR)
+token="$(printf '%s' "$token" | xargs || printf '')"
+channel="$(printf '%s' "$channel" | xargs || printf '')"
+
+can_post="true"
+[ -z "$token" ] || [ -z "$channel" ] && can_post="false"
+[ -n "$token" ] && echo "::add-mask::$token"
+
+{
+  echo "can_post=$can_post"
+  echo "token=$token"
+  echo "channel=$channel"
+  echo "alias=$alias_lc"
+  echo "profile_label=${alias_lc}-agent"
+} >> "$GITHUB_OUTPUT"
+```
+
+핵심:
+- `case` 화이트리스트로 변수 이름을 명시 → `set -u` 위반 없음.
+- bot 입력은 fail-loud, alias 입력은 default fallback (v1 동작 호환).
+- 구 인터페이스 (`INPUT_CHANNEL_OPS` 등 v1 input) 도 동일 case 로 매핑 → compat env 매핑 모순 해소.
+
+### 5.4. Reusable Workflow 대안 (권장 후속)
+
+Composite action 은 `secrets:` 키워드 불가 → 매 caller 가 12라인 env 매핑 반복. Reusable workflow (`workflow_call`) 는 `secrets: inherit` 로 caller 측 보일러플레이트를 1라인으로 축소한다.
+
+```yaml
+# .github/workflows/_post-to-slack.yml
+on:
+  workflow_call:
+    inputs:
+      alias:   { type: string, required: true }
+      bot:     { type: string, default: default }
+      message: { type: string, required: true }
+    secrets: inherit
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/resolve-slack-config
+        with:
+          target_channel_alias: ${{ inputs.alias }}
+          bot: ${{ inputs.bot }}
+        env:
+          # 12라인 env 매핑 (이 reusable workflow 안에서만 1회 정의)
+          ...
+      - uses: slackapi/slack-github-action@...
+        if: steps.slack.outputs.can_post == 'true'
+        with:
+          method: chat.postMessage
+          token: ${{ steps.slack.outputs.token }}
+          payload: |
+            channel: "${{ steps.slack.outputs.channel }}"
+            text: "${{ inputs.message }}"
+```
+
+caller (예: `collect-defi-llama.yml`):
+```yaml
+post-slack:
+  needs: collect
+  uses: ./.github/workflows/_post-to-slack.yml
+  with:
+    alias: investing
+    message: "[investing-agent] DeFi Llama collection completed - ${{ github.run_id }}"
+  secrets: inherit
+```
+
+→ caller 당 ~30라인 → ~6라인. 별도 PR 로 진행 권장 (§ 8).
+
+## 6. 마이그레이션 절차 (실측 기반 v2)
+
+### Phase 0 — Audit (자동화 완료)
+
+```bash
+scripts/migrate_slack_naming.sh --phase=0
+```
+
+산출: canonical present/missing, legacy present/absent 카운트. 본 문서 § 2.2 의 데이터 출처.
+
+### Phase 0.5 — Vault Snapshot (필수 게이트)
+
+Phase 4 destructive 작업의 롤백 가능성 확보. 다음 2개 토큰 값을 1Password / Bitwarden / SOPS 등에 명명 entry 로 백업:
+
+- `gh-investing-AI_SLACK_BOT_TOKEN`
+- `gh-investing-OPENCLAW_SLACK_BOT_TOKEN`
+
+검증: 1건은 실제 restore 테스트 (vault → 새 GH secret 등록 → 1분 후 삭제) 후 진행. 스냅샷 경로는 별도 runbook(commit-safe, 값 미포함) 에 기록.
+
+### Phase 1 — Canonical 등록 (additive, 7건)
+
+```bash
+scripts/migrate_slack_naming.sh --phase=1            # dry-run 검토
+scripts/migrate_slack_naming.sh --phase=1 --apply    # 값 입력 7회 (read -s)
+```
+
+안전 동작:
+- 기본 dry-run, `--apply` 명시 시에만 실행.
+- 이미 존재하는 canonical (`SLACK_CHANNEL_ID_OPENCLAW`, `SLACK_CHANNEL_ID_AI`) 은 **자동 skip**. `--force-overwrite` 미사용 시 덮어쓰기 없음.
+- `printf '%s' "$v" | gh secret set NAME --body -` → 값 word-splitting 방지.
+- 공백 trim 후 빈 문자열은 skip.
+
+값 확정 작업: `SLACK_AI_BOT_TOKEN` / `SLACK_OPENCLAW_BOT_TOKEN` 은 기존 `AI_SLACK_BOT_TOKEN` / `OPENCLAW_SLACK_BOT_TOKEN` 값과 동일하게 복사. 채널 ID 5건은 운영자가 Slack 채널 카탈로그와 1회 매핑.
+
+검증: `scripts/migrate_slack_naming.sh --phase=0` → `Canonical present: 10/10`.
+
+### Phase 2 — `resolve-slack-config` v2 + 17 워크플로우 점진 갱신
+
+PR 1 (action 만):
+- `.github/actions/resolve-slack-config/action.yml` 를 § 5.3 의 additive 로직으로 교체.
+- 구 input (`channel_candidates_*`, `token_candidates`) 은 `required: false` 로 유지하여 17 caller 가 그대로 동작.
+- merge 후 모든 워크플로우 1회 dispatch → can_post=true 비율이 baseline 유지 확인.
+
+PR 2~N (워크플로우 갱신):
+- 1 PR 당 1~3 워크플로우씩 신 인터페이스 (`bot:` + env 블록) 로 전환.
+- `respond-ai-mentions.yml` 부터 시작 (가장 복잡한 caller). 30분 모니터링 후 다음 PR.
+
+### Phase 3 — 스크립트 동기화
+
+`scripts/respond_ai_mentions.py:174-211` 의 `channel_id_for_alias()` 를 단순화:
+
+```python
+def channel_id_for_alias(alias: str) -> str:
+    upper = alias.upper()
+    if upper in {"OPS", "DEV", "SECURITY", "OPENCLAW", "AI", "INVESTING"}:
+        return env_first(f"SLACK_CHANNEL_ID_{upper}", "SLACK_CHANNEL_ID")
+    return os.getenv("SLACK_CHANNEL_ID", "")
+```
+
+기존 fallback `openclaw → AI → default` 의 의미를 보존해야 한다면 (Reviewer A MINOR), Phase 1 에서 `SLACK_CHANNEL_ID_OPENCLAW` 가 이미 등록되어 있음을 audit 으로 확인했으므로 직접 lookup 이 안전.
+
+### Phase 4 — Legacy 삭제 (D+7, vault snapshot 검증 후)
+
+```bash
+scripts/migrate_slack_naming.sh --phase=4 \
+  --vault=/path/to/vault-snapshot.txt \
+  --apply
+```
+
+안전 동작:
+- `--vault=PATH` 필수, 파일 존재 + 비어있지 않음 검증.
+- 실행 직전 repo 이름 정확 입력 confirm.
+- 멱등 삭제 (`|| true` 패턴) — 미등록 entry 무시.
+
+실제 삭제 대상 (실측 기반): `AI_SLACK_BOT_TOKEN`, `OPENCLAW_SLACK_BOT_TOKEN` (legacy channel 22개는 미등록이므로 noop).
+
+또한 action.yml 의 구 input 도 동시 제거 PR 가능.
+
+### 롤백
+
+- Phase 2: action.yml 만 git revert. 신 canonical secret 보존.
+- Phase 4: vault snapshot 에서 `gh secret set` 재등록. action.yml 의 구 input 복원 PR.
+
+## 7. 영향 분석
+
+| 항목 | Before | After (Phase 4 완료) | After (+reusable workflow) |
+|---|---|---|---|
+| 등록된 secret 수 | 5 (canonical 3 + legacy 2) | 10 (canonical 10) | 10 |
+| 워크플로우당 Slack 보일러플레이트 | ~30라인 | ~12라인 | ~6라인 |
+| 신규 워크플로우 추가 시 결정 | 4 prefix × alias 후보 12개 | bot 1 + alias 1 = 2 | bot 1 + alias 1 = 2 |
+| dead fallback (YAML 참조하나 미등록) | 22개 | 0 | 0 |
+
+## 8. 오픈 이슈 / 후속
+
+1. **Reusable workflow `_post-to-slack.yml` 추출** — Reviewer B MAJOR 권고. caller 보일러플레이트를 1/4로 축소. § 5.4 초안 기반으로 별도 PR.
+2. **org-level secret 충돌 audit** — `gh api orgs/<org>/actions/secrets` (권한 시) → canonical 10개 이름이 org 레벨에서 다른 값으로 정의되어 있지 않은지 확인 (Reviewer A LOW).
+3. **외부 스크립트 의존성** — `~/Desktop/.twodragon0/` 중앙 관리 스크립트가 동일 secret 명을 참조할 수 있음. 별도 검토.
+4. **`SLACK_TOKEN` (deprecated) workflow 참조 정리** — `collect-defi-llama.yml:43` 등에서 fallback 으로 등장. Phase 2 워크플로우 갱신 시 제거.
+
+## 9. 실행 체크리스트
+
+- [x] Phase 0: audit 자동화 (`scripts/migrate_slack_naming.sh --phase=0`)
+- [ ] Phase 0.5: 2개 legacy 토큰 vault snapshot + restore 테스트
+- [ ] Phase 1: canonical 7개 등록 (`--phase=1 --apply`)
+- [ ] Phase 2 (PR 1): action.yml v2 additive 배포
+- [ ] Phase 2 (PR 2~N): 17 워크플로우 점진 갱신, `respond-ai-mentions.yml` 부터 canary
+- [ ] Phase 3: `scripts/respond_ai_mentions.py` 단순화
+- [ ] Phase 4 (D+7): legacy 토큰 2건 삭제 + action.yml 구 input 제거 PR
+- [ ] (선택) Reusable workflow `_post-to-slack.yml` 별도 PR
+- [ ] 회귀 모니터링 1주: Slack post 성공률 ≥ 직전 7일 baseline

--- a/scripts/migrate_slack_naming.sh
+++ b/scripts/migrate_slack_naming.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# migrate_slack_naming.sh
+#
+# Slack secret naming unification — Phase 1 interactive registration tool.
+# Design: docs/slack-secret-naming-unification.md
+#
+# Safety contract (incorporates reviewer findings):
+#   - Default mode is DRY-RUN. Use --apply to actually call `gh secret set`.
+#   - Existing secrets are NEVER overwritten without --force-overwrite. The
+#     reviewer warning is that Phase 1 SLACK_CHANNEL_ID overwrite can break
+#     17 live workflows mid-migration.
+#   - Phase 4 destructive deletion is gated behind --phase=4 AND a vault
+#     snapshot path. The snapshot file must exist with non-empty content.
+#   - All `gh secret set` calls use `printf '%s' "$value" | gh secret set NAME --body -`
+#     to avoid bash word-splitting on values with backslashes/newlines.
+#   - Whitespace-only values are rejected.
+#   - Phase 0 (audit) prints the current Slack-related secret inventory
+#     without taking any destructive action.
+
+set -euo pipefail
+
+REPO="${REPO:-Twodragon0/investing}"
+DRY_RUN=true
+PHASE="0"
+FORCE_OVERWRITE=false
+VAULT_SNAPSHOT=""
+
+usage() {
+  cat <<'USAGE'
+Usage: migrate_slack_naming.sh [options]
+
+Options:
+  --phase=N           Phase to execute (0=audit, 1=register canonical, 4=delete legacy)
+  --apply             Actually execute; default is dry-run
+  --force-overwrite   Allow overwriting existing names (Phase 1 only, dangerous)
+  --vault=PATH        Path to vault snapshot file (required for --phase=4)
+  --repo=OWNER/NAME   Override target repo (default: Twodragon0/investing)
+  -h, --help          Show this help
+
+Phases:
+  0  Audit: list Slack-related entries, classify legacy vs canonical, print counts.
+  1  Register canonical entries interactively. Skips names that already exist
+     unless --force-overwrite is set. Reads values via read -s with explicit prompt.
+  4  Delete legacy entries after verifying vault snapshot. Idempotent (404 ignored).
+
+Examples:
+  ./migrate_slack_naming.sh --phase=0
+  ./migrate_slack_naming.sh --phase=1                    # dry-run
+  ./migrate_slack_naming.sh --phase=1 --apply
+  ./migrate_slack_naming.sh --phase=4 --vault=/path/to/vault-2026-06-01.txt --apply
+USAGE
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --phase=*)         PHASE="${arg#--phase=}" ;;
+    --apply)           DRY_RUN=false ;;
+    --force-overwrite) FORCE_OVERWRITE=true ;;
+    --vault=*)         VAULT_SNAPSHOT="${arg#--vault=}" ;;
+    --repo=*)          REPO="${arg#--repo=}" ;;
+    -h|--help)         usage; exit 0 ;;
+    *)                 echo "Unknown option: $arg" >&2; usage; exit 2 ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not found in PATH" >&2
+  exit 1
+fi
+
+log()  { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+warn() { printf '[%s] WARN: %s\n' "$(date -u +%H:%M:%SZ)" "$*" >&2; }
+die()  { printf '[%s] ERROR: %s\n' "$(date -u +%H:%M:%SZ)" "$*" >&2; exit 1; }
+
+mode_label() {
+  $DRY_RUN && printf '[DRY-RUN]' || printf '[APPLY]'
+}
+
+# --- Canonical / legacy catalogs --------------------------------------------
+
+CANONICAL_TOKENS=(
+  SLACK_BOT_TOKEN
+  SLACK_AI_BOT_TOKEN
+  SLACK_OPENCLAW_BOT_TOKEN
+)
+
+CANONICAL_CHANNELS=(
+  SLACK_CHANNEL_ID
+  SLACK_CHANNEL_ID_OPS
+  SLACK_CHANNEL_ID_DEV
+  SLACK_CHANNEL_ID_SECURITY
+  SLACK_CHANNEL_ID_OPENCLAW
+  SLACK_CHANNEL_ID_AI
+  SLACK_CHANNEL_ID_INVESTING
+)
+
+LEGACY_TOKENS=(
+  AI_SLACK_BOT_TOKEN
+  OPENCLAW_SLACK_BOT_TOKEN
+  SLACK_TOKEN
+)
+
+LEGACY_CHANNELS=(
+  OPENCLAW_SLACK_CHANNEL_ID
+  OPENCLAW_SLACK_CHANNEL_ID_OPS
+  OPENCLAW_SLACK_CHANNEL_ID_DEV
+  OPENCLAW_SLACK_CHANNEL_ID_SECURITY
+  OPENCLAW_SLACK_CHANNEL_ID_OPENCLAW
+  OPENCLAW_SLACK_CHANNEL_ID_AI
+  OPENCLAW_SLACK_CHANNEL_ID_INVESTING
+  AI_SLACK_CHANNEL_ID
+  AI_SLACK_CHANNEL_ID_OPS
+  AI_SLACK_CHANNEL_ID_DEV
+  AI_SLACK_CHANNEL_ID_SECURITY
+  AI_SLACK_CHANNEL_ID_OPENCLAW
+  AI_SLACK_CHANNEL_ID_AI
+  AI_SLACK_CHANNEL_ID_INVESTING
+  SLACK_CHANNEL
+  SLACK_CHANNEL_OPS
+  SLACK_CHANNEL_DEV
+  SLACK_CHANNEL_SECURITY
+  SLACK_CHANNEL_OPENCLAW
+  SLACK_CHANNEL_AI
+  SLACK_CHANNEL_INVESTING
+)
+
+# --- Helpers ----------------------------------------------------------------
+
+list_live() {
+  gh secret list --repo "$REPO" --json name -q '.[].name' 2>/dev/null
+}
+
+name_present() {
+  local name="$1"
+  list_live | grep -qx "$name"
+}
+
+trim_ws() {
+  local v="$1"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  printf '%s' "$v"
+}
+
+prompt_value() {
+  local name="$1"
+  local value
+  printf 'Enter value for %s (input hidden, empty to skip): ' "$name" >&2
+  IFS= read -rs value
+  printf '\n' >&2
+  printf '%s' "$value"
+}
+
+apply_set() {
+  local name="$1"
+  local value="$2"
+  if $DRY_RUN; then
+    log "$(mode_label) would set $name (${#value} chars)"
+    return 0
+  fi
+  printf '%s' "$value" | gh secret set "$name" --repo "$REPO" --body -
+  log "[APPLY] set $name"
+}
+
+apply_delete() {
+  local name="$1"
+  if $DRY_RUN; then
+    log "$(mode_label) would delete $name"
+    return 0
+  fi
+  if gh secret delete "$name" --repo "$REPO" 2>/dev/null; then
+    log "[APPLY] deleted $name"
+  else
+    log "[APPLY] skip $name (not present)"
+  fi
+}
+
+# --- Phase implementations --------------------------------------------------
+
+phase_audit() {
+  log "Phase 0 audit on $REPO"
+  local live
+  if ! live="$(list_live)"; then
+    die "gh secret list failed"
+  fi
+
+  local present_canonical=() missing_canonical=()
+  local present_legacy=() missing_legacy=()
+
+  for s in "${CANONICAL_TOKENS[@]}" "${CANONICAL_CHANNELS[@]}"; do
+    if grep -qx "$s" <<<"$live"; then present_canonical+=("$s")
+    else                              missing_canonical+=("$s"); fi
+  done
+
+  for s in "${LEGACY_TOKENS[@]}" "${LEGACY_CHANNELS[@]}"; do
+    if grep -qx "$s" <<<"$live"; then present_legacy+=("$s")
+    else                              missing_legacy+=("$s"); fi
+  done
+
+  printf '\nCanonical present (%d/%d):\n' \
+    "${#present_canonical[@]}" \
+    "$(( ${#CANONICAL_TOKENS[@]} + ${#CANONICAL_CHANNELS[@]} ))"
+  printf '  - %s\n' "${present_canonical[@]:-(none)}"
+
+  printf '\nCanonical missing (need Phase 1 registration):\n'
+  printf '  - %s\n' "${missing_canonical[@]:-(none)}"
+
+  printf '\nLegacy present (Phase 4 deletion candidates, %d total):\n' "${#present_legacy[@]}"
+  printf '  - %s\n' "${present_legacy[@]:-(none)}"
+
+  printf '\nLegacy absent (already removed or never set):\n'
+  printf '  - %s\n' "${missing_legacy[@]:-(none)}"
+
+  printf '\nSummary: canonical=%d/%d, legacy_present=%d/%d\n' \
+    "${#present_canonical[@]}" \
+    "$(( ${#CANONICAL_TOKENS[@]} + ${#CANONICAL_CHANNELS[@]} ))" \
+    "${#present_legacy[@]}" \
+    "$(( ${#LEGACY_TOKENS[@]} + ${#LEGACY_CHANNELS[@]} ))"
+}
+
+phase_register() {
+  log "Phase 1 canonical registration on $REPO ($(mode_label))"
+  log "Existing names are SKIPPED unless --force-overwrite is set"
+
+  local total=$(( ${#CANONICAL_TOKENS[@]} + ${#CANONICAL_CHANNELS[@]} ))
+  local processed=0 skipped=0 registered=0
+
+  for name in "${CANONICAL_TOKENS[@]}" "${CANONICAL_CHANNELS[@]}"; do
+    processed=$((processed + 1))
+    printf '\n--- (%d/%d) %s ---\n' "$processed" "$total" "$name"
+
+    if name_present "$name"; then
+      if $FORCE_OVERWRITE; then
+        warn "$name already exists — --force-overwrite is on, will overwrite"
+      else
+        log "skip: $name already exists (use --force-overwrite to overwrite)"
+        skipped=$((skipped + 1))
+        continue
+      fi
+    fi
+
+    local raw trimmed
+    raw="$(prompt_value "$name")"
+    trimmed="$(trim_ws "$raw")"
+
+    if [ -z "$trimmed" ]; then
+      log "skip: empty/whitespace value entered for $name"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    apply_set "$name" "$trimmed"
+    registered=$((registered + 1))
+  done
+
+  printf '\nPhase 1 done: processed=%d, registered=%d, skipped=%d\n' \
+    "$processed" "$registered" "$skipped"
+}
+
+phase_delete_legacy() {
+  log "Phase 4 legacy deletion on $REPO ($(mode_label))"
+
+  [ -n "$VAULT_SNAPSHOT" ] || die "--vault=PATH is required for Phase 4"
+  [ -f "$VAULT_SNAPSHOT" ] || die "vault snapshot not found: $VAULT_SNAPSHOT"
+  [ -s "$VAULT_SNAPSHOT" ] || die "vault snapshot is empty: $VAULT_SNAPSHOT"
+
+  log "vault snapshot present: $VAULT_SNAPSHOT ($(wc -c <"$VAULT_SNAPSHOT" | tr -d ' ') bytes)"
+
+  if ! $DRY_RUN; then
+    printf 'About to DELETE %d legacy entries from %s.\n' \
+      "$(( ${#LEGACY_TOKENS[@]} + ${#LEGACY_CHANNELS[@]} ))" "$REPO"
+    printf 'Type the exact repo name to confirm: ' >&2
+    local confirm
+    IFS= read -r confirm
+    [ "$confirm" = "$REPO" ] || die "confirmation mismatch — aborting"
+  fi
+
+  local processed=0
+  for name in "${LEGACY_TOKENS[@]}" "${LEGACY_CHANNELS[@]}"; do
+    apply_delete "$name"
+    processed=$((processed + 1))
+  done
+
+  printf '\nPhase 4 done: processed=%d (idempotent — non-existent names skipped)\n' \
+    "$processed"
+}
+
+# --- Dispatch ---------------------------------------------------------------
+
+case "$PHASE" in
+  0) phase_audit ;;
+  1) phase_register ;;
+  4) phase_delete_legacy ;;
+  *) die "Unknown phase: $PHASE (valid: 0, 1, 4)" ;;
+esac


### PR DESCRIPTION
## Summary

- `action.yml` v2 (additive): canonical `bot` + `target_channel_alias` inputs with env-based channel lookup; legacy `channel_candidates_*` / `token_candidates` inputs preserved for backward compat through Phase 4
- Design v2 (`docs/slack-secret-naming-unification.md`, 397줄) — review-incorporated, 3 BLOCKER + 6 MAJOR + 4 MINOR resolved
- Phase 0.5 vault snapshot runbook (`docs/runbook-slack-vault-snapshot.md`) — 1Password/SOPS/Bitwarden 3 옵션 + mandatory restore test
- Migration tool (`scripts/migrate_slack_naming.sh`) — Phase 0/1/4 dry-run 기본, overwrite 차단, vault gate, 멱등 삭제

## Key safety guarantees

- **Additive**: 기존 17 caller 워크플로우는 코드 변경 없이 그대로 동작 (legacy input 그대로 수락)
- **`set -u` safe**: indirect expansion 제거, case 화이트리스트로 변수 lookup
- **fail-loud on unknown bot**: typo로 인한 silent misrouting 방지
- **Phase 0 실측**: legacy channel 22개는 워크플로우 YAML의 dead fallback (실제 등록 0건). 실제 destructive 작업은 legacy token 2건 삭제로 축소

## Phase 0 실측 결과

```
Canonical present:  3/10  (SLACK_BOT_TOKEN, SLACK_CHANNEL_ID_OPENCLAW, SLACK_CHANNEL_ID_AI)
Canonical missing:  7     (Phase 1에서 등록)
Legacy present:     2     (AI_SLACK_BOT_TOKEN, OPENCLAW_SLACK_BOT_TOKEN — Phase 4에서 삭제)
Legacy absent:      22    (워크플로우 YAML 참조하나 실제 미등록 — dead fallback)
```

## Test plan

- [x] `bash -n` syntax check on action.yml shell block
- [x] Python YAML parse validation
- [x] 7-scenario functional simulation (new I/F + legacy fallback + unknown bot)
- [x] `migrate_slack_naming.sh --phase=0` 실 audit 통과
- [x] `migrate_slack_naming.sh --phase=1` dry-run: 3 skip + 7 prompt
- [ ] (merge 후) Phase 1 canonical 7개 등록 (operator)
- [ ] (별도 PR) respond-ai-mentions.yml를 신 인터페이스로 전환 + dispatch 검증

## Out of scope

- 17 워크플로우 caller migration (Phase 2 PR 2~N, 점진 적용)
- `_post-to-slack.yml` reusable workflow 추출 (design § 5.4 권고, 별도 PR)
- Phase 4 destructive deletion (D+7, vault snapshot 검증 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)