### PR TITLE
test(ci): 커버리지 게이트 55→65 래칫 + 회귀 가드 (P3-1/P3-2)

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 61 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 48 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 113 |
+| 테스트 파일 (tests/test_*.py) | 114 |
 
 <!-- component-counts:end -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ quote-style = "double"
 relative_files = true
 
 [tool.pytest.ini_options]
-addopts = "--cov=scripts --cov-fail-under=55"
+addopts = "--cov=scripts --cov-fail-under=65"
 # 베어 `pytest` 가 Jekyll 빌드 산출물(_site/) 내 복사된 테스트를 수집해
 # ImportError 로 깨지던 문제 방지. CI 는 명시적으로 `pytest tests/` 를 호출하므로 영향 없음.
 testpaths = ["tests"]

--- a/tests/test_coverage_floor_guard.py
+++ b/tests/test_coverage_floor_guard.py
@@ -1,0 +1,95 @@
+"""CI config regression guard: the global coverage floor must not be silently
+lowered.
+
+Two independent gates enforce the ``scripts`` coverage floor and both must stay
+at or above :data:`_MIN_FLOOR`:
+
+* ``pyproject.toml`` — ``addopts = "--cov=scripts --cov-fail-under=NN"`` runs on
+  every ``pytest`` invocation (local and CI).
+* ``.github/workflows/code-quality.yml`` — a dedicated
+  ``coverage report --fail-under=NN`` step re-checks the same data in CI.
+
+Total ``scripts`` coverage sits ~68% (2026-07); the floor was ratcheted
+55 -> 65 (P3-1/P3-2) to lock the existing coverage as a regression baseline.
+Without this guard the floor could be quietly dropped back — re-opening the gap
+between "tests deleted" and "build still green".
+
+Direction: floor is ``>=`` — ratcheting UP (65 -> 70 ...) stays green; only
+removing a gate or lowering it below 65 trips this test. If the floor is lowered
+intentionally, update ``_MIN_FLOOR`` here AND both ``--fail-under`` values
+together.
+
+The workflow gate that scopes coverage to ``summary_sections.py`` (a stricter
+95% per-module floor) is intentionally excluded here — it is guarded separately
+by ``test_summary_sections_coverage_floor.py``.
+
+Text/regex scan only (no YAML parser, no import of the measured source) so the
+guard cannot perturb the coverage gate it protects.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "code-quality.yml"
+
+# The global scripts coverage floor both gates must enforce.
+_MIN_FLOOR = 65
+
+_COV_FAIL_UNDER_RE = re.compile(r"--cov-fail-under=(\d+)")
+_FAIL_UNDER_RE = re.compile(r"--fail-under=(\d+)")
+
+
+def test_config_files_exist() -> None:
+    """Canary: a moved/renamed config fails loudly instead of vacuously."""
+    assert _PYPROJECT.is_file(), f"{_PYPROJECT} not found"
+    assert _WORKFLOW.is_file(), f"{_WORKFLOW} not found"
+
+
+def test_pyproject_coverage_floor_enforced() -> None:
+    """pyproject.toml must gate scripts coverage at >= 65%."""
+    text = _PYPROJECT.read_text(encoding="utf-8")
+
+    floors = [int(m.group(1)) for m in _COV_FAIL_UNDER_RE.finditer(text)]
+    assert floors, (
+        "pyproject.toml no longer sets `--cov-fail-under=N`. The global "
+        "coverage floor was removed — restore it or, if intentional, delete "
+        "this guard with justification."
+    )
+    assert min(floors) >= _MIN_FLOOR, (
+        f"pyproject.toml coverage floor lowered to {min(floors)} "
+        f"(< {_MIN_FLOOR}). If intentional, update _MIN_FLOOR in this guard "
+        f"and both --fail-under values (pyproject + code-quality.yml) together."
+    )
+
+
+def test_workflow_global_coverage_floor_enforced() -> None:
+    """code-quality.yml must re-check the global coverage floor at >= 65%.
+
+    Only the *global* ``coverage report --fail-under=N`` line counts — the
+    ``--include="*/summary_sections.py"`` line is a separate per-module gate.
+    """
+    text = _WORKFLOW.read_text(encoding="utf-8")
+
+    global_lines = [
+        line
+        for line in text.splitlines()
+        if "coverage report" in line and "--fail-under=" in line and "--include=" not in line
+    ]
+    assert global_lines, (
+        "code-quality.yml no longer runs a global "
+        "`coverage report --fail-under=N` step (without --include). The global "
+        "coverage gate was removed — restore it or, if intentional, delete this "
+        "guard with justification."
+    )
+
+    floors = [int(m.group(1)) for line in global_lines if (m := _FAIL_UNDER_RE.search(line)) is not None]
+    assert floors, "global coverage report step exists but has no --fail-under floor; the gate is a no-op."
+    assert min(floors) >= _MIN_FLOOR, (
+        f"code-quality.yml global coverage floor lowered to {min(floors)} "
+        f"(< {_MIN_FLOOR}). If intentional, update _MIN_FLOOR in this guard "
+        f"and both --fail-under values (pyproject + code-quality.yml) together."
+    )


### PR DESCRIPTION
## 개요
`docs/refactoring-plan-2026-07.md` §3의 **P3-1/P3-2**를 실행합니다: 전역 커버리지 게이트를 55→65로 래칫하고, 다시 낮아지지 않도록 `ci-config-guard` 회귀 가드를 추가합니다.

## 변경 내용

### 📊 커버리지 게이트 래칫 (`pyproject.toml`)
- `--cov-fail-under=55` → `65`.
- 전체 `scripts` 커버리지가 **이미 ~68%**(계획서 §3 실측)라 신규 테스트 없이 즉시 그린.
- CI의 `coverage report --fail-under=65`(`code-quality.yml:80`)와 동일 수준으로 정렬 → 기존 커버리지를 회귀 방지 바닥으로 잠금.

### 🛡️ 회귀 가드 (`tests/test_coverage_floor_guard.py`, 신규)
두 게이트가 65 밑으로 낮아지거나 제거되면 **CI에서 실패**:
1. `pyproject.toml`의 `--cov-fail-under` ≥ 65
2. `code-quality.yml`의 **전역** `coverage report --fail-under` ≥ 65

설계 원칙(기존 `test_summary_sections_coverage_floor.py` 패턴 미러):
- 방향 `>=` — 래칫업(65→70)은 그린, 낮추면 트립.
- YAML **텍스트 스캔만** 사용, 측정 소스 import 안 함 → 가드가 커버리지 게이트를 교란하지 않음.
- `summary_sections.py` 전용 95% 게이트(`--include=` 라인)는 별도 가드 담당이라 **명시적으로 제외**(스코핑 검증 포함).
- `*_exists` 카나리로 파일 이동/개명 시 공허 통과 방지.

## 검증
- `ruff check` / `ruff format --check` → 통과
- `pytest tests/test_coverage_floor_guard.py` → **3 passed**
- **비-공허성 실증**(임시 복사본, 실제 파일 미변경):
  - pyproject 게이트 55로 낮춤 → 실패 ✓
  - pyproject 게이트 제거 → 실패 ✓
  - workflow 전역 게이트 낮춤 → 실패 ✓
  - summary_sections(95) 라인만 낮춤 → 전역 가드 트립 안 함(스코핑 정확) ✓

## 참고
- P3-3(65→70, `og_visuals` 테스트 필요 구간)은 본 PR 범위 밖 — 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)