### PR TITLE
feat(workflows): migrate 4 multi-alias workflows to v2 slack-config

### DIFF
--- a/.github/workflows/continuous-improvement-loop.yml
+++ b/.github/workflows/continuous-improvement-loop.yml
@@ -59,20 +59,11 @@ jobs:
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: investing
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.OPENCLAW_SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_investing: |
-            ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
+          bot: default
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_CHANNEL_ID_INVESTING: ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
 
       - name: Post loop priorities to Slack thread
         if: steps.slack.outputs.can_post == 'true'
@@ -89,19 +80,11 @@ jobs:
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: ops
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.OPENCLAW_SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_ops: |
-            ${{ secrets.SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.SLACK_CHANNEL_OPS }}
-          channel_candidates_default: |
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
+          bot: default
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_CHANNEL_ID_OPS: ${{ secrets.SLACK_CHANNEL_ID_OPS }}
 
       - name: Post ops forum to Slack thread
         if: steps.slack_ops.outputs.can_post == 'true'
@@ -118,19 +101,11 @@ jobs:
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: security
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.OPENCLAW_SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_security: |
-            ${{ secrets.SLACK_CHANNEL_ID_SECURITY }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_SECURITY }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_SECURITY }}
-            ${{ secrets.SLACK_CHANNEL_SECURITY }}
-          channel_candidates_default: |
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
+          bot: default
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_CHANNEL_ID_SECURITY: ${{ secrets.SLACK_CHANNEL_ID_SECURITY }}
 
       - name: Post security forum to Slack thread
         if: steps.slack_security.outputs.can_post == 'true'
@@ -147,19 +122,11 @@ jobs:
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: dev
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.OPENCLAW_SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_dev: |
-            ${{ secrets.SLACK_CHANNEL_ID_DEV }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_DEV }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_DEV }}
-            ${{ secrets.SLACK_CHANNEL_DEV }}
-          channel_candidates_default: |
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
+          bot: default
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_CHANNEL_ID_DEV: ${{ secrets.SLACK_CHANNEL_ID_DEV }}
 
       - name: Post UI/UX forum to Slack thread
         if: steps.slack_dev.outputs.can_post == 'true'

--- a/.github/workflows/ops-10am-digest.yml
+++ b/.github/workflows/ops-10am-digest.yml
@@ -46,21 +46,11 @@ jobs:
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: ops
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.OPENCLAW_SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_ops: |
-            ${{ secrets.SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.SLACK_CHANNEL_OPS }}
-          channel_candidates_default: |
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
+          bot: default
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_CHANNEL_ID_OPS: ${{ secrets.SLACK_CHANNEL_ID_OPS }}
 
       - name: Generate 10AM digest message
         id: digest

--- a/.github/workflows/push-folder-info-to-slack.yml
+++ b/.github/workflows/push-folder-info-to-slack.yml
@@ -150,42 +150,16 @@ jobs:
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: ${{ matrix.channel_alias }}
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.OPENCLAW_SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_default: |
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
-          channel_candidates_ops: |
-            ${{ secrets.SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_OPS }}
-            ${{ secrets.SLACK_CHANNEL_OPS }}
-          channel_candidates_dev: |
-            ${{ secrets.SLACK_CHANNEL_ID_DEV }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_DEV }}
-            ${{ secrets.SLACK_CHANNEL_DEV }}
-          channel_candidates_security: |
-            ${{ secrets.SLACK_CHANNEL_ID_SECURITY }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_SECURITY }}
-            ${{ secrets.SLACK_CHANNEL_SECURITY }}
-          channel_candidates_openclaw: |
-            ${{ secrets.SLACK_CHANNEL_ID_OPENCLAW }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_OPENCLAW }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_OPENCLAW }}
-            ${{ secrets.SLACK_CHANNEL_OPENCLAW }}
-            ${{ secrets.SLACK_CHANNEL_ID_AI }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_AI }}
-            ${{ secrets.SLACK_CHANNEL_AI }}
-          channel_candidates_investing: |
-            ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
+          bot: default
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_CHANNEL_ID_OPS: ${{ secrets.SLACK_CHANNEL_ID_OPS }}
+          SLACK_CHANNEL_ID_DEV: ${{ secrets.SLACK_CHANNEL_ID_DEV }}
+          SLACK_CHANNEL_ID_SECURITY: ${{ secrets.SLACK_CHANNEL_ID_SECURITY }}
+          SLACK_CHANNEL_ID_OPENCLAW: ${{ secrets.SLACK_CHANNEL_ID_OPENCLAW }}
+          SLACK_CHANNEL_ID_AI: ${{ secrets.SLACK_CHANNEL_ID_AI }}
+          SLACK_CHANNEL_ID_INVESTING: ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
 
       - name: Post to Slack investing channel
         if: steps.slack-config.outputs.can_post == 'true'

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -35,20 +35,11 @@ jobs:
         uses: ./.github/actions/resolve-slack-config
         with:
           target_channel_alias: investing
-          token_candidates: |
-            ${{ secrets.SLACK_BOT_TOKEN }}
-            ${{ secrets.OPENCLAW_SLACK_BOT_TOKEN }}
-            ${{ secrets.AI_SLACK_BOT_TOKEN }}
-            ${{ secrets.SLACK_TOKEN }}
-          channel_candidates_investing: |
-            ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_INVESTING }}
-            ${{ secrets.SLACK_CHANNEL_ID }}
-            ${{ secrets.OPENCLAW_SLACK_CHANNEL_ID }}
-            ${{ secrets.AI_SLACK_CHANNEL_ID }}
-            ${{ secrets.SLACK_CHANNEL }}
+          bot: default
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_CHANNEL_ID_INVESTING: ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
 
       - name: Post weekly digest notification to Slack
         if: steps.slack.outputs.can_post == 'true'


### PR DESCRIPTION
Phase 2 PR 7/N — 마지막 배치 (multi-alias / matrix callers).

## Migrated
- ops-10am-digest.yml (alias=ops)
- weekly-digest.yml (alias=investing)
- continuous-improvement-loop.yml (4 resolve 호출: investing/ops/security/dev)
- push-folder-info-to-slack.yml (matrix.channel_alias, 6 alias env 모두 전달)

## Coverage
17 워크플로우 마이그레이션 완료:
- PR #990: respond-ai-mentions (canary)
- PR #992: collectors x3
- PR #993: generators x3
- PR #994: alerts x3
- PR #995: maintenance x3
- PR #996 (this): final x4

🤖 Generated with [Claude Code](https://claude.com/claude-code)