### PR TITLE
test(enrichment): 실 네트워크 호출 차단 가드 + flaky-green 2건 수정

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,33 @@ except ImportError:
 
 
 @pytest.fixture(autouse=True)
+def _block_real_http(monkeypatch):
+    """Fail fast if a test makes a real outbound HTTP call via ``requests``.
+
+    The enrichment pipeline reaches the network only through ``requests``, and
+    every enrichment test mocks it. A misplaced patch (e.g. after the P2-A module
+    split relocates a symbol) can silently become inert, letting a real GET hit a
+    public host that the SSRF guard permits (``example.com`` resolves publicly) —
+    a slow, flaky "green". Blocking the transport layer turns that into an
+    immediate, obvious failure. Tests that mock ``requests`` never reach this
+    adapter, so they are unaffected; DNS-resolution guards (``socket.getaddrinfo``)
+    are also untouched.
+    """
+    try:
+        from requests.adapters import HTTPAdapter
+    except ImportError:
+        return
+
+    def _blocked(self, request, *args, **kwargs):
+        raise RuntimeError(
+            f"Real outbound HTTP blocked in tests: {request.method} {request.url}. "
+            "A requests mock is missing or patched on the wrong module namespace."
+        )
+
+    monkeypatch.setattr(HTTPAdapter, "send", _blocked)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_image_rejection_state(tmp_path, monkeypatch):
     """Redirect image_rejection_metrics state + archive paths to a per-test tmp dir.
 

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -365,16 +365,19 @@ class TestResolveGoogleNewsUrl:
     @patch("common.enrichment._resolve_via_gnewsdecoder")
     @patch("common.enrichment._decode_google_news_base64")
     @patch("common.enrichment.requests.head")
-    def test_network_exception_returns_empty(self, mock_head, mock_decode, mock_gnews):
+    @patch("common.enrichment.requests.get")
+    def test_network_exception_returns_empty(self, mock_get, mock_head, mock_decode, mock_gnews):
         """Network errors should be swallowed and return empty."""
         import requests as req_mod
 
         mock_gnews.return_value = ""
         mock_decode.return_value = ""
         mock_head.side_effect = req_mod.exceptions.ConnectionError("refused")
+        # Step 4 (full GET fallback) must also raise so no real network call escapes.
+        mock_get.side_effect = req_mod.exceptions.ConnectionError("refused")
         result = _resolve_google_news_url("https://news.google.com/rss/articles/CBMiXXX")
         # Should return "" (empty) after all fallbacks fail
-        assert isinstance(result, str)
+        assert result == ""
 
 
 class TestFetchPageMetadata:
@@ -2871,14 +2874,21 @@ class TestResolveGoogleNewsInnerRedirectHops:
     @patch("common.enrichment._decode_google_news_base64", return_value="")
     @patch("common.enrichment.is_private_url", return_value=False)
     @patch("common.enrichment.requests.head")
-    def test_empty_location_header_breaks_loop(self, mock_head, _mock_priv, _mock_b64, _mock_gnews):  # noqa: PT019
+    @patch("common.enrichment.requests.get")
+    def test_empty_location_header_breaks_loop(self, mock_get, mock_head, _mock_priv, _mock_b64, _mock_gnews):  # noqa: PT019
         mock_resp = MagicMock()
         mock_resp.status_code = 301
         mock_resp.headers = {"Location": ""}
         mock_resp.url = ""
         mock_head.return_value = mock_resp
+        # Empty Location breaks the HEAD loop and falls through to the GET fallback;
+        # mock it (still on the google domain, no canonical) so no real request escapes.
+        get_resp = MagicMock()
+        get_resp.url = "https://news.google.com/rss/articles/CBMiEMPTY"
+        get_resp.text = ""
+        mock_get.return_value = get_resp
         result = _enrich_mod._resolve_google_news_url_inner("https://news.google.com/rss/articles/CBMiEMPTY", timeout=1)
-        assert isinstance(result, str)
+        assert result == ""
 
     @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
     @patch("common.enrichment._decode_google_news_base64", return_value="")


### PR DESCRIPTION
## 배경 (P2-A batch 1 선행 조건)

critic이 P2-A 분리 계획에서 제기한 open question — **CI가 enrichment 테스트의 네트워크를 격리하는가?** — 를 조사한 결과 **격리 안 됨**으로 확인됐다.

| 확인 항목 | 결과 |
|-----------|------|
| pytest-socket / responses / respx / vcr | 없음 |
| pyproject `addopts` socket 차단 | 없음 (커버리지 플래그만) |
| `tests/conftest.py` 네트워크 가드 | 없음 |
| CI `quality` 잡 pytest 호출 | `PYTHONPATH=scripts pytest tests/` — offline/`-m` 제외 없음 |
| 테스트 URL | `example.com`(101회), `news.google.com`, `reuters.com` 등 실해석 public |
| `is_private_url_target` | public host 허용 (private/loopback만 차단) → example.com 미차단 |

→ P2-A batch 1 patch 재배치로 `requests` mock이 잘못된 네임스페이스에 붙으면 **inert**가 되어, 실 GET이 나가고도 통과하는 **flaky-green** 위험.

## 변경 내용

### 1. 네트워크 차단 가드 (`tests/conftest.py`)
autouse fixture로 `requests` `HTTPAdapter.send`를 차단 — mock되지 않은 실호출은 즉시 `RuntimeError`.
- `requests`를 mock하는 테스트는 어댑터에 도달하지 않아 **무영향**
- `socket.getaddrinfo`(DNS SSRF 가드)도 **무영향** (전송계층만 차단, socket 전면 차단 아님)
- 새 의존성 없음

### 2. 가드가 즉시 노출한 기존 flaky-green 2건 수정 (`tests/test_enrichment.py`)
둘 다 `_resolve_google_news_url_inner` **step 4 (full GET 폴백, enrichment.py:384)**를 mock하지 않아 `news.google.com`에 실 GET을 보냈고, 단언도 tautological(`isinstance(result, str)`):
- `test_network_exception_returns_empty`: `requests.get` side_effect 추가, 단언 `result == ""`로 강화
- `test_empty_location_header_breaks_loop`: `requests.get` return 추가, 단언 `result == ""`로 강화

## 검증

- ✅ 전체 스위트 **4804 passed** (i18n 제외 — 서버 필요; 다른 실네트워크 의존 테스트 없음)
- ✅ enrichment 서브셋 706 passed
- ✅ `ruff check` + `ruff format --check` clean

## 후속

이 가드가 머지되면 P2-A batch 1의 patch 재배치가 inert mock을 만들 경우 CI가 **즉시 red**로 잡아낸다 (기존엔 flaky-green으로 통과).

🤖 Generated with [Claude Code](https://claude.com/claude-code)