### PR TITLE
fix: 보안 피드 교체(Rekt→CoinTelegraph) + 캐시 변형 패턴 정밀화

### DIFF
--- a/scripts/clean_translation_cache.py
+++ b/scripts/clean_translation_cache.py
@@ -23,7 +23,17 @@ from common.translator import _CACHE_PATH, _postprocess_translation
 # Translate into 통보/알림/공지/안내/보상/경고 (see enrichment._split_synthetic_ko_suffix).
 # These are removed (not patched) so they are re-translated cleanly; the source
 # fix changes the translation key, so the bad entries are never re-created.
-_MUTATION_ARTIFACT_RE = re.compile(r"관련\s?(?:통보|알림|공지|안내|보상|경고)(?:입니다)?\s*[.。]?\s*$")
+#
+# Precision: the mutated suffix is always an APPENDED short fragment, so we
+# require a boundary (sentence period / dash / ellipsis / close-paren) followed
+# by a short (<=24 char) lead-in before "관련 {noun}". A standalone legitimate
+# description like "신규 상장 관련 공지" (the whole value, no preceding boundary)
+# is therefore preserved — worst case for any residual false positive is a
+# benign cache eviction → re-translation.
+_MUTATION_ARTIFACT_RE = re.compile(
+    r"[.。)\-–—…]\s*[가-힣A-Za-z0-9,()%·\s]{0,24}"
+    r"관련\s?(?:통보|알림|공지|안내|보상|경고)(?:입니다)?\s*[.。]?\s*$"
+)
 
 
 def main() -> None:

--- a/scripts/collect_crypto_news.py
+++ b/scripts/collect_crypto_news.py
@@ -451,22 +451,26 @@ def fetch_exchange_announcements() -> List[Dict[str, Any]]:
 
 
 def fetch_rekt_news(limit: int = 10) -> List[Dict[str, Any]]:
-    """Fetch security incidents from Rekt News via RSS feed."""
+    """Fetch security incidents via RSS feed (CoinTelegraph hacks tag).
+
+    Historically sourced from Rekt News; the URL/key retain the ``rekt`` name
+    for backward compatibility after Rekt stopped publishing incident RSS.
+    """
     items: List[Dict[str, Any]] = []
 
     try:
         rss_items = fetch_rss_feed(
-            get_url("crypto_news", "rss_rekt_news", "https://rekt.news/rss/feed.xml"),
-            "Rekt News",
-            ["security", "hack", "rekt"],
+            get_url("crypto_news", "rss_rekt_news", "https://cointelegraph.com/rss/tag/hacks"),
+            "CoinTelegraph Hacks",
+            ["security", "hack", "exploit", "rekt"],
         )
         for item in rss_items[:limit]:
             item["title"] = f"[Security] {item['title']}"
             item["category_override"] = "security-alerts"
             items.append(item)
-        logger.info("Rekt News RSS: fetched %d incidents", len(items))
+        logger.info("CoinTelegraph Hacks RSS: fetched %d incidents", len(items))
     except Exception as e:
-        logger.warning("Rekt News RSS failed: %s", e)
+        logger.warning("CoinTelegraph Hacks RSS failed: %s", e)
 
     return items
 

--- a/scripts/config/collectors.yml
+++ b/scripts/config/collectors.yml
@@ -90,7 +90,10 @@ crypto_news:
     rss_decrypt: "https://decrypt.co/feed"
     rss_bitcoin_magazine: "https://bitcoinmagazine.com/.rss/full/"
     rss_theblock: "https://www.theblock.co/rss"
-    rss_rekt_news: "https://rekt.news/rss/feed.xml"
+    # Rekt News stopped publishing hack-incident RSS (opinion/research only,
+    # 0 incident items since ~2026-04). Swapped to CoinTelegraph's hacks tag
+    # feed — incident-focused, refreshed daily. Key kept for backward compat.
+    rss_rekt_news: "https://cointelegraph.com/rss/tag/hacks"
     # Google News RSS (영어/한국어)
     google_news_crypto_en: "https://news.google.com/rss/search?q=cryptocurrency&hl=en-US&gl=US&ceid=US:en"
     google_news_crypto_kr: "https://news.google.com/rss/search?q=암호화폐+비트코인&hl=ko&gl=KR&ceid=KR:ko"

--- a/tests/test_clean_translation_cache.py
+++ b/tests/test_clean_translation_cache.py
@@ -72,6 +72,8 @@ def test_main_removes_suffix_mutation_artifacts(tmp_path, monkeypatch, capsys):
             "k2": "1,600% 상승하기 전에 구매해야 할 상위 암호화폐입니다. (1,600% 개정) 광고 관련 알림.",
             "k3": "비트코인이 사상 최고가를 경신했습니다.",  # clean — kept
             "k4": "지정학적 리스크가 커지고 있습니다. 급락 관련 보도.",  # legit 보도 suffix — kept
+            "k5": "신규 상장 관련 공지",  # standalone legit notice (no boundary) — kept
+            "k6": "이용 약관 변경 관련 안내",  # standalone legit guide — kept
         },
     )
     monkeypatch.setattr(ctc, "_CACHE_PATH", cache_path)
@@ -81,5 +83,6 @@ def test_main_removes_suffix_mutation_artifacts(tmp_path, monkeypatch, capsys):
     ctc.main()
 
     remaining = json.loads(cache_path.read_text(encoding="utf-8"))
-    assert set(remaining) == {"k3", "k4"}  # mutated entries removed, clean + legit kept
+    # mutated appended-fragment entries removed; clean + legit-suffix + standalone notices kept
+    assert set(remaining) == {"k3", "k4", "k5", "k6"}
     assert "removed 2" in capsys.readouterr().out


### PR DESCRIPTION
이전 라운드 후속 2건 (각 atomic commit).

## 1. 보안 피드 교체 — Rekt News → CoinTelegraph hacks
**근본 원인**(collector-reviewer 조사): Rekt News RSS가 사건 보도를 중단 — 현재 오피니언/리서치만 제공하고 **사건 항목 0건이 2026-04부터 지속**. 이로 인해 `daily-security-report`가 최소 기준(1건) 미달로 스킵 (06-04/05 누락).

**검증**(WebFetch): `https://cointelegraph.com/rss/tag/hacks` = 유효 RSS, **30개 항목 전부 해킹/익스플로잇/보안 사건**, 최신 2026-06-05.

- `collectors.yml`: `rss_rekt_news` 값 교체 (키는 backward-compat 유지)
- `collect_crypto_news.py`: fallback URL + feed_name + 로그 + docstring 갱신, 키워드에 `exploit` 추가
- **가드라인 검증**: `fetch_rekt_news()` 실행 → `[Security]` 태그 + `security-alerts` 카테고리로 사건 수집 확인 (0건 → ≥1건)

## 2. 캐시 변형 제거 패턴 정밀화 (리뷰 MEDIUM 대응)
`_MUTATION_ARTIFACT_RE`이 "관련 {통보/알림/공지/안내/보상/경고}"로 끝나는 **모든** 값을 매칭 → 미래 정당한 거래소 공지("신규 상장 관련 공지")까지 제거할 위험.

변형 접미사는 항상 **경계(마침표/대시/말줄임/닫는괄호) 뒤의 짧은(≤24자) 후행 단편**이라는 구조를 이용해 정밀화:
- 실제 캐시 5000개 중 변형 **15개 여전히 정확 타겟** (놓침 0)
- 독립 legit `신규 상장 관련 공지` / `이용 약관 변경 관련 안내` 등 **보존 검증**
- 잔여 FP는 "문장. 단편" 형태뿐 + worst-case는 무해한 재번역

## 검증
- `ruff check`/`format` clean, YAML 파싱 OK
- collector 통합 테스트 **75 passed**, 캐시 도구 테스트 **5 passed**(보호 케이스 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)