### PR TITLE
fix: 합성 접미사 번역 변형 재발 방지 (소스 D안) + 캐시 변형 항목 제거

### DIFF
--- a/scripts/clean_translation_cache.py
+++ b/scripts/clean_translation_cache.py
@@ -12,11 +12,18 @@ Usage:
 import argparse
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 
 from common.translator import _CACHE_PATH, _postprocess_translation
+
+# Cached values whose synthetic "...관련 보도." suffix was mutated by Google
+# Translate into 통보/알림/공지/안내/보상/경고 (see enrichment._split_synthetic_ko_suffix).
+# These are removed (not patched) so they are re-translated cleanly; the source
+# fix changes the translation key, so the bad entries are never re-created.
+_MUTATION_ARTIFACT_RE = re.compile(r"관련\s?(?:통보|알림|공지|안내|보상|경고)(?:입니다)?\s*[.。]?\s*$")
 
 
 def main() -> None:
@@ -32,7 +39,16 @@ def main() -> None:
         cache = json.load(f)
 
     fixed_count = 0
+    removed_count = 0
     for key, value in list(cache.items()):
+        # Remove suffix-mutation artifacts so they are re-translated cleanly.
+        if _MUTATION_ARTIFACT_RE.search(value):
+            removed_count += 1
+            if args.dry_run:
+                print(f"  [remove {key[:8]}] {value[-60:]}")
+            else:
+                del cache[key]
+            continue
         cleaned = _postprocess_translation(value)
         if cleaned != value:
             fixed_count += 1
@@ -42,16 +58,16 @@ def main() -> None:
             else:
                 cache[key] = cleaned
 
-    if fixed_count == 0:
+    if fixed_count == 0 and removed_count == 0:
         print(f"Cache clean: {len(cache)} entries, 0 fixes needed.")
         return
 
     if args.dry_run:
-        print(f"\n[DRY RUN] Would fix {fixed_count}/{len(cache)} entries.")
+        print(f"\n[DRY RUN] Would fix {fixed_count} and remove {removed_count} of {len(cache)} entries.")
     else:
         with open(_CACHE_PATH, "w", encoding="utf-8") as f:
             json.dump(cache, f, ensure_ascii=False)
-        print(f"Fixed {fixed_count}/{len(cache)} cached translations.")
+        print(f"Fixed {fixed_count}, removed {removed_count} of {len(cache)} cached translations.")
 
 
 if __name__ == "__main__":

--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -171,6 +171,26 @@ _SYNTHETIC_MARKERS = [
 ]
 
 
+# Synthetic Korean category suffix appended by _analyze_*_title — it always
+# ends in "...보도." (관련 보도 / 섹터 보도 / 시장 보도 / 산업 보도 / 자산 보도).
+# When such a suffix rides on an English-dominant synthetic description, the
+# downstream translation pass would re-translate the whole string and Google
+# Translate mutates "보도" → 통보/알림/공지/안내/보상/경고. We split the suffix
+# off, translate only the English body, then reattach the suffix verbatim.
+_SYNTHETIC_KO_SUFFIX_RE = re.compile(r"\s+[가-힣][가-힣A-Za-z0-9·\s]*보도\.\s*$")
+
+
+def _split_synthetic_ko_suffix(desc: str) -> tuple:
+    """Split a synthetic description into ``(english_body, korean_suffix)``.
+
+    Returns ``(desc, "")`` when no trailing "...보도." category suffix exists.
+    """
+    m = _SYNTHETIC_KO_SUFFIX_RE.search(desc)
+    if m:
+        return desc[: m.start()], m.group(0)
+    return desc, ""
+
+
 def is_private_url(url: str) -> bool:
     """Check if URL points to an obvious private/internal target."""
     return is_private_url_target(url)
@@ -2060,7 +2080,15 @@ def enrich_items(
                 )
             )
         ):
-            ko_desc = translate_to_korean(desc)
+            # Protect a synthetic Korean category suffix ("...보도.") from being
+            # re-translated and mutated. Translate only the English body, then
+            # reattach the suffix verbatim.
+            if item.get("_synthetic"):
+                body, suffix = _split_synthetic_ko_suffix(desc)
+            else:
+                body, suffix = desc, ""
+            ko_body = translate_to_korean(body)
+            ko_desc = (ko_body.rstrip() + suffix) if suffix else ko_body
             if ko_desc != desc:
                 item["description_ko"] = ko_desc
 

--- a/tests/test_clean_translation_cache.py
+++ b/tests/test_clean_translation_cache.py
@@ -46,7 +46,7 @@ def test_main_dry_run_previews_changes_without_writing(tmp_path, monkeypatch, ca
     assert before == after
     output = capsys.readouterr().out
     assert "[abc12345] bad artifact" in output
-    assert "[DRY RUN] Would fix 1/2 entries." in output
+    assert "[DRY RUN] Would fix 1 and remove 0 of 2 entries." in output
 
 
 def test_main_writes_cleaned_cache(tmp_path, monkeypatch, capsys):
@@ -60,4 +60,26 @@ def test_main_writes_cleaned_cache(tmp_path, monkeypatch, capsys):
     ctc.main()
 
     assert json.loads(cache_path.read_text(encoding="utf-8")) == {"abc": "bad output"}
-    assert "Fixed 1/1 cached translations." in capsys.readouterr().out
+    assert "Fixed 1, removed 0 of 1 cached translations." in capsys.readouterr().out
+
+
+def test_main_removes_suffix_mutation_artifacts(tmp_path, monkeypatch, capsys):
+    cache_path = tmp_path / "cache.json"
+    _write_cache(
+        cache_path,
+        {
+            "k1": "미국 재무부는 트럼프 계정 앱을 출시합니다. 해당 관련 통보.",
+            "k2": "1,600% 상승하기 전에 구매해야 할 상위 암호화폐입니다. (1,600% 개정) 광고 관련 알림.",
+            "k3": "비트코인이 사상 최고가를 경신했습니다.",  # clean — kept
+            "k4": "지정학적 리스크가 커지고 있습니다. 급락 관련 보도.",  # legit 보도 suffix — kept
+        },
+    )
+    monkeypatch.setattr(ctc, "_CACHE_PATH", cache_path)
+    monkeypatch.setattr(ctc, "_postprocess_translation", lambda value: value)
+    monkeypatch.setattr(ctc.sys, "argv", ["clean_translation_cache.py"])
+
+    ctc.main()
+
+    remaining = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert set(remaining) == {"k3", "k4"}  # mutated entries removed, clean + legit kept
+    assert "removed 2" in capsys.readouterr().out

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -3416,3 +3416,39 @@ class TestEnrichItemOriginalUrlAndMaxFetchLog:
             # The debug message about max_fetch should have been emitted
             debug_calls = [str(c) for c in mock_debug.call_args_list]
             assert any("max_fetch" in c for c in debug_calls)
+
+
+class TestSplitSyntheticKoSuffix:
+    """_split_synthetic_ko_suffix — protect synthetic '...보도.' tag from translation mutation."""
+
+    def test_splits_kwanryeon_bodo_suffix(self):
+        body, suf = _enrichment_mod._split_synthetic_ko_suffix("Bitcoin crashes 10%. (10% 변동) 급락 관련 보도.")
+        assert body == "Bitcoin crashes 10%. (10% 변동)"
+        assert suf == " 급락 관련 보도."
+
+    def test_splits_entity_bodo_suffix(self):
+        body, suf = _enrichment_mod._split_synthetic_ko_suffix("Colombia accuses Ecuador. Colombia 관련 보도.")
+        assert body == "Colombia accuses Ecuador. Colombia"
+        assert suf == " 관련 보도."
+
+    def test_splits_sector_bodo_suffix(self):
+        body, suf = _enrichment_mod._split_synthetic_ko_suffix("Nvidia chip revenue beats. 반도체 섹터 보도.")
+        assert suf == " 반도체 섹터 보도."
+
+    def test_no_suffix_returns_original(self):
+        text = "S&P 500 falls 3%. (3% 변동)"
+        body, suf = _enrichment_mod._split_synthetic_ko_suffix(text)
+        assert body == text
+        assert suf == ""
+
+    def test_pure_korean_no_split(self):
+        text = "비트코인이 사상 최고가를 경신했습니다."
+        body, suf = _enrichment_mod._split_synthetic_ko_suffix(text)
+        assert body == text
+        assert suf == ""
+
+    def test_suffix_does_not_span_paren(self):
+        # The Korean '(... 변동)' detail must stay in the body, not be swallowed.
+        body, suf = _enrichment_mod._split_synthetic_ko_suffix("Crypto economy grows. ($78억) 디지털 자산 보도.")
+        assert body == "Crypto economy grows. ($78억)"
+        assert suf == " 디지털 자산 보도."


### PR DESCRIPTION
## 근본 원인 (추적 결과)
`_analyze_english_title`(fallback)이 영어 제목에 한글 접미사 `관련 보도`를 붙여 **영어 우세** 문자열 생성 → `detect_language`="en" → `enrich_items` 번역 패스가 `_synthetic` 무시하고 재번역 → Google Translate가 `보도`를 문맥따라 `통보/알림/공지/안내/보상/경고`로 변형. (PR #1008은 과거 잔재 정리, 이 PR은 **재발 차단**)

## 소스 수정 — A/B/C 비교 후 D안 채택
| 안 | 내용 | 판정 |
|---|---|---|
| A | 영어 경로 접미사 제거 | ❌ 카테고리 태그 상실 + `desc==title` 중복탐지 유발 |
| B | `_synthetic` 재번역 스킵 | ❌ 영어 설명 잔존 → 한국어 SEO 악화 |
| **D** | 번역 전 한글 접미사 분리→번역 후 verbatim 재부착 | ✅ **동작 downside 0** |

- `enrichment._split_synthetic_ko_suffix` 신규: 트레일링 `...보도.` 접미사를 `(english_body, korean_suffix)`로 분리 (Korean `(...변동)` 디테일은 본문에 보존)
- `enrich_items` 번역 패스: `_synthetic` 항목은 본문만 번역 후 접미사 재부착 → `보도` 보존, 변형 차단

## 캐시 변형 항목 제거 (#2)
- `clean_translation_cache.py`에 변형 아티팩트 제거 로직 추가 (값이 `관련 {통보|알림|공지|안내|보상|경고}`로 끝나면 삭제 → 재번역 유도)
- 현재 캐시 5000개 중 변형 **15개만 정확히 타겟** (dry-run 검증, 오탐 0)
- `server_morning_autopost.sh`가 이미 이 도구를 실행 → 자동 정리. `_state`는 수동 미편집(가드 준수)

## 검증
- `ruff check`/`format` clean, `basedpyright` 0 에러
- 전체 테스트 **4599 passed, 16 skipped**
- 신규: `TestSplitSyntheticKoSuffix`(6) + `test_main_removes_suffix_mutation_artifacts`

## Test plan
- [x] `_split_synthetic_ko_suffix`: 관련 보도/섹터 보도/엔티티 보도 분리, 접미사 없음/순한글 무변경, paren 비-스팬
- [x] 캐시 도구: 변형 15건 제거, 정당 `관련 보도`·clean 항목 보존
- [x] 전체 회귀 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)