### PR TITLE
test(og): og_visuals·og_compose 커버리지 100% (P3-3, 전체 67.75→69.71%)

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 61 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 48 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 114 |
+| 테스트 파일 (tests/test_*.py) | 115 |
 
 <!-- component-counts:end -->

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 61 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 48 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 115 |
+| 테스트 파일 (tests/test_*.py) | 116 |
 
 <!-- component-counts:end -->

--- a/tests/test_og_compose.py
+++ b/tests/test_og_compose.py
@@ -1,0 +1,226 @@
+"""Unit tests for scripts/common/og_compose.py (표준 OG 이미지 합성).
+
+`generate_og_image` 는 matplotlib 로 1200x630 OG 이미지를 렌더한 뒤 저장하고,
+포맷 변환([[og_image_formats]])과 R2 미러링([[asset_storage]])을 호출한다.
+테스트는 실제 Agg 백엔드로 렌더하되, 디스크 밖 부수효과(포맷 변환·미러링)는
+patch 로 고정한다 (MEMORY `feedback_golden_master_hermetic` 교훈 — 파일시스템/외부
+probe 의존을 제거해 결정적·격리 상태로 검증).
+
+`_draw_data_chips` 는 렌더 경로 내부에서만 호출되므로, 메트릭이 담긴 description
+을 넘겨 `generate_og_image` 를 통해 커버한다.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# scripts/ 를 경로에 추가 (conftest 와 동일하게 `from common.X` 임포트 지원)
+_SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, os.path.abspath(_SCRIPTS_DIR))
+
+try:
+    import matplotlib
+
+    matplotlib.use("Agg")  # headless 렌더 백엔드 (CI 안전)
+
+    from common import og_compose as c
+
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover - 의존성 부재 시 스킵
+    c = None  # type: ignore
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="matplotlib/og_compose unavailable")
+
+
+# ---------------------------------------------------------------------------
+# 순수 헬퍼: safe_text / wrap_text
+# ---------------------------------------------------------------------------
+
+
+def test_safe_text_escapes_dollar():
+    assert c.safe_text("BTC $100") == r"BTC \$100"
+
+
+def test_safe_text_no_dollar_unchanged():
+    assert c.safe_text("plain text") == "plain text"
+
+
+def test_wrap_text_short_not_wrapped():
+    assert c.wrap_text("hello", max_width=20, max_lines=2) == ["hello"]
+
+
+def test_wrap_text_truncates_long_last_line_with_ellipsis():
+    # 마지막 라인이 (max_width-3) 보다 길면 자른 뒤 "..." 부착
+    text = "abcdefghij klmnopqrst uvwxyz1234"
+    lines = c.wrap_text(text, max_width=10, max_lines=1)
+    assert len(lines) == 1
+    assert lines[0].endswith("...")
+
+
+def test_wrap_text_short_last_line_gets_ellipsis_only():
+    # max_lines 초과 + 마지막 라인이 짧음 → else 분기(rstrip + "...")
+    text = "aaaa bb cccccccc"
+    lines = c.wrap_text(text, max_width=10, max_lines=1)
+    assert lines == ["aaaa bb..."]
+
+
+# ---------------------------------------------------------------------------
+# _extract_metrics — description 파싱
+# ---------------------------------------------------------------------------
+
+
+def test_extract_metrics_empty():
+    assert c._extract_metrics("") == []
+
+
+def test_extract_metrics_caps_at_three():
+    desc = "BTC $50,000 공포탐욕: 40/100 KOSPI 2,500 (+1.2%) VIX 30 달러지수 104"
+    metrics = c._extract_metrics(desc)
+    assert len(metrics) == 3
+    assert all(len(m) == 3 for m in metrics)
+
+
+def test_extract_metrics_news_count():
+    # "N건 수집" 패턴 → NEWS 메트릭
+    metrics = c._extract_metrics("오늘 총 12건 수집 완료")
+    assert ("NEWS", "12건", "#8b5cf6") in metrics
+
+
+# ---------------------------------------------------------------------------
+# generate_og_image — 전체 렌더 경로 (I/O patch 로 격리)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_io():
+    """포맷 변환·R2 미러링을 no-op 으로 고정 (디스크/네트워크 격리)."""
+    with (
+        patch.object(c, "_convert_formats_parallel") as m_conv,
+        patch.object(c.asset_storage, "mirror_generated_variants") as m_mirror,
+    ):
+        yield m_conv, m_mirror
+
+
+def test_generate_og_image_success(tmp_path, patched_io):
+    m_conv, m_mirror = patched_io
+    out = str(tmp_path / "crypto-news.png")
+    ok = c.generate_og_image(
+        title="비트코인 급등 소식",
+        date_str="2026-07-15",
+        category="crypto-news",
+        description="BTC $50,000 수집 12건",
+        output_path=out,
+    )
+    assert ok is True
+    assert os.path.exists(out)
+    m_conv.assert_called_once()
+    m_mirror.assert_called_once()
+
+
+def test_generate_og_image_with_metrics_draws_chips(tmp_path, patched_io):
+    # 메트릭이 담긴 description → _draw_data_chips 경로 커버
+    out = str(tmp_path / "market-analysis.png")
+    ok = c.generate_og_image(
+        title="시장 분석",
+        date_str="2026-07-15",
+        category="market-analysis",
+        description="공포탐욕: 25/100 KOSPI 2,600 (+0.5%) BTC $48,000",
+        output_path=out,
+    )
+    assert ok is True
+    assert os.path.exists(out)
+
+
+def test_generate_og_image_empty_description(tmp_path, patched_io):
+    # description 없음 → desc_lines/visual_data 빈 분기
+    out = str(tmp_path / "stock-news.png")
+    ok = c.generate_og_image(
+        title="주식 뉴스",
+        date_str="2026-07-15",
+        category="stock-news",
+        description="",
+        output_path=out,
+    )
+    assert ok is True
+
+
+def test_generate_og_image_unknown_category_uses_default(tmp_path, patched_io):
+    # 미등록 카테고리 → DEFAULT_ACCENT + _draw_visual_default
+    out = str(tmp_path / "unknown-thing.png")
+    ok = c.generate_og_image(
+        title="Unknown",
+        date_str="2026-07-15",
+        category="not-a-real-category",
+        description="",
+        output_path=out,
+    )
+    assert ok is True
+
+
+def test_generate_og_image_slug_override(tmp_path, patched_io):
+    # 파일명 slug 가 override 키를 포함 → 전용 visual 함수 선택 분기
+    out = str(tmp_path / "2026-07-15-fmp-economic-calendar.png")
+    ok = c.generate_og_image(
+        title="경제 캘린더",
+        date_str="2026-07-15",
+        category="market-analysis",
+        description="",
+        output_path=out,
+    )
+    assert ok is True
+
+
+def test_generate_og_image_long_title_multiline(tmp_path, patched_io):
+    # 긴 제목 → title_lines 2줄 분기 + 긴 description 2줄 분기
+    out = str(tmp_path / "worldmonitor.png")
+    ok = c.generate_og_image(
+        title="아주 긴 제목입니다 " * 5,
+        date_str="2026-07-15",
+        category="worldmonitor",
+        description="아주 긴 설명입니다 " * 8,
+        output_path=out,
+    )
+    assert ok is True
+
+
+def test_generate_og_image_returns_false_when_mpl_unavailable(tmp_path, monkeypatch):
+    # matplotlib 부재 시 즉시 False (렌더 시도 안 함)
+    monkeypatch.setattr(c, "_MPL_AVAILABLE", False)
+    out = str(tmp_path / "crypto-news.png")
+    ok = c.generate_og_image(
+        title="x",
+        date_str="2026-07-15",
+        category="crypto-news",
+        description="",
+        output_path=out,
+    )
+    assert ok is False
+    assert not os.path.exists(out)
+
+
+def test_generate_og_image_returns_false_on_save_error(tmp_path, patched_io):
+    # output_path 가 디렉터리 → savefig 가 OSError(IsADirectoryError) → False
+    target_dir = tmp_path / "isdir.png"
+    target_dir.mkdir()
+    ok = c.generate_og_image(
+        title="x",
+        date_str="2026-07-15",
+        category="crypto-news",
+        description="",
+        output_path=str(target_dir),
+    )
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# 레지스트리 정합성 — 색/라벨 매핑이 카테고리별로 존재
+# ---------------------------------------------------------------------------
+
+
+def test_category_colors_and_labels_aligned():
+    # 모든 색 키는 라벨 키에도 존재해야 함 (렌더 시 KeyError 방지)
+    assert set(c.CATEGORY_COLORS).issubset(set(c.CATEGORY_LABELS))

--- a/tests/test_og_visuals.py
+++ b/tests/test_og_visuals.py
@@ -1,0 +1,164 @@
+"""Unit tests for scripts/common/og_visuals.py drawing helpers.
+
+각 `_draw_visual_*` 함수는 matplotlib Axes 에 카테고리 고유의 배경 일러스트를
+그리는 순수 드로잉 헬퍼다. 외부 부수효과가 없고, numpy 시드가 함수 내부에서
+고정되므로 결정적이다. 테스트는 실제 Agg 백엔드 Axes 를 넘겨 호출한 뒤
+아티스트(patches/lines/texts)가 실제로 추가됐는지 검증한다.
+
+MEMORY `feedback_golden_master_hermetic` 교훈: 이 모듈은 `_render_generated_image`
+디스크 probe 나 파일시스템에 의존하지 않으므로 골든마스터/디스크 patch 가 불필요하다.
+"""
+
+import os
+import sys
+
+import pytest
+
+# scripts/ 를 경로에 추가 (conftest 와 동일하게 `from common.X` 임포트 지원)
+_SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, os.path.abspath(_SCRIPTS_DIR))
+
+try:
+    import matplotlib
+
+    matplotlib.use("Agg")  # headless 렌더 백엔드 (CI 안전)
+    import matplotlib.pyplot as plt
+
+    from common import og_visuals as v
+
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover - 의존성 부재 시 스킵
+    plt = None  # type: ignore
+    v = None  # type: ignore
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="matplotlib/og_visuals unavailable")
+
+_ACCENT = "#58a6ff"
+
+
+@pytest.fixture
+def ax():
+    """headless Agg Axes fixture — 각 테스트 후 figure 를 닫아 자원 누수 방지."""
+    fig, _ax = plt.subplots(figsize=(12, 6.3), dpi=100)
+    yield _ax
+    plt.close(fig)
+
+
+def _artist_count(_ax) -> int:
+    """Axes 에 추가된 드로잉 아티스트(patch/line/text) 총합."""
+    return len(_ax.patches) + len(_ax.lines) + len(_ax.texts)
+
+
+# ---------------------------------------------------------------------------
+# 1. accent-only 시그니처 함수 — 파라미터라이즈로 일괄 커버
+# ---------------------------------------------------------------------------
+
+_ACCENT_ONLY_FUNCS = [
+    "_draw_visual_crypto",
+    "_draw_visual_regulatory",
+    "_draw_visual_social",
+    "_draw_visual_defi",
+    "_draw_visual_political",
+    "_draw_visual_world",
+    "_draw_visual_security",
+    "_draw_visual_blockchain",
+    "_draw_visual_economic_calendar",
+    "_draw_visual_default",
+    "_draw_visual_geopolitical",
+]
+
+
+@pytest.mark.parametrize("func_name", _ACCENT_ONLY_FUNCS)
+def test_accent_only_visual_draws_artists(ax, func_name):
+    func = getattr(v, func_name)
+    before = _artist_count(ax)
+    func(ax, _ACCENT)
+    after = _artist_count(ax)
+    assert after > before, f"{func_name} 이 아티스트를 추가하지 않음"
+
+
+@pytest.mark.parametrize("func_name", _ACCENT_ONLY_FUNCS)
+def test_accent_only_visual_is_deterministic(ax, func_name):
+    """numpy 시드가 내부 고정이므로 두 번 호출 시 동일 개수의 아티스트를 추가."""
+    func = getattr(v, func_name)
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    try:
+        func(ax1, _ACCENT)
+        func(ax2, _ACCENT)
+        assert len(ax1.patches) == len(ax2.patches)
+        assert len(ax1.lines) == len(ax2.lines)
+        assert len(ax1.texts) == len(ax2.texts)
+    finally:
+        plt.close(fig1)
+        plt.close(fig2)
+
+
+# ---------------------------------------------------------------------------
+# 2. _draw_visual_stock — data(kospi) 분기
+# ---------------------------------------------------------------------------
+
+
+def test_stock_without_data(ax):
+    v._draw_visual_stock(ax, _ACCENT)
+    assert _artist_count(ax) > 0
+    # data 없으면 기본 "KOSPI" 라벨
+    labels = [t.get_text() for t in ax.texts]
+    assert "KOSPI" in labels
+
+
+def test_stock_with_kospi_data(ax):
+    v._draw_visual_stock(ax, _ACCENT, {"kospi": "2,500"})
+    labels = [t.get_text() for t in ax.texts]
+    assert "KOSPI 2,500" in labels
+
+
+def test_stock_with_empty_data_falls_back(ax):
+    # kospi 키 없는 dict → 기본 라벨 유지
+    v._draw_visual_stock(ax, _ACCENT, {"other": 1})
+    labels = [t.get_text() for t in ax.texts]
+    assert "KOSPI" in labels
+
+
+# ---------------------------------------------------------------------------
+# 3. _draw_visual_analysis — data(fear_greed) 게이지 분기
+# ---------------------------------------------------------------------------
+
+
+def test_analysis_without_data_uses_default_score(ax):
+    v._draw_visual_analysis(ax, _ACCENT)
+    labels = [t.get_text() for t in ax.texts]
+    # 기본 fear_greed 62 → "62" 텍스트
+    assert "62" in labels
+
+
+def test_analysis_with_fear_greed_data(ax):
+    v._draw_visual_analysis(ax, _ACCENT, {"fear_greed": 30.0})
+    labels = [t.get_text() for t in ax.texts]
+    assert "30" in labels
+
+
+@pytest.mark.parametrize("score", [0.0, 50.0, 100.0])
+def test_analysis_fear_greed_boundary_scores(ax, score):
+    v._draw_visual_analysis(ax, _ACCENT, {"fear_greed": score})
+    labels = [t.get_text() for t in ax.texts]
+    assert str(int(score)) in labels
+
+
+# ---------------------------------------------------------------------------
+# 4. 레지스트리 정합성 — _CATEGORY_VISUALS 의 모든 값이 호출 가능
+# ---------------------------------------------------------------------------
+
+
+def test_category_registry_all_callable(ax):
+    from common.og_compose import _CATEGORY_VISUALS
+
+    for category, func in _CATEGORY_VISUALS.items():
+        fig, a = plt.subplots()
+        try:
+            func(a, _ACCENT)
+            assert _artist_count(a) > 0, f"{category} 비주얼이 비어 있음"
+        finally:
+            plt.close(fig)


### PR DESCRIPTION
## 요약

P3-3 커버리지 캠페인 — OG 렌더링 계열 `common/` 모듈 2개에 단위 테스트를 추가해 미테스트 대형 갭을 제거합니다.

| 모듈 | 이전 | 이후 |
|------|------|------|
| `scripts/common/og_visuals.py` | 4% (354 miss) | **100%** |
| `scripts/common/og_compose.py` | 38% (88 miss) | **100%** |
| 전체 (TOTAL) | 67.75% | **69.71%** |

커버리지 게이트(`--cov-fail-under=65`)는 **변경하지 않습니다**. `common/`-only 범위에선 70% 미달이고(최대 잔여 레버 `generate_og_images.py`는 진입점 스크립트라 P3에서 명시 제외), 게이트 여유는 2.75%p → **4.71%p**로 넓어집니다.

## 변경 내용

- `tests/test_og_visuals.py` (31): 카테고리별 `_draw_visual_*` 드로잉 헬퍼 — 실제 Agg Axes 렌더 후 아티스트 검증, 결정적(numpy 시드 내부 고정)
- `tests/test_og_compose.py` (17): `generate_og_image` 전체 렌더 경로 + `safe_text`/`wrap_text`/`_extract_metrics`/`_draw_data_chips`
  - 포맷 변환(`_convert_formats_parallel`)·R2 미러링(`asset_storage.mirror_generated_variants`)은 patch로 격리 → 골든마스터 비-격리 함정 회피
  - MPL 부재/저장 실패(OSError)/slug override/멀티라인 등 분기 커버
- `docs/component-counts.md`: 테스트 파일 수 동기화 (114→116, `test_component_counts` 가드)

## 검증

- `pytest tests/ --ignore=tests/i18n` → **4741 passed, 63 skipped, 0 failed**, TOTAL 69.71% (게이트 65 통과)
- `ruff check` + `ruff format --check` 클린
- `og_visuals.py` / `og_compose.py` 각각 100% (0 miss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)