### PR TITLE
feat: post summary quality — dedup/meta/stat-dump cleanup + theme subtitle dedup

### DIFF
--- a/scripts/common/markdown_utils.py
+++ b/scripts/common/markdown_utils.py
@@ -322,6 +322,114 @@ def smart_truncate(text: str, max_len: int) -> str:
 _truncate_title = smart_truncate
 
 
+# Meta-commentary sentences that describe the *collection* rather than the news
+# itself — these read as noise when surfaced as a human-facing summary bullet.
+_META_BULLET_RE = re.compile(r"(?:가격 언급|신규 상장)\s*[:：]|데이터가 포착되었습니다")
+
+
+def _collapse_repeated_paren_tokens(text: str) -> str:
+    """Collapse duplicate comma-separated tokens inside parentheses.
+
+    e.g. ``($1, $1, $1, $73k, $1,000)`` → ``($1, $73k, $1,000)``.
+    Splits on ", " (comma + space) so thousands separators like ``$1,000``
+    are preserved.
+    """
+
+    def _dedupe(match: "re.Match[str]") -> str:
+        inner = match.group(1)
+        parts = inner.split(", ")
+        seen: set = set()
+        out: List[str] = []
+        for part in parts:
+            key = part.strip()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(part)
+        return "(" + ", ".join(out) + ")"
+
+    return re.sub(r"\(([^()]*)\)", _dedupe, text)
+
+
+def _collapse_adjacent_duplicate_blocks(text: str) -> str:
+    """Collapse an immediately repeated block ``<block><sep><block>`` → ``<block>``.
+
+    Handles interleaved duplication where a title/clause is echoed back-to-back.
+    Applied iteratively until the string stabilises.
+    """
+    pattern = re.compile(r"(.{12,}?)\s*\1")
+    prev = None
+    cur = text
+    while prev != cur:
+        prev = cur
+        cur = pattern.sub(r"\1", cur, count=1)
+    return cur
+
+
+def _dedupe_sentences(text: str) -> str:
+    """Drop later sentences that repeat an earlier one (whitespace-insensitive)."""
+    sentences = re.split(r"(?<=[.!?。])\s+", text)
+    seen: set = set()
+    out: List[str] = []
+    for sentence in sentences:
+        norm = re.sub(r"\s+", "", sentence).rstrip(".。")
+        if norm and norm in seen:
+            continue
+        if norm:
+            seen.add(norm)
+        out.append(sentence)
+    return " ".join(out)
+
+
+def _is_stats_enumeration(text: str) -> bool:
+    """Return True for non-prose stat dumps that should not be a summary bullet.
+
+    Targets two observed shapes (no sentence-ending punctuation):
+      - "20 총 이슈 3 테마 수 2 출처 수 5 안보 이슈"  (≥3 ``<n> <label>`` pairs)
+      - "WorldMonitor/Al Jazeera 13건 65%"          (source + count + percent)
+    """
+    stripped = text.strip()
+    if not stripped:
+        return True
+    has_sentence_punct = bool(re.search(r"[.!?]", stripped))
+    if has_sentence_punct:
+        return False
+    tokens = stripped.split()
+    if len(tokens) <= 6 and any(t.endswith("%") for t in tokens) and any("건" in t for t in tokens):
+        return True
+    pairs = re.findall(r"\d+\s+[가-힣]{1,6}", stripped)
+    return len(pairs) >= 3
+
+
+def sanitize_summary_bullet(text: str) -> str:
+    """Clean a candidate summary/excerpt bullet for digest display.
+
+    Returns ``""`` when the text is non-prose (stat enumeration) or pure
+    meta-commentary that should not surface as a human-facing summary.
+    Otherwise returns the de-duplicated, noise-collapsed text. Designed to be
+    safe on normal prose (returns it unchanged).
+    """
+    if not text or not text.strip():
+        return ""
+    text = text.strip()
+    # 1) Collapse repeated tokens inside parentheses (e.g. "$1, $1, $1").
+    text = _collapse_repeated_paren_tokens(text)
+    # 2) Drop meta-commentary sentences, keep genuine insight sentences.
+    sentences = re.split(r"(?<=[.!?。])\s+", text)
+    kept = [s for s in sentences if not _META_BULLET_RE.search(s)]
+    text = " ".join(kept).strip()
+    if not text:
+        return ""
+    # 3) Remove duplicated blocks / sentences.
+    text = _collapse_adjacent_duplicate_blocks(text)
+    text = _dedupe_sentences(text)
+    text = re.sub(r"\s{2,}", " ", text).strip()
+    # 4) Drop non-prose stat enumerations entirely.
+    if _is_stats_enumeration(text):
+        return ""
+    return text
+
+
 def html_reference_details(
     summary: str,
     references: Iterable[Dict[str, str]],

--- a/scripts/common/theme_briefing.py
+++ b/scripts/common/theme_briefing.py
@@ -156,6 +156,7 @@ class ThemeBriefingGenerator:
         this returns a direct description snippet from the top article,
         giving readers a concrete preview of the most important story.
         """
+        from .enrichment import _is_desc_duplicate_of_title
         from .summarizer import _is_generic_desc
 
         if not articles:
@@ -164,7 +165,9 @@ class ThemeBriefingGenerator:
         for article in articles[:5]:
             desc = _fix_mistranslations((article.get("description_ko") or article.get("description", "")).strip())
             title = _fix_mistranslations(article.get("title_ko") or article.get("title", ""))
-            if not desc or desc == title or len(desc) < 20:
+            # Skip descriptions that merely echo the title (incl. "title + source"
+            # variants) — they produce a redundant italic subtitle above the card.
+            if not desc or len(desc) < 20 or _is_desc_duplicate_of_title(desc, title):
                 continue
             if _is_generic_desc(desc):
                 continue

--- a/scripts/generate_daily_summary.py
+++ b/scripts/generate_daily_summary.py
@@ -29,6 +29,7 @@ from common.markdown_utils import (
     html_report_links,
     markdown_link,
     markdown_table,
+    sanitize_summary_bullet,
     smart_truncate,
 )
 from common.post_generator import POSTS_DIR
@@ -140,7 +141,10 @@ def extract_bullet_points(content: str, heading: str, max_items: int = 5) -> Lis
     for line in section.split("\n"):
         line = line.strip()
         if line.startswith("- "):
-            bullets.append(line)
+            cleaned = sanitize_summary_bullet(line[2:].strip())
+            if not cleaned:
+                continue
+            bullets.append(f"- {cleaned}")
             if len(bullets) >= max_items:
                 break
     return bullets

--- a/scripts/generate_weekly_digest.py
+++ b/scripts/generate_weekly_digest.py
@@ -19,7 +19,7 @@ from typing import Dict, List
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from common.config import get_kst_timezone, setup_logging
-from common.markdown_utils import smart_truncate
+from common.markdown_utils import sanitize_summary_bullet, smart_truncate
 from common.post_generator import PostGenerator
 
 logger = setup_logging("generate_weekly_digest")
@@ -246,6 +246,9 @@ def extract_key_bullets(body: str, max_bullets: int = 3) -> List[str]:
             clean = re.sub(r"\*\*(.+?)\*\*", r"\1", line)
             if _is_generic_sentence(clean):
                 continue
+            clean = sanitize_summary_bullet(clean)
+            if not clean:
+                continue
             clean = smart_truncate(clean, 120)
             bullets.append(clean)
             if len(bullets) >= max_bullets:
@@ -273,6 +276,10 @@ def extract_key_bullets(body: str, max_bullets: int = 3) -> List[str]:
         text = text.strip()
 
         if len(text) < 15 or _is_generic_sentence(text):
+            continue
+
+        text = sanitize_summary_bullet(text)
+        if not text or len(text) < 15:
             continue
 
         score = _sentence_score(text)

--- a/tests/test_generate_daily_summary.py
+++ b/tests/test_generate_daily_summary.py
@@ -147,6 +147,22 @@ class TestExtractBulletPoints:
     def test_no_section(self):
         assert gds.extract_bullet_points("no section here", "없는 섹션") == []
 
+    def test_sanitizes_defective_bullets(self):
+        content = (
+            "## 핵심 요약\n"
+            "- 20 총 이슈 3 테마 수 2 출처 수 5 안보 이슈\n"
+            "- 비트코인이 하락했습니다. 비트코인이 하락했습니다.\n"
+            "- 비트코인은 ETF 수요가 줄어들면서 $73,000 가까이 하락했습니다.\n"
+        )
+        bullets = gds.extract_bullet_points(content, "핵심 요약")
+        # Non-prose stat dump dropped entirely.
+        assert all("총 이슈 3 테마" not in b for b in bullets)
+        # Duplicated sentence collapsed to one occurrence.
+        dup = [b for b in bullets if "비트코인이 하락했습니다" in b]
+        assert dup and dup[0].count("비트코인이 하락했습니다") == 1
+        # Normal prose preserved.
+        assert any("$73,000" in b for b in bullets)
+
 
 # ---------------------------------------------------------------------------
 # extract_table_rows

--- a/tests/test_markdown_utils.py
+++ b/tests/test_markdown_utils.py
@@ -14,6 +14,7 @@ from common.markdown_utils import (
     html_text,
     markdown_link,
     markdown_table,
+    sanitize_summary_bullet,
     smart_truncate,
 )
 
@@ -356,3 +357,73 @@ class TestSmartTruncateKoreanBranch:
         result = smart_truncate(text, 20)
         assert result.endswith("…")
         assert len(result) <= 21  # 20 chars + ellipsis
+
+
+class TestSanitizeSummaryBullet:
+    """Tests for sanitize_summary_bullet — cleaning digest/summary bullets.
+
+    Real defect strings observed in 2026-06-01 weekly-investment-digest.
+    """
+
+    def test_empty_returns_empty(self):
+        assert sanitize_summary_bullet("") == ""
+        assert sanitize_summary_bullet("   ") == ""
+
+    def test_stats_enumeration_dropped(self):
+        # Garbled token-dump from worldmonitor stats block flattened into a line.
+        assert sanitize_summary_bullet("20 총 이슈 3 테마 수 2 출처 수 5 안보 이슈") == ""
+
+    def test_source_count_fragment_dropped(self):
+        # "<source> <n>건 <n>%" fragment — not prose.
+        assert sanitize_summary_bullet("WorldMonitor/Al Jazeera 13건 65%") == ""
+
+    def test_meta_commentary_sentence_dropped_keeps_insight(self):
+        text = (
+            "가격 언급: 뉴스 제목에서 24건의 가격 데이터가 포착되었습니다 "
+            "($1, $1, $1, $73k, $1,000). 구체적 가격대가 언급되는 것은 시장의 가격 민감도가 높다는 신호입니다."
+        )
+        result = sanitize_summary_bullet(text)
+        assert result == "구체적 가격대가 언급되는 것은 시장의 가격 민감도가 높다는 신호입니다."
+
+    def test_meta_only_returns_empty(self):
+        # When the only content is meta-commentary, nothing useful remains.
+        text = "가격 언급: 뉴스 제목에서 24건의 가격 데이터가 포착되었습니다 ($1, $1, $1)."
+        assert sanitize_summary_bullet(text) == ""
+
+    def test_adjacent_duplicated_block_collapsed(self):
+        text = (
+            "긴급 알림 암호화폐가 하락하는 동안 과대광고는 치솟고 있습니다. 이제 두 개의 ETF가 있습니다 "
+            "암호화폐가 하락하는 동안 과대광고는 치솟고 있습니다. 이제 두 개의 ETF가 있습니다."
+        )
+        result = sanitize_summary_bullet(text)
+        # The repeated block must appear only once.
+        assert result.count("이제 두 개의 ETF가 있습니다") == 1
+        assert result.count("과대광고는 치솟고 있습니다") == 1
+
+    def test_duplicated_sentence_collapsed(self):
+        text = "비트코인이 하락했습니다. 비트코인이 하락했습니다."
+        result = sanitize_summary_bullet(text)
+        assert result.count("비트코인이 하락했습니다") == 1
+
+    def test_collapse_repeated_paren_tokens(self):
+        text = "가격대는 ($1, $1, $1, $73k, $1,000) 범위입니다."
+        result = sanitize_summary_bullet(text)
+        # Repeated identical "$1" tokens collapsed to a single occurrence.
+        assert result.count("$1,") + result.count("$1)") <= 2
+        assert "$73k" in result
+        assert "$1,000" in result
+
+    def test_normal_sentence_unchanged(self):
+        text = "비트코인은 ETF 수요가 줄어들면서 $73,000 가까이 하락했습니다."
+        assert sanitize_summary_bullet(text) == text
+
+    def test_numeric_prose_with_punctuation_preserved(self):
+        # Price stats sentence with commas/periods is informative — must NOT be dropped.
+        text = "현재가 $363.36, 24시간 -3.48% 하락, 7일 -7.82%. 시가총액 $6.70B"
+        result = sanitize_summary_bullet(text)
+        assert result != ""
+        assert "$363.36" in result
+
+    def test_kospi_insight_preserved(self):
+        text = "KOSPI 8,476.15 (+3.55%): 강한 상승세로 매수 심리가 우세합니다."
+        assert sanitize_summary_bullet(text) == text

--- a/tests/test_summarizer_coverage.py
+++ b/tests/test_summarizer_coverage.py
@@ -338,6 +338,19 @@ class TestGenerateThemeSubtitle:
         ]
         result = ts._generate_theme_subtitle("bitcoin", articles)
         assert isinstance(result, str)
+        assert "Bitcoin surged 15%" in result
+
+    def test_title_plus_source_desc_skipped(self):
+        """Description that is only the title + source suffix is a duplicate and
+        must be skipped (avoids the redundant italic theme-subtitle line)."""
+        ts = ThemeSummarizer([])
+        articles = [
+            {
+                "title": "5월 코스피 44조 팔아치운 외국인, 코스닥 2.8조 순매수",
+                "description": "5월 코스피 44조 팔아치운 외국인, 코스닥 2.8조 순매수 조선일보",
+            }
+        ]
+        assert ts._generate_theme_subtitle("stock", articles) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
집계/테마 포스트의 요약 표시 품질을 생성 단계에서 개선 (3 커밋).

## 1. weekly digest 요약 bullet 정제
- `markdown_utils.sanitize_summary_bullet()` 공유 헬퍼: 메타 문장 제거 · 괄호 반복 토큰 축약(`$1,$1,$1`) · 인접 중복/중복 문장 제거 · 비-산문 통계 나열 드롭 · 정상 산문 보존
- `generate_weekly_digest.extract_key_bullets` 두 경로에 적용

## 2. daily summary 집계 bullet 정제
- `generate_daily_summary.extract_bullet_points`(중앙 집계 추출기)에 동일 sanitizer 적용 → daily 집계 포스트에도 통계 나열·중복·메타 노이즈 제거

## 3. 테마 subtitle 중복 제거
- `theme_briefing.generate_theme_subtitle` 가드를 `_is_desc_duplicate_of_title()`로 교체 → "제목+출처"형 설명(예: "...순매수 조선일보")을 중복으로 인식해 스킵 → 테마 헤더 아래 redundant 이탤릭 줄 제거. 진짜 설명 스니펫은 보존, golden 스냅샷 불변.

## 검증
- 영향 모듈 전체 **548 passed** (markdown_utils/weekly_digest/daily_summary/summarizer/themed-news **golden**/renderer)
- ruff check / format 통과
- 신규 단위 테스트: sanitizer 11건 + daily 집계 정제 1건 + 테마 subtitle 중복 1건

## 범위 메모
- description(front matter) 97.5% 양호 → 미변경
- 뉴스 URL 링크는 이미 HTML 카드로 충족(stock 55 / worldmonitor 41 / crypto 70+) → 추가 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)