### PR TITLE
feat(workflows): migrate respond-ai-mentions to v2 slack-config (canary)

### DIFF
--- a/.github/workflows/respond-ai-mentions.yml
+++ b/.github/workflows/respond-ai-mentions.yml
@@ -32,49 +32,18 @@ jobs:
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: ${{ matrix.channel_alias }}
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.OPENCLAW_SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_default: |
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
-          channel_candidates_ops: |
-            ${{ secrets.SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.SLACK_CHANNEL_OPS }}
-          channel_candidates_dev: |
-            ${{ secrets.SLACK_CHANNEL_ID_DEV }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_DEV }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_DEV }}
-            ${{ secrets.SLACK_CHANNEL_DEV }}
-          channel_candidates_security: |
-            ${{ secrets.SLACK_CHANNEL_ID_SECURITY }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_SECURITY }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_SECURITY }}
-            ${{ secrets.SLACK_CHANNEL_SECURITY }}
-          channel_candidates_openclaw: |
-            ${{ secrets.SLACK_CHANNEL_ID_OPENCLAW }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_OPENCLAW }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_OPENCLAW }}
-            ${{ secrets.SLACK_CHANNEL_OPENCLAW }}
-            ${{ secrets.SLACK_CHANNEL_ID_AI }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_AI }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_AI }}
-            ${{ secrets.SLACK_CHANNEL_AI }}
-          channel_candidates_investing: |
-            ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
+          bot: default
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_AI_BOT_TOKEN: ${{ secrets.SLACK_AI_BOT_TOKEN }}
+          SLACK_OPENCLAW_BOT_TOKEN: ${{ secrets.SLACK_OPENCLAW_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_CHANNEL_ID_OPS: ${{ secrets.SLACK_CHANNEL_ID_OPS }}
+          SLACK_CHANNEL_ID_DEV: ${{ secrets.SLACK_CHANNEL_ID_DEV }}
+          SLACK_CHANNEL_ID_SECURITY: ${{ secrets.SLACK_CHANNEL_ID_SECURITY }}
+          SLACK_CHANNEL_ID_OPENCLAW: ${{ secrets.SLACK_CHANNEL_ID_OPENCLAW }}
+          SLACK_CHANNEL_ID_AI: ${{ secrets.SLACK_CHANNEL_ID_AI }}
+          SLACK_CHANNEL_ID_INVESTING: ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
 
       - name: Setup Python
         if: steps.slack-config.outputs.can_post == 'true'


### PR DESCRIPTION
> Recreation of #987 (auto-closed when stacked base `feat/slack-naming-v2-infra` was deleted on #986 merge). Rebased onto main.

## Summary

Phase 2 PR 2/N — design § 6 의 canary 단계. `respond-ai-mentions.yml`을 `resolve-slack-config` v2 신 인터페이스로 전환.

PR #986 (action v2) merged into main as `ca83e3fd1b`. This PR builds on top.

## Diff

- channel_candidates_* 6개 블록 (30+ 라인) → env 매핑 12라인
- token_candidates 4개 → `bot: default` 단일 인자
- legacy 참조 제거: `SLACK_TOKEN`, `OPENCLAW_SLACK_CHANNEL_ID*`, `AI_SLACK_CHANNEL_ID*`, `SLACK_CHANNEL*` (이름 형식)
- matrix.channel_alias 그대로 (ops|dev|security|openclaw|investing)

총 98 → 66 라인 (32 라인 감소).

## Test plan

- [x] YAML parse OK
- [x] v2 action 7-시나리오 시뮬레이션 (PR #986)
- [x] **`gh workflow run respond-ai-mentions.yml --ref` 검증 통과** (run 26733260546, 5/5 matrix success)
- [ ] (별도 PR) 나머지 16 워크플로우 점진 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)