### PR TITLE
feat: 보안 리포트에 bridgeHack/targetType 기반 공격 분류 섹션 추가

### DIFF
--- a/scripts/collect_crypto_news.py
+++ b/scripts/collect_crypto_news.py
@@ -522,6 +522,9 @@ def fetch_defillama_hacks(limit: int = 8, days: int = 30) -> List[Dict[str, Any]
             chains = [chains]
         chain_str = ", ".join(str(c) for c in chains if c) or "N/A"
 
+        bridge_hack = bool(hack.get("bridgeHack"))
+        target_type = sanitize_string(str(hack.get("targetType") or "")).strip()
+
         title = f"[Security] {name} exploit"
         if technique:
             title += f": {technique}"
@@ -547,6 +550,8 @@ def fetch_defillama_hacks(limit: int = 8, days: int = 30) -> List[Dict[str, Any]
                 "description": " | ".join(desc_parts),
                 "source": "DeFiLlama",
                 "category_override": "security-alerts",
+                "bridge_hack": bridge_hack,
+                "target_type": target_type,
             }
         )
 
@@ -1654,6 +1659,21 @@ class CryptoNewsCollector(BaseCollector):
                 sec_insight_lines.append(f"주요 공격 유형: {tech_str}.")
             if total_funds > 0:
                 sec_insight_lines.append(f"총 피해 규모는 **${total_funds:,.0f}**으로 추정됩니다.")
+
+            # DeFiLlama 정형 분류 (bridgeHack / targetType) — 해당 메타데이터가
+            # 있는 사건(DeFiLlama 출처)만 집계. RSS/뉴스 항목에는 키가 없어 자연 제외.
+            classified = [it for it in rekt_items if "bridge_hack" in it]
+            if classified:
+                bridge_n = sum(1 for it in classified if it.get("bridge_hack"))
+                if bridge_n:
+                    sec_insight_lines.append(
+                        f"이 중 **브리지 공격 {bridge_n}건**이 포함되어, "
+                        "크로스체인 브리지의 자금 집중 리스크에 주의가 필요합니다."
+                    )
+                target_counter: Counter = Counter(it.get("target_type") for it in classified if it.get("target_type"))
+                if target_counter:
+                    target_str = ", ".join(f"{t}({c}건)" for t, c in target_counter.most_common(3))
+                    sec_insight_lines.append(f"공격 대상 유형: {target_str}.")
 
         if google_security_items:
             sec_insight_lines.append(f"\n블록체인 보안 관련 뉴스 {len(google_security_items)}건이 수집되었습니다.")

--- a/tests/test_collect_crypto_news.py
+++ b/tests/test_collect_crypto_news.py
@@ -333,3 +333,88 @@ def test_fetch_defillama_hacks_handles_non_list_payload():
     mod = importlib.import_module("collect_crypto_news")
     with patch.object(mod, "request_with_retry", return_value=_defillama_response({"error": "nope"})):
         assert mod.fetch_defillama_hacks() == []
+
+
+def test_fetch_defillama_hacks_captures_bridge_and_target_fields():
+    """bridgeHack/targetType를 구조화 필드로 보존합니다."""
+    import time
+
+    mod = importlib.import_module("collect_crypto_news")
+    now = time.time()
+    payload = [
+        {
+            "name": "BridgeX",
+            "technique": "Signature Verification",
+            "amount": 50_000_000,
+            "chain": ["Ethereum"],
+            "source": "https://x/1",
+            "date": now,
+            "bridgeHack": True,
+            "targetType": "Bridge",
+        },
+        {
+            "name": "TokenY",
+            "technique": "Reentrancy",
+            "amount": 1_000_000,
+            "chain": ["BSC"],
+            "source": "",
+            "date": now,
+            "bridgeHack": False,
+            "targetType": "Token",
+        },
+    ]
+    with patch.object(mod, "request_with_retry", return_value=_defillama_response(payload)):
+        items = mod.fetch_defillama_hacks(limit=8, days=30)
+
+    assert items[0]["bridge_hack"] is True
+    assert items[0]["target_type"] == "Bridge"
+    assert items[1]["bridge_hack"] is False
+    assert items[1]["target_type"] == "Token"
+
+
+def test_security_content_emits_attack_classification_section():
+    """bridgeHack/targetType이 있는 사건은 보안 인사이트에 분류 섹션을 렌더합니다."""
+    mod = importlib.import_module("collect_crypto_news")
+    incidents = [
+        {
+            "title": "[Security] BridgeX exploit: Signature Verification",
+            "link": "https://x/1",
+            "description": "Funds Lost: $50,000,000 | Technique: Signature Verification | Chain: Ethereum",
+            "source": "DeFiLlama",
+            "category_override": "security-alerts",
+            "bridge_hack": True,
+            "target_type": "Bridge",
+        },
+        {
+            "title": "[Security] ProtoZ exploit: Oracle Manipulation",
+            "link": "https://defillama.com/hacks#ProtoZ",
+            "description": "Funds Lost: $2,000,000 | Technique: Oracle Manipulation | Chain: Solana",
+            "source": "DeFiLlama",
+            "category_override": "security-alerts",
+            "bridge_hack": True,
+            "target_type": "Protocol",
+        },
+    ]
+    collector = mod.CryptoNewsCollector()
+    content = collector._build_security_content(incidents, incidents, [])
+    assert "브리지 공격 2건" in content
+    assert "공격 대상 유형" in content
+    assert "Bridge(1건)" in content
+    assert "Protocol(1건)" in content
+
+
+def test_security_content_no_classification_for_news_only_items():
+    """bridge_hack 키가 없는 RSS/뉴스 항목만 있으면 분류 섹션을 렌더하지 않습니다."""
+    mod = importlib.import_module("collect_crypto_news")
+    incidents = [
+        {
+            "title": "[Security] Some hack reported by media",
+            "link": "https://news/1",
+            "description": "Funds Lost: $1,000,000",
+            "source": "CoinTelegraph Hacks",
+        }
+    ]
+    collector = mod.CryptoNewsCollector()
+    content = collector._build_security_content(incidents, incidents, [])
+    assert "브리지 공격" not in content
+    assert "공격 대상 유형" not in content


### PR DESCRIPTION
## 배경
#1011에서 통합한 DeFiLlama hacks API는 `bridgeHack`(bool)·`targetType`(string) 등 정형 분류 필드를 제공하지만 현재 미활용 상태입니다. 이를 보안 리포트 분석에 반영합니다.

## 변경
- **`fetch_defillama_hacks`**: `bridge_hack`(bool) / `target_type`(str)를 아이템의 구조화 필드로 보존 (다운스트림이 문자열 파싱 없이 직접 소비)
- **`_build_security_content`**: `bridge_hack` 키가 있는 사건(= DeFiLlama 출처)만 집계해 '보안 인사이트'에 분류 추가
  - `이 중 **브리지 공격 N건**이 포함되어, 크로스체인 브리지의 자금 집중 리스크에 주의가 필요합니다.`
  - `공격 대상 유형: Bridge(N건), Token(N건), Protocol(N건).`
  - RSS/뉴스 항목에는 키가 없어 **자연 제외** → 기존 동작 영향 없음 (graceful)

## 검증
- 신규 테스트 3종: 구조화 필드 보존 / 분류 섹션 렌더 / **뉴스 전용 항목은 미렌더**(회귀 가드)
- `tests/test_collect_crypto_news.py` + `tests/test_collector_integration.py` 77 passed, ruff clean
- e2e(합성 페이로드): "브리지 공격 2건" + 대상유형 분포(Bridge/Token/Protocol) 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)