### PR TITLE
perf(ci): Jekyll build guard 빌드 시간 단축 (related-posts O(n²) 제거)

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -180,14 +180,32 @@ layout: default
       {% assign p3_urls = "" %}
       {% assign p4_urls = "" %}
       {% assign p5_urls = "" %}
+      {% comment %}
+        표시에는 우선순위 순서대로 최대 related_limit(3)개만 필요하다. 각 버킷을
+        related_limit개로 상한하고, 최상위 버킷(p1)이 가득 차면 전체 스캔을 조기
+        종료한다 — 최종 선택은 항상 우선순위 순 앞쪽 3개뿐이고 버킷은 상호배타
+        (한 포스트는 한 버킷에만 들어감)이므로 출력은 완전히 동일하다. 상한이 없으면
+        같은 카테고리 포스트가 수백 개일 때 append가 문자열 전체를 매번 복사해
+        페이지당 O(n^2) 문자열 증가가 발생하고, 이것이 포스트 누적 시 빌드가
+        급격히 느려지던 근본 원인이다.
+      {% endcomment %}
+      {% assign p1_count = 0 %}
+      {% assign p2_count = 0 %}
+      {% assign p3_count = 0 %}
+      {% assign p4_count = 0 %}
+      {% assign p5_count = 0 %}
       {% for post in related_all %}
+      {% if p1_count >= related_limit %}{% break %}{% endif %}
       {% if post.pin %}{% continue %}{% endif %}
       {% assign post_is_summary = false %}
       {% if post.tags contains "daily-digest" or post.tags contains "weekly-digest" or post.tags contains "summary" or post.tags contains "일일요약" %}
       {% assign post_is_summary = true %}
       {% endif %}
       {% if page_is_summary != true and post_is_summary %}
-        {% assign p5_urls = p5_urls | append: post.url | append: "||" %}
+        {% if p5_count < related_limit %}
+          {% assign p5_urls = p5_urls | append: post.url | append: "||" %}
+          {% assign p5_count = p5_count | plus: 1 %}
+        {% endif %}
         {% continue %}
       {% endif %}
       {% assign same_cat = false %}
@@ -199,13 +217,25 @@ layout: default
       {% endfor %}
       {% endif %}
       {% if same_cat and shared_tags >= 2 %}
-        {% assign p1_urls = p1_urls | append: post.url | append: "||" %}
+        {% if p1_count < related_limit %}
+          {% assign p1_urls = p1_urls | append: post.url | append: "||" %}
+          {% assign p1_count = p1_count | plus: 1 %}
+        {% endif %}
       {% elsif same_cat and shared_tags == 1 %}
-        {% assign p2_urls = p2_urls | append: post.url | append: "||" %}
+        {% if p2_count < related_limit %}
+          {% assign p2_urls = p2_urls | append: post.url | append: "||" %}
+          {% assign p2_count = p2_count | plus: 1 %}
+        {% endif %}
       {% elsif same_cat %}
-        {% assign p3_urls = p3_urls | append: post.url | append: "||" %}
+        {% if p3_count < related_limit %}
+          {% assign p3_urls = p3_urls | append: post.url | append: "||" %}
+          {% assign p3_count = p3_count | plus: 1 %}
+        {% endif %}
       {% elsif shared_tags >= 1 %}
-        {% assign p4_urls = p4_urls | append: post.url | append: "||" %}
+        {% if p4_count < related_limit %}
+          {% assign p4_urls = p4_urls | append: post.url | append: "||" %}
+          {% assign p4_count = p4_count | plus: 1 %}
+        {% endif %}
       {% endif %}
       {% endfor %}
 


### PR DESCRIPTION
## 배경

CI `Code Quality` 워크플로우의 `Run Jekyll build guard` 단계가 포스트 누적으로 8분+ 걸려 만성 timeout을 유발했다(직전 임시 조치로 timeout 15→25분 상향). 이 PR은 build guard의 목적(빌드 파손 감지)과 커버리지, 그리고 프로덕션 배포 산출물을 훼손하지 않으면서 **근본 원인**을 제거한다.

## 실측 병목 (`jekyll build --profile`, 로컬 1990개 포스트)

| 템플릿 | 렌더 시간 | 비중 |
|---|---|---|
| `_layouts/post.html` | **153.0s** | **RENDER의 81.8%** |
| `_layouts/default.html` | 10.5s | |
| `_layouts/category.html` | 5.3s | |
| 나머지 전부 | < 5s each | |

병목은 전적으로 `post.html`의 **관련 포스트 선별 루프**였다.

## 근본 원인

기존 루프는 포스트 렌더마다 나머지 전 포스트를 순회하며 우선순위 버킷 문자열(`p1_urls`~`p5_urls`)에 URL을 `append` 했다. Liquid의 `append`는 매번 문자열 전체를 새로 복사하므로, 같은 카테고리 포스트가 수백 개일 때 **페이지당 O(n²) 문자열 증가**가 발생했고, 이것이 포스트가 쌓일수록 전체 빌드를 급격히 느리게 만든 원인이다.

## 적용한 최적화 (출력 동일 보장)

관련 포스트는 우선순위 순 **최대 3개(`related_limit`)** 만 표시된다. 따라서:
- 각 버킷을 `related_limit`개로 **상한**한다.
- 최상위 버킷(p1)이 가득 차면 스캔을 **조기 종료**한다.

버킷은 상호배타(한 포스트 = 한 버킷)이고 최종 선택은 항상 우선순위 순 앞쪽 3개뿐이므로, 어떤 버킷도 3개를 넘겨 읽히지 않는다 → **렌더 출력은 완전히 동일**하다. 알고리즘·선별 기준·표시 개수는 그대로다.

## 빌드 시간 (before / after, 로컬 1990개 포스트)

| | 전체 빌드 | `post.html` 렌더 |
|---|---|---|
| before | 187.2s | 153.0s |
| after | **72.0s** | **38.9s** |
| | **2.6× faster** | **3.9× faster** |

(둘 다 `--profile` 동일 조건. CI 러너는 더 느리지만 비율은 유지된다.)

## guard 커버리지 보존

- 전체 사이트가 그대로 빌드된다 (`--limit_posts` 등 범위 축소 **없음**).
- 생성된 HTML 페이지 수 동일: **2007개** (before/after).
- `bundle exec jekyll build` 성공 + `python scripts/check_jekyll_build.py` **exit 0**, destination conflict **0건**.

## 프로덕션 산출물 동일성

- 전체 **2007개 HTML 페이지 콘텐츠 동일성** 확인: 빌드 타임스탬프 토큰(`og:updated_time`, `google-translate.js?v=`)과 무의미한 공백 라인만 정규화한 뒤 실제 콘텐츠 차이 **0건**.
- 변경은 `post.html` 하나뿐이라 CI와 Vercel이 동일 템플릿으로 빌드 → 두 환경 산출물이 동일하게 유지된다.

## 변경 범위

`_layouts/post.html` 1개 파일, +35 / -5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)