### PR TITLE
chore(slack): Phase 3 — simplify token fallback to canonical names

### DIFF
--- a/.github/workflows/alert-consecutive-failures.yml
+++ b/.github/workflows/alert-consecutive-failures.yml
@@ -115,7 +115,7 @@ jobs:
               `${{ steps.check.outputs.recent_failures }}`,
               ``,
               `## What to investigate`,
-              `- Slack token rotation: verify \`SLACK_BOT_TOKEN\` / \`AI_SLACK_BOT_TOKEN\` secrets are current`,
+              `- Slack token rotation: verify \`SLACK_BOT_TOKEN\` / \`SLACK_AI_BOT_TOKEN\` secrets are current`,
               `- Channel ID drift: confirm \`SLACK_CHANNEL_ID_INVESTING\` still resolves to the expected channel`,
               `- If Slack was in outage, close this issue once alerts resume`,
             ].join('\n');

--- a/scripts/respond_ai_mentions.py
+++ b/scripts/respond_ai_mentions.py
@@ -387,11 +387,12 @@ def main() -> int:
         logger.warning("Unsupported alias: %s", alias)
         return 1
 
+    # Phase 3: canonical 이름만 유지. respond-ai-mentions.yml 은 SLACK_BOT_TOKEN(등록됨)
+    # 과 canonical SLACK_AI_BOT_TOKEN 만 주입하므로, 미주입 legacy env
+    # (OPENCLAW_SLACK_BOT_TOKEN / AI_SLACK_BOT_TOKEN / SLACK_TOKEN) fallback 은 dead → 제거.
     token = env_first(
         "SLACK_BOT_TOKEN",
-        "OPENCLAW_SLACK_BOT_TOKEN",
-        "AI_SLACK_BOT_TOKEN",
-        "SLACK_TOKEN",
+        "SLACK_AI_BOT_TOKEN",
     )
     channel_id = channel_id_for_alias(alias)
 


### PR DESCRIPTION
## 배경

Slack 시크릿 네이밍 통일 마이그레이션(`docs/slack-secret-naming-unification.md`)의 **Phase 3** — `respond_ai_mentions.py` 토큰 fallback 체인 단순화 + 운영 가이드 문자열 정합.

## 변경

| 파일 | 변경 |
|------|------|
| `scripts/respond_ai_mentions.py:390` | 토큰 `env_first` 체인을 canonical 이름만으로 단순화: `SLACK_BOT_TOKEN`, `SLACK_AI_BOT_TOKEN` |
| `.github/workflows/alert-consecutive-failures.yml:118` | 운영 가이드 문자열 `AI_SLACK_BOT_TOKEN` → canonical `SLACK_AI_BOT_TOKEN` |

## 안전성 근거 (Phase 1 미적용 상태에서도 무중단)

`respond-ai-mentions.yml` 은 env로 **`SLACK_BOT_TOKEN`(등록됨) + `SLACK_AI_BOT_TOKEN`(canonical)** 만 주입합니다. 제거 대상 legacy env(`OPENCLAW_SLACK_BOT_TOKEN` / `AI_SLACK_BOT_TOKEN` / `SLACK_TOKEN`)는 **워크플로우가 애초에 주입하지 않는 dead fallback**이므로 제거해도 동작 불변입니다.

- 현재: `SLACK_BOT_TOKEN`(등록·우선) 으로 정상 동작
- Phase 1(operator) 등록 후: canonical `SLACK_AI_BOT_TOKEN` 도 인식

`gh secret list` 실측: `SLACK_BOT_TOKEN`·`AI_SLACK_BOT_TOKEN`·`OPENCLAW_SLACK_BOT_TOKEN` 등록됨 / canonical `SLACK_AI_BOT_TOKEN`·`SLACK_OPENCLAW_BOT_TOKEN` 미등록(Phase 1 대상).

## 범위 한정

- 채널 해석 체인(`respond_ai_mentions.py:174-211`)은 본 변경 **미포함**.
- legacy secret 삭제(`gh secret delete` ×2)는 **Phase 4** 별도 작업.

## 검증
```
ruff check / ruff format --check → 통과
py_compile scripts/respond_ai_mentions.py → OK
actionlint / yaml lint → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)