### PR TITLE
feat: og front matter R2 배선 + 워크플로우 env 게이트

### DIFF
--- a/.github/workflows/check-post-images.yml
+++ b/.github/workflows/check-post-images.yml
@@ -29,6 +29,14 @@ jobs:
   check-images:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      # R2 오프로딩 게이트: 5키가 모두 설정돼야 backfill/thumbnail 재생성분이 R2로 미러링.
+      # 미설정 시 빈 값 → asset_storage.is_enabled()=False → 로컬 경로 no-op.
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/.github/workflows/generate-journal-og-images.yml
+++ b/.github/workflows/generate-journal-og-images.yml
@@ -19,6 +19,14 @@ jobs:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # R2 오프로딩 게이트: 5키가 모두 설정돼야 미러링+front matter CDN URL 활성.
+      # 미설정 시 빈 값 → asset_storage.is_enabled()=False → 로컬 경로 no-op.
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/docs/r2-provisioning-guide.md
+++ b/docs/r2-provisioning-guide.md
@@ -84,6 +84,12 @@ export R2_PUBLIC_BASE_URL=https://img.2twodragon.com
    미러링은 `image_generator/base.py:_save_and_close` 의 공통 chokepoint에서 일어나므로, 이미지를 만드는 모든 워크플로우에 노출돼야 신규분이 R2로 올라간다.
 3. `boto3` 는 이미 `scripts/requirements.txt:23` (`boto3>=1.40,<2`) 에 포함 — 추가 설치 불필요.
 
+### ⚠️ Jekyll 프론트 동기 (필수, 누락 시 hero 이미지 누락)
+`R2_PUBLIC_BASE_URL` 을 켜는 것과 **동시에** `_config.yml:17` `r2_image_base` 를 설정해야 한다.
+- 레이아웃(`_layouts/post.html`, `_layouts/default.html`, `_includes/generated-picture.html`)은 `image contains site.r2_image_base` 로 CDN URL을 원격으로 분류해 `static_files` 존재 가드를 건너뛴다.
+- `r2_image_base` 가 빈 값이면 CDN URL(`https://.../generated/...`)이 원격으로도, 로컬(`/assets/images/generated/`)로도 매칭되지 않아 hero/og 이미지가 드롭될 수 있다.
+- 값은 `R2_PUBLIC_BASE_URL` 의 substring이어야 한다 (예: `r2_image_base: "img.2twodragon.com"` 또는 `https://img.2twodragon.com`).
+
 ## Step 5 — 활성화 검증 (쓰기 없음)
 
 ```bash
@@ -135,6 +141,13 @@ Step 7로 **앞으로의** churn은 멈추지만, 과거 history의 죽은 blob(
 
 ---
 
+## 알려진 제약 (활성화 후, PR #1041 리뷰 반영)
+
+R2 활성화로 front matter `image:` 가 CDN 절대 URL이 되면서 생기는 비-blocking 동작 변화. 결함은 아니나 인지 필요:
+
+- **`check_post_images.py:23` 이 CDN URL을 스킵한다.** `IMAGE_RE` 는 `/` 시작 값만 매칭하므로 `https://` CDN URL은 이미지 무결성/auto-heal 검사에서 제외된다 → 해당 포스트 커버리지 감소. (기존 `migrate_images_to_r2` 경로도 동일 URL을 생성하므로 신규 회귀 아님.)
+- **generator 간 front matter URL 정책이 갈린다.** journal-OG 경로(`generate_og_images.py:637`)는 활성 시 CDN URL을 쓰지만 `backfill_images.py:568/575` 는 로컬 경로를 유지한다. 의도적(마이그레이션 스크립트가 backfill 산출물을 나중에 sweep) — 컷오버 시 backfill 산출물이 마이그레이션 대상에 포함되는지 확인.
+
 ## 롤백 / 안전성
 
 - 어느 단계든 5개 시크릿을 제거하면 `is_enabled()=False` → 즉시 로컬 경로로 복귀(no-op). 단 이미 `--apply`로 CDN URL이 박힌 포스트는 되돌리려면 백업 복원 필요.
@@ -142,6 +155,7 @@ Step 7로 **앞으로의** churn은 멈추지만, 과거 history의 죽은 blob(
 
 ## 검증 체크리스트
 
+- [ ] Step 4: `_config.yml` `r2_image_base` 가 `R2_PUBLIC_BASE_URL` substring으로 설정됨 (누락 시 hero 드롭)
 - [ ] Step 5: `is_enabled()=True`, `public_url` 이 CDN URL 반환
 - [ ] Step 5: dry-run 건수 > 0, `git status` clean
 - [ ] Step 6: `--apply` 후 샘플 포스트 OG/hero 이미지 200

--- a/docs/r2-provisioning-guide.md
+++ b/docs/r2-provisioning-guide.md
@@ -129,7 +129,7 @@ Step 7로 **앞으로의** churn은 멈추지만, 과거 history의 죽은 blob(
 
 - 플랜: `.omc/plans/git-history-image-blob-reclaim.md` (4차 critic APPROVE) + 컷오버→strip 시퀀스 `.omc/wiki/r2-strip-b-og.md` (시나리오 B).
 - **전체 strip 도구 = `git filter-repo --invert-paths --path assets/images/generated/`.** BFG는 HEAD 보호로 현재분(HEAD 트리)을 못 지워 full strip에 부적합 → filter-repo 사용(미설치 시 설치가 게이트). BFG는 churn-only 축소에만 유효.
-- strip은 **비가역** → 표본 아닌 **전수 검증**: 마이그레이션 후 잔존 `grep==0` + 1,603 포스트 ~6변형(main 3 + og-* thumb 3) **전수 curl 200** 확인 후에만 strip.
+- strip은 **비가역** → 표본 아닌 **전수 검증**: 마이그레이션 후 잔존 `grep==0` + **실행 시점 라이브 grep으로 도출한 전체 참조 포스트**(2026-07-06 실측 1,879, 매일 증가 — 고정 수치 금지) ~6변형(main 3 + og-* thumb 3) **전수 curl 200** 확인 후에만 strip. V→S 구간 신규 포스트 자동화 동결 필수.
 - 전 협업자 재클론 필요, force-push 전 자동화 크론 일시 중단 필수.
 - **별도 승인·정비 윈도우에서 실행** (이 가이드 범위 밖).
 

--- a/scripts/generate_og_images.py
+++ b/scripts/generate_og_images.py
@@ -632,7 +632,9 @@ def main() -> None:
             # Generate card thumbnail
             generate_thumbnail(out_path)
             if args.update_frontmatter:
-                url = og_image_url(post["slug"], post["date"])
+                # R2 활성 시 CDN 절대 URL, 비활성 시 로컬 경로 그대로 반환한다
+                # (public_url은 basename만 취하므로 로컬 URL을 넘겨도 동작 동일).
+                url = asset_storage.public_url(og_image_url(post["slug"], post["date"]))
                 if update_post_frontmatter(post["filepath"], url):
                     updated += 1
 


### PR DESCRIPTION
## 요약

R2 이미지 오프로딩 컷오버를 위한 **배선(wiring) 단계**. R2 5키가 프로비저닝되기 전까지는 전부 로컬 no-op으로 동작하여 프로덕션 영향이 없습니다.

## 변경 사항

- **`scripts/generate_og_images.py`** — `--update-frontmatter` 경로에서 `og_image_url()`을 `asset_storage.public_url()`로 감쌈. R2 활성 시 CDN 절대 URL, 비활성 시 로컬 경로 그대로 반환 (`public_url`이 basename만 취하므로 동작 동일).
- **`.github/workflows/check-post-images.yml`, `generate-journal-og-images.yml`** — R2 5키 env 블록 추가. 미설정 시 빈 값 → `asset_storage.is_enabled()=False` → 로컬 no-op.
- **`docs/r2-provisioning-guide.md`** — strip 전수 검증 수치를 고정값 대신 실행 시점 라이브 grep 기준으로 명시 (매일 증가, 고정 수치 금지).

## 안전성

- R2 게이트: `is_enabled()`는 5키 전부 존재할 때만 True. 현재 리포에 `R2_*` 시크릿 미설정 → 전 경로 로컬 no-op.
- dry-run 재검증 완료: `현재 → CDN` URL이 동일(로컬 경로 유지)함을 확인.

## 검증

- `ruff check scripts/ tests/` — All checks passed
- `ruff format --check scripts/ tests/` — 241 files already formatted
- `migrate_images_to_r2.py` dry-run — 게이트 no-op 정상 동작 확인

## 후속 (이 PR 범위 밖)

- Cloudflare R2 콘솔 프로비저닝 + 리포 시크릿 5키 등록
- 프로비저닝 후 `migrate_images_to_r2.py --apply`
- 별도 승인·정비 윈도우에서 git-history blob strip (비가역, 시나리오 B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)