### PR TITLE
feat: TERM_OVERRIDES에 DeFi 프로젝트 고유명사 보강 (번역 mangling 예방)

### DIFF
--- a/scripts/common/translator.py
+++ b/scripts/common/translator.py
@@ -202,6 +202,55 @@ TERM_OVERRIDES: Dict[str, str] = {
     "Benzinga": "Benzinga",
     "Investopedia": "Investopedia",
     "CoinMetrics": "CoinMetrics",
+    # DeFi protocols, L1/L2 chains & bridges — proper nouns prone to MT mangling
+    # (e.g. "Cetus Protocol", "Wormhole"). Matching is word-boundary + case-
+    # insensitive, so names that collide with common English words are
+    # DELIBERATELY EXCLUDED or qualified with a multi-word form to avoid false
+    # positives like "market optimism" → "market 옵티미즘" or "yield curve" →
+    # "yield 커브". Excluded bare: Optimism, Curve, Maker, Balancer, Yearn, Base,
+    # Near, Compound, Convex, Harmony, Cosmos, Sui, TON, Blast, Jupiter.
+    "Lido": "리도",
+    "Arbitrum": "아비트럼",
+    "Aptos": "앱토스",
+    "Synthetix": "신세틱스",
+    "Celestia": "셀레스티아",
+    "Starknet": "스타크넷",
+    "Fantom": "팬텀",
+    "Tron": "트론",
+    "PancakeSwap": "팬케이크스왑",
+    "SushiSwap": "스시스왑",
+    "MakerDAO": "MakerDAO",
+    "zkSync": "zkSync",
+    "EigenLayer": "EigenLayer",
+    "Pendle": "Pendle",
+    "Ethena": "Ethena",
+    "GMX": "GMX",
+    "dYdX": "dYdX",
+    "Frax": "Frax",
+    "1inch": "1inch",
+    "Raydium": "Raydium",
+    "Jito": "Jito",
+    "Hyperliquid": "Hyperliquid",
+    "Berachain": "Berachain",
+    # Multi-word forms (avoid bare-word collisions)
+    "Curve Finance": "Curve Finance",
+    "Compound Finance": "Compound Finance",
+    "Euler Finance": "Euler Finance",
+    "Ondo Finance": "Ondo Finance",
+    "NEAR Protocol": "NEAR Protocol",
+    "Cetus Protocol": "Cetus Protocol",
+    "Mango Markets": "Mango Markets",
+    "Celsius Network": "Celsius Network",
+    "Terra Luna": "Terra Luna",
+    # Bridges / notable hack targets
+    "Wormhole": "Wormhole",
+    "Ronin Bridge": "Ronin Bridge",
+    "Ronin Network": "Ronin Network",
+    "Nomad Bridge": "Nomad Bridge",
+    "Poly Network": "Poly Network",
+    "Beanstalk": "Beanstalk",
+    "Mt. Gox": "마운트곡스",
+    "FTX": "FTX",
 }
 
 # Build case-insensitive lookup (key_lower -> (original_key, korean))

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -334,6 +334,44 @@ class TestTermOverridesData:
             assert k != "", "Empty key found in TERM_OVERRIDES"
 
 
+class TestDeFiProjectTermOverrides:
+    """DeFi 프로젝트 고유명사 보호 + 흔한 단어 오탐 방지 회귀 가드."""
+
+    def test_defi_proper_nouns_protected(self):
+        # 신규 고유명사는 placeholder로 보호되어 MT 변형을 받지 않아야 한다.
+        for term in ["Lido", "Arbitrum", "PancakeSwap", "Wormhole", "Hyperliquid"]:
+            modified, replacements = _apply_term_overrides(f"{term} suffered an exploit")
+            assert term not in modified, f"{term} should be protected"
+            assert len(replacements) >= 1
+
+    def test_multiword_form_protected(self):
+        # 다단어 형태는 통째로 보호된다.
+        modified, replacements = _apply_term_overrides("Cetus Protocol was hacked")
+        assert "Cetus Protocol" not in modified
+        assert any(kr == "Cetus Protocol" for _, kr in replacements)
+
+    def test_ambiguous_common_words_not_matched(self):
+        # 흔한 영어 단어와 충돌하는 프로젝트명은 추가하지 않았으므로,
+        # 이 문장들은 어떤 용어도 치환하지 않아야 한다 (#1006-1009 품질 회귀 방지).
+        for text in [
+            "market optimism remains high",
+            "the yield curve steepened",
+            "a load balancer failure",
+            "compound interest grows over time",
+            "investors yearn for higher returns",
+        ]:
+            _, replacements = _apply_term_overrides(text)
+            assert replacements == [], f"unexpected term match in: {text!r} → {replacements}"
+
+    def test_bare_curve_not_matched_but_curve_finance_is(self):
+        # bare "Curve"는 미보호(흔한 단어), "Curve Finance"만 보호.
+        _, bare = _apply_term_overrides("the curve flattened")
+        assert bare == []
+        modified, full = _apply_term_overrides("Curve Finance exploit drained funds")
+        assert "Curve Finance" not in modified
+        assert any(kr == "Curve Finance" for _, kr in full)
+
+
 class TestGetDisplayTitle:
     """Tests for get_display_title()."""
 


### PR DESCRIPTION
## 배경
#1011(DeFiLlama hacks 통합)로 `Cetus Protocol`, `Wormhole`, `Hyperliquid` 등 DeFi 프로젝트 고유명사가 보안 리포트에 노출됩니다. 코드 리뷰(#1011)에서 이들이 번역 패스에서 Google Translate에 의해 변형될 수 있는 **기존 리스크 클래스**(#1006~#1009)로 지적되어, 별도 PR로 하드닝합니다.

## 변경
- `TERM_OVERRIDES`에 주요 DeFi 프로토콜 / L1·L2 체인 / 브리지 ~40종 추가
  - 대부분 **원문 유지**(mangling 0 보장), 정착 표기만 한글(`Lido→리도`, `Arbitrum→아비트럼`, `Tron→트론` 등)

## 핵심 안전 설계 — 오탐 방지
매칭이 **단어 경계 + 대소문자 무시**라, 흔한 영어 단어와 충돌하는 프로젝트명을 추가하면 `"market optimism"→"market 옵티미즘"`, `"yield curve"→"yield 커브"` 같은 오탐으로 **#1006~1009가 고친 품질을 회귀**시킵니다. 따라서:
- **제외(bare)**: Optimism, Curve, Maker, Balancer, Yearn, Base, Near, Compound, Convex, Harmony, Cosmos, Sui, TON, Blast, Jupiter
- **다단어 형태로만 등록**: `Curve Finance`, `Compound Finance`, `Euler Finance`, `NEAR Protocol`, `Mango Markets`, `Celsius Network`, `Terra Luna` 등

## 검증
- 신규 테스트 4종: 고유명사 보호 / 다단어 보호 / **흔한 단어 미매칭 회귀가드** / bare-vs-multiword
- `tests/test_translator.py` 109 passed, 용어 참조 테스트(defi_llama/blockchain/summarizer/enrichment 등) 343 passed
- ruff check/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)