### PR TITLE
fix(hooks): remove CWE-94 code-injection in yaml-syntax-check hook

### DIFF
--- a/.claude/hooks/yaml-syntax-check.sh
+++ b/.claude/hooks/yaml-syntax-check.sh
@@ -6,8 +6,11 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 if [[ "$FILE_PATH" == *.yml || "$FILE_PATH" == *.yaml ]]; then
   if [[ -f "$FILE_PATH" ]]; then
-    if ! python3 -c "import yaml,sys; yaml.safe_load(open('$FILE_PATH'))" 2>/dev/null; then
-      echo "[yaml-syntax-check] WARNING: $FILE_PATH has YAML syntax errors. Verify with: python3 -c \"import yaml; yaml.safe_load(open('$FILE_PATH'))\"" >&2
+    # Pass the path as argv, never interpolated into the -c program text, so a
+    # crafted file name cannot break out and execute code (CWE-94 / OWASP
+    # A03:2021 Injection).
+    if ! python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$FILE_PATH" 2>/dev/null; then
+      echo "[yaml-syntax-check] WARNING: $FILE_PATH has YAML syntax errors." >&2
     fi
   fi
 fi


### PR DESCRIPTION
## Summary

The `.claude/hooks/yaml-syntax-check.sh` PostToolUse hook interpolated `$FILE_PATH` (from `tool_input.file_path`) directly into a `python3 -c "...open('$FILE_PATH')"` program body. A crafted file name could break out of the string literal and execute arbitrary Python in the hook's shell context — **CWE-94 / OWASP A03:2021 (Injection)**, reachable via a prompt-injection foothold that steers a Write/Edit's `file_path` (OWASP LLM01 / MITRE ATLAS).

## Fix
- Pass the path as `sys.argv[1]` instead of splicing it into the `-c` source (data/code separation).
- Drop the runnable copy-paste snippet from the WARNING message (it embedded the raw path inside a `python -c` command — a copy-paste hazard); keep the path as plain display text.

## Verification
- Injection payload as a filename (`x'); import os; os.system('touch /tmp/INJPWNED'); open('`) → **no code executed** (treated as a filename, `open` fails).
- Valid YAML → silent, exit 0. Invalid YAML → WARNING, exit 0 (behaviour preserved).
- `bash -n` + `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)