### PR TITLE
refactor: enrichment 파사드를 enrichment_network로 분리 (P2-A batch 1-3)

### DIFF
--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from . import summary_quality as _summary_quality_mod
 from .config import get_verify_ssl
 from .encoding_guard import force_utf8_if_mislabelled, sanitize_mojibake
 from .enrichment_images import (  # noqa: F401  (re-exported for backward compat)
@@ -18,6 +17,23 @@ from .enrichment_images import (  # noqa: F401  (re-exported for backward compat
     is_logo_like_url,
     match_bad_image_pattern,
     match_logo_pattern,
+)
+from .enrichment_network import (  # noqa: F401  (re-exported for backward compat)
+    _BOILERPLATE_FRAGMENT_PATTERNS,
+    _BROWSER_UA,
+    _EXCLUDE_CLASS_RE,
+    _IMAGE_META_PATTERNS,
+    _NOISE_DESC_PATTERNS,
+    _USER_AGENT,
+    _clean_meta_description,
+    _decode_google_news_base64,
+    _extract_og_metadata,
+    _extract_via_bs4_article,
+    _extract_via_paragraphs,
+    _extract_via_readability,
+    _gnews_url_cache,
+    _is_low_information_fragment,
+    is_private_url,
 )
 from .enrichment_synthetic import (  # noqa: F401  (re-exported for backward compat)
     _CRYPTO_SOURCE_CONTEXT,
@@ -38,17 +54,9 @@ from .enrichment_synthetic import (  # noqa: F401  (re-exported for backward com
     _is_title_related_description,
     generate_synthetic_description,
 )
-from .markdown_utils import smart_truncate
 from .summary_quality import _is_site_boilerplate  # noqa: F401  (re-exported for backward compat)
-from .utils import is_private_url_target
 
 logger = logging.getLogger(__name__)
-
-# readability-lxml is a declared dependency (requirements.txt); its absence is
-# an environment regression that silently drops the best-quality extraction
-# path. Warn once per process so the degradation is visible without flooding
-# the per-URL enrichment loop.
-_warned_readability_missing = False
 
 # Public API — names documented for import by collectors and renderers.
 # Names prefixed with _ remain internal helpers (shared via explicit import only).
@@ -71,14 +79,10 @@ __all__ = [
 # Digest size is typically top (~100) + overflow (~50) ≈ 150 items; 120 covers the bulk.
 MAX_IMAGES_PER_DIGEST = 120
 
-# Cache for resolved Google News URLs to avoid redundant lookups
-_gnews_url_cache: Dict[str, str] = {}
-
 # Site-level boilerplate detection (``_is_site_boilerplate`` + its patterns)
 # now lives in ``common.summary_quality`` and is re-exported at the top of this
 # module for backward compatibility. Article-specific token detection likewise
-# lives in ``summary_quality.ARTICLE_SPECIFIC_RE`` (accessed via
-# ``_summary_quality_mod.ARTICLE_SPECIFIC_RE``); do not redefine either here.
+# lives in ``summary_quality.ARTICLE_SPECIFIC_RE``; do not redefine either here.
 
 
 # Module-level synthetic markers for consistent detection across functions
@@ -126,11 +130,6 @@ def _split_synthetic_ko_suffix(desc: str) -> tuple:
     return desc, ""
 
 
-def is_private_url(url: str) -> bool:
-    """Check if URL points to an obvious private/internal target."""
-    return is_private_url_target(url)
-
-
 _VERIFY_SSL: Optional[object] = None
 
 
@@ -139,153 +138,6 @@ def _get_verify_ssl():
     if _VERIFY_SSL is None:
         _VERIFY_SSL = get_verify_ssl()
     return _VERIFY_SSL
-
-
-_USER_AGENT = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/120.0.0.0 Safari/537.36"
-)
-
-
-# Patterns that indicate the description is noise, not real content
-_NOISE_DESC_PATTERNS = [
-    re.compile(r"please enable javascript", re.I),
-    re.compile(r"enable cookies", re.I),
-    re.compile(r"your browser.{0,20}(not supported|outdated|javascript)", re.I),
-    re.compile(r"^access denied", re.I),
-    re.compile(r"^403 forbidden", re.I),
-    re.compile(r"^page not found", re.I),
-    re.compile(r"^404\b", re.I),
-    re.compile(r"^we use cookies", re.I),
-    re.compile(r"^this site requires", re.I),
-    re.compile(r"^you need to enable", re.I),
-    re.compile(r"^AMENDMENT NO\.", re.I),
-    re.compile(r"^FORM\s+\d", re.I),
-]
-
-# Boilerplate/legal/syndication snippets often found in low-quality meta tags
-_BOILERPLATE_FRAGMENT_PATTERNS = [
-    re.compile(r"\ball rights reserved\b", re.I),
-    re.compile(r"\bcopyright\b", re.I),
-    re.compile(r"\bsyndicat(?:ed|ion)\b", re.I),
-    re.compile(r"\bthis material may not be published\b", re.I),
-    re.compile(r"\breproduction (?:without|in whole or in part)\b", re.I),
-    re.compile(r"\bfor informational purposes only\b", re.I),
-    re.compile(r"\bnot investment advice\b", re.I),
-    re.compile(r"\bterms of use\b", re.I),
-    re.compile(r"\bprivacy policy\b", re.I),
-    re.compile(r"무단전재", re.I),
-    re.compile(r"재배포", re.I),
-    re.compile(r"저작권자", re.I),
-]
-
-
-def _clean_meta_description(text: str) -> str:
-    """Clean extracted meta description text for quality."""
-    text = text.strip()
-    # Remove common site-wide boilerplate prefixes
-    for noise in [
-        "Sign up for ",
-        "Subscribe to ",
-        "Get the latest ",
-        "Read more about ",
-        "Click here ",
-        "Share this ",
-        "Follow us ",
-        # Korean boilerplate
-        "무단전재 및 재배포 금지",
-        "저작권자 ©",
-        "기사제보 및 보도자료",
-        "네이버 뉴스스탠드에서",
-        "카카오톡에서 받아보기",
-    ]:
-        if text.startswith(noise):
-            return ""
-    # Reject noise patterns (JS required, 403, etc.)
-    for pattern in _NOISE_DESC_PATTERNS:
-        if pattern.search(text):
-            return ""
-    # Reject legal/syndication boilerplate fragments
-    for pattern in _BOILERPLATE_FRAGMENT_PATTERNS:
-        if pattern.search(text):
-            return ""
-    # Remove trailing "Read more..." / "Continue reading..."
-    text = re.sub(r"\s*(Read more|Continue reading|더 보기|자세히 보기)\.{0,3}\s*$", "", text)
-    # Remove trailing source name appended to RSS titles (e.g. "Title Text - SourceName")
-    # English sources (short, capitalized)
-    text = re.sub(r"\s+[-–—]\s+[A-Z][A-Za-z\s]{2,25}$", "", text)
-    # Korean sources (e.g. "...내용 디지털투데이", "...내용 연합인포맥스")
-    text = re.sub(
-        r"\s+[-–—]?\s*(?:디지털투데이|연합인포맥스|펜앤마이크|네이트|복지TV\S*"
-        r"|ER\s*이코노믹리뷰|v\.daum\.net|매일경제|한국경제|조선일보|중앙일보"
-        r"|경향신문|한겨레|BBS불교방송|이데일리|뉴시스|아시아경제"
-        r"|서울경제|뉴스1|노컷뉴스|SBS뉴스|MBC뉴스|KBS뉴스|JTBC|채널A|TV조선|연합뉴스"
-        r"|파이낸셜뉴스|헤럴드경제|머니투데이|더팩트|데일리안|뉴데일리|오마이뉴스"
-        r"|프레시안|시사저널|주간조선|한겨레21|인사이트|위키트리|ZDNet\s*Korea"
-        r"|핀포인트뉴스|공감신문|브레이크뉴스|한국글로벌뉴스|gukjenews\.com|ilyoseoul\.co\.kr"
-        r")\s*$",
-        "",
-        text,
-    )
-    # Generic trailing domain-like source (e.g. "...text simplywall.st")
-    text = re.sub(r"\s+[a-z][a-z0-9-]*\.[a-z]{2,6}$", "", text)
-    # Collapse whitespace
-    text = re.sub(r"\s+", " ", text).strip()
-    # Final boilerplate guard — reject site-level descriptions
-    if _is_site_boilerplate(text):
-        return ""
-    if _is_low_information_fragment(text):
-        return ""
-    return text
-
-
-def _is_low_information_fragment(desc: str) -> bool:
-    """Return True for short, generic, low-information fragments."""
-    if not desc:
-        return True
-    if len(desc) < 25:
-        generic_tokens = {"news", "update", "latest", "market", "story", "기사", "속보", "뉴스", "보도"}
-        token_count = len(re.findall(r"[A-Za-z]+|[가-힣]+", desc.lower()))
-        has_specific = bool(_summary_quality_mod.ARTICLE_SPECIFIC_RE.search(desc))
-        has_generic = any(tok in desc.lower() for tok in generic_tokens)
-        if token_count <= 6 and (has_generic or not has_specific):
-            return True
-    return False
-
-
-def _decode_google_news_base64(url: str) -> str:
-    """Try to extract the actual article URL from a Google News RSS URL.
-
-    Google News RSS URLs like ``https://news.google.com/rss/articles/CBMi...``
-    contain a base64-encoded payload that wraps the real article URL.
-    """
-    import base64
-    import urllib.parse
-
-    try:
-        # Extract the base64 segment after /articles/ or /read/
-        match = re.search(r"(?:/rss/articles/|/read/)([A-Za-z0-9_-]+)", url)
-        if not match:
-            return ""
-        encoded = match.group(1)
-        # Add padding if needed
-        padded = encoded + "=" * (4 - len(encoded) % 4) if len(encoded) % 4 else encoded
-        # Try standard and URL-safe base64
-        for decoder in [base64.urlsafe_b64decode, base64.b64decode]:
-            try:
-                raw = decoder(padded)
-                decoded_str = raw.decode("utf-8", errors="ignore")
-                # Find URLs embedded in the decoded bytes
-                urls = re.findall(r"https?://[^\s\"'<>\x00-\x1f]+", decoded_str)
-                for candidate in urls:
-                    if "news.google.com" not in candidate and "google." not in candidate:
-                        return urllib.parse.unquote(candidate).rstrip("\x00")
-            except Exception:  # noqa: BLE001, S112
-                continue
-    except Exception:  # noqa: BLE001, S110
-        pass
-    return ""
 
 
 def _resolve_google_news_url(url: str, timeout: int = 8) -> str:
@@ -435,32 +287,10 @@ def _resolve_via_gnewsdecoder(url: str) -> str:
     return ""
 
 
-_BROWSER_UA = _USER_AGENT
-
 # Image URL validation (``match_bad_image_pattern``, ``_is_valid_image_url``,
 # ``match_logo_pattern``, ``is_logo_like_url`` + their pattern data) now lives
 # in ``common.enrichment_images`` and is re-exported at the top of this module
 # for backward compatibility.
-
-
-# Meta tag patterns for article image extraction, tried in priority order.
-# Each entry is (attr_pair, label) — the regex builder below produces both
-# content-first and property/name-first variants to handle either attr order.
-# Logo-like URLs are rejected so the fallback chain keeps searching for a
-# real article image instead of returning a site banner.
-_IMAGE_META_PATTERNS = [
-    # OpenGraph standard
-    (r'property=["\']og:image["\']', "og:image"),
-    (r'property=["\']og:image:secure_url["\']', "og:image:secure_url"),
-    (r'property=["\']og:image:url["\']', "og:image:url"),
-    # Twitter Cards
-    (r'name=["\']twitter:image["\']', "twitter:image"),
-    (r'name=["\']twitter:image:src["\']', "twitter:image:src"),
-    # OpenGraph article namespace (used by some Korean/legacy publishers)
-    (r'property=["\']article:image["\']', "article:image"),
-    # Schema.org / Microdata
-    (r'itemprop=["\']image["\']', "itemprop=image"),
-]
 
 
 def _fetch_og_image(url: str, timeout: int = 8) -> str:
@@ -683,191 +513,6 @@ def fetch_descriptions_concurrent(
     if fetched:
         logger.info("Concurrent description fetch: enriched %d/%d items", fetched, len(targets))
     return fetched
-
-
-_EXCLUDE_CLASS_RE = re.compile(
-    r"sidebar|widget|nav|menu|footer|header|comment|social|share|promo|"
-    r"ad-|ads-|advert|sponsor|related|recommend|popup|modal|cookie|banner",
-    re.I,
-)
-
-
-def _extract_og_metadata(soup: Any, title: str = "") -> Dict[str, str]:
-    """Extract Open Graph / twitter meta tags from a parsed page.
-
-    Returns a dict with keys: ``image``, ``description``, ``published_time``,
-    ``author``, ``section`` (all may be empty). The article:* fields come from
-    the OpenGraph article namespace and are useful for downstream consumers
-    (RSS metadata, search indexing, description fallback synthesis).
-    """
-    from bs4 import BeautifulSoup as BS4  # noqa: F401 – type hint only
-
-    result: Dict[str, str] = {
-        "description": "",
-        "image": "",
-        "published_time": "",
-        "author": "",
-        "section": "",
-    }
-
-    # og:image / twitter:image
-    for img_attr_key, img_attr_val in [
-        ("property", "og:image"),
-        ("name", "twitter:image"),
-    ]:
-        meta = soup.find("meta", attrs={img_attr_key: img_attr_val})
-        if meta:
-            img_url = str(meta.get("content", "")).strip()
-            if _is_valid_image_url(img_url):
-                result["image"] = img_url
-                break
-
-    # meta description / og:description / twitter:description
-    # Prioritize og:description (most reliable), then standard description,
-    # then twitter:description. Korean news sites often use og:description
-    # and/or <meta name="description"> with good article summaries.
-    for attr_key, attr_val in [
-        ("property", "og:description"),
-        ("name", "description"),
-        ("name", "twitter:description"),
-        ("property", "twitter:description"),
-    ]:
-        meta = soup.find("meta", attrs={attr_key: attr_val})
-        content = str(meta.get("content", "")) if meta else ""
-        cleaned = _clean_meta_description(content)
-        if (
-            cleaned
-            and len(cleaned) > 20
-            and not _is_site_boilerplate(cleaned)
-            and _is_title_related_description(title, cleaned)
-        ):
-            result["description"] = smart_truncate(cleaned, 1000)
-            break
-
-    # article:published_time — ISO-8601 timestamp (fallback to modified_time)
-    for attr_key, attr_val in [
-        ("property", "article:published_time"),
-        ("property", "article:modified_time"),
-        ("name", "pubdate"),
-        ("itemprop", "datePublished"),
-    ]:
-        meta = soup.find("meta", attrs={attr_key: attr_val})
-        content = str(meta.get("content", "")).strip() if meta else ""
-        if content:
-            result["published_time"] = content[:40]
-            break
-
-    # article:author — article-level author metadata
-    for attr_key, attr_val in [
-        ("property", "article:author"),
-        ("name", "author"),
-        ("itemprop", "author"),
-    ]:
-        meta = soup.find("meta", attrs={attr_key: attr_val})
-        content = str(meta.get("content", "")).strip() if meta else ""
-        if content and len(content) < 200:
-            result["author"] = content
-            break
-
-    # article:section — topic/category
-    meta = soup.find("meta", attrs={"property": "article:section"})
-    if meta:
-        content = str(meta.get("content", "")).strip()
-        if content and len(content) < 100:
-            result["section"] = content
-
-    return result
-
-
-def _extract_via_readability(html: str, url: str) -> str:
-    """Extract article text using readability-lxml (best quality).
-
-    Returns a non-empty description string on success, or empty string if
-    readability is not installed or extraction fails.
-    """
-    from bs4 import BeautifulSoup as BS4
-
-    try:
-        from readability import Document
-
-        doc = Document(html)
-        summary_html = doc.summary()
-        summary_soup = BS4(summary_html, "html.parser")
-        paragraphs = []
-        for p in summary_soup.find_all("p"):
-            text = _clean_meta_description(p.get_text(strip=True))
-            if len(text) > 50:
-                paragraphs.append(text)
-            if len(paragraphs) >= 5:
-                break
-        if paragraphs:
-            return smart_truncate(" ".join(paragraphs), 1000)
-    except ImportError:
-        # Declared dep missing: best-quality extraction disabled, callers fall
-        # through to bs4/paragraph extractors. Warn once (parity with
-        # text_lang's langdetect fail-open) instead of silently passing.
-        global _warned_readability_missing
-        if not _warned_readability_missing:
-            _warned_readability_missing = True
-            logger.warning(
-                "readability-lxml not installed; high-quality article extraction "
-                "disabled (falling back to bs4/paragraph). Install readability-lxml to restore."
-            )
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("readability extraction failed for %s: %s", url, exc)
-    return ""
-
-
-def _extract_via_bs4_article(soup: Any) -> str:
-    """Extract article text from BeautifulSoup <article> or article-class containers.
-
-    Returns a non-empty description string on success, or empty string if no
-    suitable article container is found.
-    """
-    article = soup.find("article")
-    if not article:
-        for tag in soup.find_all(
-            class_=re.compile(
-                r"article[-_]?(body|content|text)|post[-_]?(body|content|text)|entry[-_]?(body|content|text)"
-            )
-        ):
-            if not _EXCLUDE_CLASS_RE.search(str(tag.get("class", ""))):
-                article = tag
-                break
-    if not article:
-        for tag in soup.find_all(class_=re.compile(r"^(article|post|entry|content)$")):
-            if not _EXCLUDE_CLASS_RE.search(str(tag.get("class", ""))):
-                article = tag
-                break
-    if not article:
-        return ""
-
-    for noise in article.find_all(class_=_EXCLUDE_CLASS_RE):
-        noise.decompose()
-    paragraphs = []
-    for p in article.find_all("p"):
-        text = _clean_meta_description(p.get_text(strip=True))
-        if len(text) > 50:
-            paragraphs.append(text)
-        if len(paragraphs) >= 5:
-            break
-    if paragraphs:
-        return smart_truncate(" ".join(paragraphs), 1000)
-    return ""
-
-
-def _extract_via_paragraphs(soup: Any) -> str:
-    """Fallback: extract the first substantial <p> not inside a noise container.
-
-    Returns a non-empty description string on success, or empty string if none found.
-    """
-    for p in soup.find_all("p"):
-        if p.find_parent(class_=_EXCLUDE_CLASS_RE):
-            continue
-        text = _clean_meta_description(p.get_text(strip=True))
-        if len(text) > 50:
-            return smart_truncate(text, 1000)
-    return ""
 
 
 def fetch_page_metadata(url: str, timeout: int = 8, title: str = "") -> Dict[str, str]:

--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from .config import get_verify_ssl
 from .encoding_guard import force_utf8_if_mislabelled, sanitize_mojibake
 from .enrichment_images import (  # noqa: F401  (re-exported for backward compat)
     _is_valid_image_url,
@@ -31,8 +30,13 @@ from .enrichment_network import (  # noqa: F401  (re-exported for backward compa
     _extract_via_bs4_article,
     _extract_via_paragraphs,
     _extract_via_readability,
+    _fetch_og_image,
+    _get_verify_ssl,
     _gnews_url_cache,
     _is_low_information_fragment,
+    _resolve_google_news_url,
+    _resolve_google_news_url_inner,
+    _resolve_via_gnewsdecoder,
     is_private_url,
 )
 from .enrichment_synthetic import (  # noqa: F401  (re-exported for backward compat)
@@ -130,243 +134,13 @@ def _split_synthetic_ko_suffix(desc: str) -> tuple:
     return desc, ""
 
 
-_VERIFY_SSL: Optional[object] = None
-
-
-def _get_verify_ssl():
-    global _VERIFY_SSL
-    if _VERIFY_SSL is None:
-        _VERIFY_SSL = get_verify_ssl()
-    return _VERIFY_SSL
-
-
-def _resolve_google_news_url(url: str, timeout: int = 8) -> str:
-    """Follow Google News redirect to get the real article URL.
-
-    Strategy:
-    1. Return cached result if available.
-    2. Try base64 decoding of the RSS article path (fastest, no network).
-    3. Follow HTTP redirects with ``requests.head`` (max 3 hops) then ``requests.get``.
-    4. Parse HTML for canonical/og:url if still on Google domain.
-
-    Handles both ``/rss/articles/CBMi...`` and ``/read/CBMi...`` URL formats.
-    """
-    if not url or "news.google.com" not in url:
-        return url
-
-    # Check cache first
-    if url in _gnews_url_cache:
-        return _gnews_url_cache[url]
-
-    resolved = _resolve_google_news_url_inner(url, timeout)
-    _gnews_url_cache[url] = resolved
-    return resolved
-
-
-def _resolve_google_news_url_inner(url: str, timeout: int = 8) -> str:
-    """Inner implementation for Google News URL resolution (uncached)."""
-    # 1. Try base64 decoding (no network call needed)
-    decoded = _decode_google_news_base64(url)
-    if decoded:
-        logger.debug("Google News base64 decoded: %s -> %s", url[:60], decoded[:80])
-        return decoded
-
-    # Normalize /read/ URLs to /rss/articles/ and retry base64
-    if "/read/" in url:
-        rss_url = url.replace("/read/", "/rss/articles/")
-        decoded = _decode_google_news_base64(rss_url)
-        if decoded:
-            logger.debug("Google News /read/ base64 decoded: %s -> %s", url[:60], decoded[:80])
-            return decoded
-
-    # 2. Try googlenewsdecoder (handles newer protobuf-encoded URLs)
-    resolved = _resolve_via_gnewsdecoder(url)
-    if resolved:
-        return resolved
-
-    # 3. Follow HTTP redirects via HEAD manually (max 5 hops), checking each hop
-    try:
-        if is_private_url(url):
-            logger.warning("SSRF blocked: %s resolves to private IP", url[:80])
-            return ""
-        current_url = url
-        max_hops = 5
-        for _hop in range(max_hops):
-            head_resp = requests.head(
-                current_url,
-                timeout=timeout,
-                allow_redirects=False,
-                headers={"User-Agent": _BROWSER_UA},
-                verify=_get_verify_ssl(),
-            )
-            if head_resp.status_code in (301, 302, 303, 307, 308):
-                location = head_resp.headers.get("Location", "")
-                if not location:
-                    break
-                # Resolve relative redirects
-                if not location.startswith("http"):
-                    from urllib.parse import urljoin
-
-                    location = urljoin(current_url, location)
-                if is_private_url(location):
-                    logger.warning("SSRF blocked (redirect hop): %s -> %s", current_url[:60], location[:80])
-                    return ""
-                if "news.google.com" not in location:
-                    logger.debug("Google News HEAD redirect: %s -> %s", url[:60], location[:80])
-                    return location
-                current_url = location
-            else:
-                # No redirect; use final URL if not on Google domain
-                final_url = head_resp.url or current_url
-                if final_url and "news.google.com" not in final_url:
-                    if is_private_url(final_url):
-                        logger.warning("SSRF blocked (redirect): %s -> %s", url[:60], final_url[:80])
-                        return ""
-                    logger.debug("Google News HEAD resolved: %s -> %s", url[:60], final_url[:80])
-                    return final_url
-                break
-    except requests.exceptions.RequestException:
-        pass
-
-    # 4. Full GET and parse HTML for canonical/og:url
-    try:
-        if is_private_url(url):
-            logger.warning("SSRF blocked: %s resolves to private IP", url[:80])
-            return ""
-        resp = requests.get(
-            url,
-            timeout=timeout,
-            allow_redirects=True,
-            headers={"User-Agent": _BROWSER_UA},
-            verify=_get_verify_ssl(),
-        )
-        if resp.url and "news.google.com" not in resp.url:
-            if is_private_url(resp.url):
-                logger.warning("SSRF blocked (redirect): %s -> %s", url[:60], resp.url[:80])
-                return ""
-            return resp.url
-        # Try to find canonical or data-url in HTML
-        for pattern in [
-            r'<link[^>]+rel=["\']canonical["\'][^>]+href=["\']([^"\']+)',
-            r'<meta[^>]+property=["\']og:url["\'][^>]+content=["\']([^"\']+)',
-            r'data-url=["\']([^"\']+)',
-            r'<a[^>]+data-redirect=["\']([^"\']+)',
-        ]:
-            m = re.search(pattern, resp.text[:20_000])
-            if m:
-                found = m.group(1)
-                if found and "news.google.com" not in found:
-                    return found
-    except requests.exceptions.RequestException:
-        pass
-    return ""
-
-
-def _resolve_via_gnewsdecoder(url: str) -> str:
-    """Resolve Google News URL using googlenewsdecoder library.
-
-    This handles the newer protobuf-encoded URLs (2024+) that cannot be
-    decoded via simple base64. Falls back gracefully if the library is
-    unavailable or decoding fails.
-    """
-    try:
-        from googlenewsdecoder import gnewsdecoder
-
-        result = gnewsdecoder(url)
-        if result and result.get("status") and result.get("decoded_url"):
-            decoded_url = result["decoded_url"]
-            if is_private_url(decoded_url):
-                logger.warning("SSRF blocked (gnewsdecoder): %s -> %s", url[:60], decoded_url[:80])
-                return ""
-            logger.debug("Google News gnewsdecoder: %s -> %s", url[:60], decoded_url[:80])
-            return decoded_url
-    except ImportError:
-        logger.debug("googlenewsdecoder not installed, skipping")
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("gnewsdecoder failed for %s: %s", url[:60], exc)
-    return ""
-
-
 # Image URL validation (``match_bad_image_pattern``, ``_is_valid_image_url``,
 # ``match_logo_pattern``, ``is_logo_like_url`` + their pattern data) now lives
-# in ``common.enrichment_images`` and is re-exported at the top of this module
-# for backward compatibility.
-
-
-def _fetch_og_image(url: str, timeout: int = 8) -> str:
-    """Fetch an article image URL from a page's meta tags.
-
-    Searches in priority order: og:image, og:image:secure_url, og:image:url,
-    twitter:image, twitter:image:src, article:image, itemprop=image, and
-    <link rel="image_src">. Returns the first URL that passes both
-    _is_valid_image_url (rejects placeholders/trackers) and is_logo_like_url
-    (rejects site logos/favicons). Returns empty string on network failure,
-    SSRF block, or when no valid article image is found.
-    """
-    if not url:
-        return ""
-    try:
-        if is_private_url(url):
-            logger.warning("SSRF blocked: %s resolves to private IP", url[:80])
-            return ""
-        resp = requests.get(
-            url,
-            timeout=timeout,
-            headers={"User-Agent": _BROWSER_UA},
-            verify=_get_verify_ssl(),
-        )
-        resp.raise_for_status()
-        force_utf8_if_mislabelled(resp)
-        # Search first 60KB — modern sites often have bloated <head> with many
-        # script/link tags before the image meta tags.
-        head_html = resp.text[:60_000]
-
-        def _accept(img_url: str) -> bool:
-            img_url = img_url.strip()
-            if not img_url.startswith(("http://", "https://")):
-                return False
-            if not _is_valid_image_url(img_url):
-                return False
-            if is_logo_like_url(img_url):
-                return False
-            return True
-
-        for attr_pattern, _label in _IMAGE_META_PATTERNS:
-            # Try both attribute orders (property-first or content-first)
-            for regex in (
-                rf'<meta[^>]+{attr_pattern}[^>]+content=["\']([^"\']+)',
-                rf'<meta[^>]+content=["\']([^"\']+)["\'][^>]+{attr_pattern}',
-            ):
-                match = re.search(regex, head_html, re.IGNORECASE)
-                if match and _accept(match.group(1)):
-                    return match.group(1).strip()
-
-        # <link rel="image_src" href="..."> — Pinterest/legacy schema
-        link_match = re.search(
-            r'<link[^>]+rel=["\']image_src["\'][^>]+href=["\']([^"\']+)',
-            head_html,
-            re.IGNORECASE,
-        )
-        if link_match and _accept(link_match.group(1)):
-            return link_match.group(1).strip()
-
-        # JSON-LD schema.org image (modern publisher pattern)
-        for ld_match in re.finditer(
-            r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
-            head_html,
-            re.IGNORECASE | re.DOTALL,
-        ):
-            ld_text = ld_match.group(1)
-            for img_match in re.finditer(
-                r'"image"\s*:\s*(?:"([^"]+)"|\{[^{}]*"url"\s*:\s*"([^"]+)")',
-                ld_text,
-            ):
-                candidate = (img_match.group(1) or img_match.group(2) or "").strip()
-                if candidate and _accept(candidate):
-                    return candidate
-    except Exception as exc:
-        logger.debug("og:image fetch failed for %s: %s", url, exc)
-    return ""
+# in ``common.enrichment_images``. The Google News resolver chain
+# (``_resolve_google_news_url`` / ``_inner`` / ``_resolve_via_gnewsdecoder``),
+# the og:image fetcher (``_fetch_og_image``), and the SSL-verify helper
+# (``_get_verify_ssl``) now live in ``common.enrichment_network``. All are
+# re-exported at the top of this module for backward compatibility.
 
 
 def fetch_images_concurrent(

--- a/scripts/common/enrichment.py
+++ b/scripts/common/enrichment.py
@@ -8,9 +8,6 @@ import logging
 import re
 from typing import Any, Dict, Optional
 
-import requests
-
-from .encoding_guard import force_utf8_if_mislabelled, sanitize_mojibake
 from .enrichment_images import (  # noqa: F401  (re-exported for backward compat)
     _is_valid_image_url,
     is_logo_like_url,
@@ -37,6 +34,7 @@ from .enrichment_network import (  # noqa: F401  (re-exported for backward compa
     _resolve_google_news_url,
     _resolve_google_news_url_inner,
     _resolve_via_gnewsdecoder,
+    fetch_page_metadata,
     is_private_url,
 )
 from .enrichment_synthetic import (  # noqa: F401  (re-exported for backward compat)
@@ -287,90 +285,6 @@ def fetch_descriptions_concurrent(
     if fetched:
         logger.info("Concurrent description fetch: enriched %d/%d items", fetched, len(targets))
     return fetched
-
-
-def fetch_page_metadata(url: str, timeout: int = 8, title: str = "") -> Dict[str, str]:
-    """Fetch meta description, image and article metadata from a URL page.
-
-    Returns a dict with keys ``description``, ``image``, ``published_time``,
-    ``author``, ``section`` (all may be empty). All article:* fields are
-    best-effort and default to empty string on failure or when the page
-    does not emit that tag.
-    """
-    result: Dict[str, str] = {
-        "description": "",
-        "image": "",
-        "published_time": "",
-        "author": "",
-        "section": "",
-    }
-    if not url:
-        return result
-    # Resolve Google News redirects (any news.google.com URL)
-    if "news.google.com" in url:
-        resolved = _resolve_google_news_url(url)
-        if not resolved:
-            return result
-        url = resolved
-
-    try:
-        from bs4 import BeautifulSoup as BS4
-
-        if is_private_url(url):
-            logger.warning("SSRF blocked: %s resolves to private IP", url[:80])
-            return result
-        resp = requests.get(
-            url,
-            timeout=timeout,
-            headers={"User-Agent": _USER_AGENT},
-            verify=_get_verify_ssl(),
-        )
-        resp.raise_for_status()
-        force_utf8_if_mislabelled(resp)
-        soup = BS4(resp.text, "html.parser")
-
-        # Extract OG metadata (image + description + article:* fields)
-        og = _extract_og_metadata(soup, title=title)
-        result["image"] = og["image"]
-        result["published_time"] = og.get("published_time", "")
-        result["author"] = og.get("author", "")
-        result["section"] = og.get("section", "")
-        if og["description"]:
-            cleaned = sanitize_mojibake(og["description"])
-            if cleaned:
-                result["description"] = cleaned
-                return result
-
-        # Try readability-lxml for high-quality article extraction
-        desc = sanitize_mojibake(_extract_via_readability(resp.text, url))
-        if desc:
-            if _is_title_related_description(title, desc):
-                result["description"] = desc
-            else:
-                logger.debug("Rejected readability description as unrelated to title")
-            return result
-
-        # Article body paragraphs (BS4 fallback)
-        desc = sanitize_mojibake(_extract_via_bs4_article(soup))
-        if desc:
-            if _is_title_related_description(title, desc):
-                result["description"] = desc
-            else:
-                logger.debug("Rejected article-body description as unrelated to title")
-            return result
-
-        # Last resort: any substantial <p> not in noise containers
-        desc = sanitize_mojibake(_extract_via_paragraphs(soup))
-        if desc:
-            if _is_title_related_description(title, desc):
-                result["description"] = desc
-            else:
-                logger.debug("Rejected paragraph description as unrelated to title")
-            return result
-
-    except Exception as e:  # noqa: BLE001
-        logger.debug("Failed to fetch metadata from %s: %s", url, e)
-    return result
 
 
 def fetch_page_description(url: str, timeout: int = 8) -> str:

--- a/scripts/common/enrichment_network.py
+++ b/scripts/common/enrichment_network.py
@@ -426,7 +426,7 @@ def _resolve_google_news_url(url: str, timeout: int = 8) -> str:
     Strategy:
     1. Return cached result if available.
     2. Try base64 decoding of the RSS article path (fastest, no network).
-    3. Follow HTTP redirects with ``requests.head`` (max 3 hops) then ``requests.get``.
+    3. Follow HTTP redirects with ``requests.head`` (max 5 hops) then ``requests.get``.
     4. Parse HTML for canonical/og:url if still on Google domain.
 
     Handles both ``/rss/articles/CBMi...`` and ``/read/CBMi...`` URL formats.

--- a/scripts/common/enrichment_network.py
+++ b/scripts/common/enrichment_network.py
@@ -10,13 +10,394 @@ split. ``common.enrichment`` re-exports the public names so existing
 ``from common.enrichment import ...`` call sites (collectors, ``rss_fetcher``, …)
 keep working unchanged.
 
-NOTE (batch 0 — scaffolding only): symbols are moved here in subsequent batches
-per ``docs/refactoring-plan-2026-07.md`` §1.4. Patch-string relocation happens in
-the same commit as each symbol move to keep every batch's test gate hermetic.
+NOTE (batch 1 — leaf move): the URL-safety wrapper, meta-description cleaner,
+Google News base64 decoder, and the HTML metadata/content extractors now live
+here. The resolver chain and page-fetch orchestrators still live in the facade
+and are moved in later batches per ``docs/refactoring-plan-2026-07.md`` §1.4.
+Patch-string relocation happens in the same commit as each symbol move to keep
+every batch's test gate hermetic.
 """
 
 from __future__ import annotations
 
 import logging
+import re
+from typing import Any, Dict
+
+from . import summary_quality as _summary_quality_mod
+from .enrichment_images import _is_valid_image_url
+from .enrichment_synthetic import _is_title_related_description
+from .markdown_utils import smart_truncate
+from .summary_quality import _is_site_boilerplate
+from .utils import is_private_url_target
 
 logger = logging.getLogger(__name__)
+
+# readability-lxml is a declared dependency (requirements.txt); its absence is
+# an environment regression that silently drops the best-quality extraction
+# path. Warn once per process so the degradation is visible without flooding
+# the per-URL enrichment loop.
+_warned_readability_missing = False
+
+# Cache for resolved Google News URLs to avoid redundant lookups
+_gnews_url_cache: Dict[str, str] = {}
+
+
+def is_private_url(url: str) -> bool:
+    """Check if URL points to an obvious private/internal target."""
+    return is_private_url_target(url)
+
+
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+# Patterns that indicate the description is noise, not real content
+_NOISE_DESC_PATTERNS = [
+    re.compile(r"please enable javascript", re.I),
+    re.compile(r"enable cookies", re.I),
+    re.compile(r"your browser.{0,20}(not supported|outdated|javascript)", re.I),
+    re.compile(r"^access denied", re.I),
+    re.compile(r"^403 forbidden", re.I),
+    re.compile(r"^page not found", re.I),
+    re.compile(r"^404\b", re.I),
+    re.compile(r"^we use cookies", re.I),
+    re.compile(r"^this site requires", re.I),
+    re.compile(r"^you need to enable", re.I),
+    re.compile(r"^AMENDMENT NO\.", re.I),
+    re.compile(r"^FORM\s+\d", re.I),
+]
+
+# Boilerplate/legal/syndication snippets often found in low-quality meta tags
+_BOILERPLATE_FRAGMENT_PATTERNS = [
+    re.compile(r"\ball rights reserved\b", re.I),
+    re.compile(r"\bcopyright\b", re.I),
+    re.compile(r"\bsyndicat(?:ed|ion)\b", re.I),
+    re.compile(r"\bthis material may not be published\b", re.I),
+    re.compile(r"\breproduction (?:without|in whole or in part)\b", re.I),
+    re.compile(r"\bfor informational purposes only\b", re.I),
+    re.compile(r"\bnot investment advice\b", re.I),
+    re.compile(r"\bterms of use\b", re.I),
+    re.compile(r"\bprivacy policy\b", re.I),
+    re.compile(r"무단전재", re.I),
+    re.compile(r"재배포", re.I),
+    re.compile(r"저작권자", re.I),
+]
+
+
+def _clean_meta_description(text: str) -> str:
+    """Clean extracted meta description text for quality."""
+    text = text.strip()
+    # Remove common site-wide boilerplate prefixes
+    for noise in [
+        "Sign up for ",
+        "Subscribe to ",
+        "Get the latest ",
+        "Read more about ",
+        "Click here ",
+        "Share this ",
+        "Follow us ",
+        # Korean boilerplate
+        "무단전재 및 재배포 금지",
+        "저작권자 ©",
+        "기사제보 및 보도자료",
+        "네이버 뉴스스탠드에서",
+        "카카오톡에서 받아보기",
+    ]:
+        if text.startswith(noise):
+            return ""
+    # Reject noise patterns (JS required, 403, etc.)
+    for pattern in _NOISE_DESC_PATTERNS:
+        if pattern.search(text):
+            return ""
+    # Reject legal/syndication boilerplate fragments
+    for pattern in _BOILERPLATE_FRAGMENT_PATTERNS:
+        if pattern.search(text):
+            return ""
+    # Remove trailing "Read more..." / "Continue reading..."
+    text = re.sub(r"\s*(Read more|Continue reading|더 보기|자세히 보기)\.{0,3}\s*$", "", text)
+    # Remove trailing source name appended to RSS titles (e.g. "Title Text - SourceName")
+    # English sources (short, capitalized)
+    text = re.sub(r"\s+[-–—]\s+[A-Z][A-Za-z\s]{2,25}$", "", text)
+    # Korean sources (e.g. "...내용 디지털투데이", "...내용 연합인포맥스")
+    text = re.sub(
+        r"\s+[-–—]?\s*(?:디지털투데이|연합인포맥스|펜앤마이크|네이트|복지TV\S*"
+        r"|ER\s*이코노믹리뷰|v\.daum\.net|매일경제|한국경제|조선일보|중앙일보"
+        r"|경향신문|한겨레|BBS불교방송|이데일리|뉴시스|아시아경제"
+        r"|서울경제|뉴스1|노컷뉴스|SBS뉴스|MBC뉴스|KBS뉴스|JTBC|채널A|TV조선|연합뉴스"
+        r"|파이낸셜뉴스|헤럴드경제|머니투데이|더팩트|데일리안|뉴데일리|오마이뉴스"
+        r"|프레시안|시사저널|주간조선|한겨레21|인사이트|위키트리|ZDNet\s*Korea"
+        r"|핀포인트뉴스|공감신문|브레이크뉴스|한국글로벌뉴스|gukjenews\.com|ilyoseoul\.co\.kr"
+        r")\s*$",
+        "",
+        text,
+    )
+    # Generic trailing domain-like source (e.g. "...text simplywall.st")
+    text = re.sub(r"\s+[a-z][a-z0-9-]*\.[a-z]{2,6}$", "", text)
+    # Collapse whitespace
+    text = re.sub(r"\s+", " ", text).strip()
+    # Final boilerplate guard — reject site-level descriptions
+    if _is_site_boilerplate(text):
+        return ""
+    if _is_low_information_fragment(text):
+        return ""
+    return text
+
+
+def _is_low_information_fragment(desc: str) -> bool:
+    """Return True for short, generic, low-information fragments."""
+    if not desc:
+        return True
+    if len(desc) < 25:
+        generic_tokens = {"news", "update", "latest", "market", "story", "기사", "속보", "뉴스", "보도"}
+        token_count = len(re.findall(r"[A-Za-z]+|[가-힣]+", desc.lower()))
+        has_specific = bool(_summary_quality_mod.ARTICLE_SPECIFIC_RE.search(desc))
+        has_generic = any(tok in desc.lower() for tok in generic_tokens)
+        if token_count <= 6 and (has_generic or not has_specific):
+            return True
+    return False
+
+
+def _decode_google_news_base64(url: str) -> str:
+    """Try to extract the actual article URL from a Google News RSS URL.
+
+    Google News RSS URLs like ``https://news.google.com/rss/articles/CBMi...``
+    contain a base64-encoded payload that wraps the real article URL.
+    """
+    import base64
+    import urllib.parse
+
+    try:
+        # Extract the base64 segment after /articles/ or /read/
+        match = re.search(r"(?:/rss/articles/|/read/)([A-Za-z0-9_-]+)", url)
+        if not match:
+            return ""
+        encoded = match.group(1)
+        # Add padding if needed
+        padded = encoded + "=" * (4 - len(encoded) % 4) if len(encoded) % 4 else encoded
+        # Try standard and URL-safe base64
+        for decoder in [base64.urlsafe_b64decode, base64.b64decode]:
+            try:
+                raw = decoder(padded)
+                decoded_str = raw.decode("utf-8", errors="ignore")
+                # Find URLs embedded in the decoded bytes
+                urls = re.findall(r"https?://[^\s\"'<>\x00-\x1f]+", decoded_str)
+                for candidate in urls:
+                    if "news.google.com" not in candidate and "google." not in candidate:
+                        return urllib.parse.unquote(candidate).rstrip("\x00")
+            except Exception:  # noqa: BLE001, S112
+                continue
+    except Exception:  # noqa: BLE001, S110
+        pass
+    return ""
+
+
+_BROWSER_UA = _USER_AGENT
+
+
+# Meta tag patterns for article image extraction, tried in priority order.
+# Each entry is (attr_pair, label) — the regex builder below produces both
+# content-first and property/name-first variants to handle either attr order.
+# Logo-like URLs are rejected so the fallback chain keeps searching for a
+# real article image instead of returning a site banner.
+_IMAGE_META_PATTERNS = [
+    # OpenGraph standard
+    (r'property=["\']og:image["\']', "og:image"),
+    (r'property=["\']og:image:secure_url["\']', "og:image:secure_url"),
+    (r'property=["\']og:image:url["\']', "og:image:url"),
+    # Twitter Cards
+    (r'name=["\']twitter:image["\']', "twitter:image"),
+    (r'name=["\']twitter:image:src["\']', "twitter:image:src"),
+    # OpenGraph article namespace (used by some Korean/legacy publishers)
+    (r'property=["\']article:image["\']', "article:image"),
+    # Schema.org / Microdata
+    (r'itemprop=["\']image["\']', "itemprop=image"),
+]
+
+
+_EXCLUDE_CLASS_RE = re.compile(
+    r"sidebar|widget|nav|menu|footer|header|comment|social|share|promo|"
+    r"ad-|ads-|advert|sponsor|related|recommend|popup|modal|cookie|banner",
+    re.I,
+)
+
+
+def _extract_og_metadata(soup: Any, title: str = "") -> Dict[str, str]:
+    """Extract Open Graph / twitter meta tags from a parsed page.
+
+    Returns a dict with keys: ``image``, ``description``, ``published_time``,
+    ``author``, ``section`` (all may be empty). The article:* fields come from
+    the OpenGraph article namespace and are useful for downstream consumers
+    (RSS metadata, search indexing, description fallback synthesis).
+    """
+    from bs4 import BeautifulSoup as BS4  # noqa: F401 – type hint only
+
+    result: Dict[str, str] = {
+        "description": "",
+        "image": "",
+        "published_time": "",
+        "author": "",
+        "section": "",
+    }
+
+    # og:image / twitter:image
+    for img_attr_key, img_attr_val in [
+        ("property", "og:image"),
+        ("name", "twitter:image"),
+    ]:
+        meta = soup.find("meta", attrs={img_attr_key: img_attr_val})
+        if meta:
+            img_url = str(meta.get("content", "")).strip()
+            if _is_valid_image_url(img_url):
+                result["image"] = img_url
+                break
+
+    # meta description / og:description / twitter:description
+    # Prioritize og:description (most reliable), then standard description,
+    # then twitter:description. Korean news sites often use og:description
+    # and/or <meta name="description"> with good article summaries.
+    for attr_key, attr_val in [
+        ("property", "og:description"),
+        ("name", "description"),
+        ("name", "twitter:description"),
+        ("property", "twitter:description"),
+    ]:
+        meta = soup.find("meta", attrs={attr_key: attr_val})
+        content = str(meta.get("content", "")) if meta else ""
+        cleaned = _clean_meta_description(content)
+        if (
+            cleaned
+            and len(cleaned) > 20
+            and not _is_site_boilerplate(cleaned)
+            and _is_title_related_description(title, cleaned)
+        ):
+            result["description"] = smart_truncate(cleaned, 1000)
+            break
+
+    # article:published_time — ISO-8601 timestamp (fallback to modified_time)
+    for attr_key, attr_val in [
+        ("property", "article:published_time"),
+        ("property", "article:modified_time"),
+        ("name", "pubdate"),
+        ("itemprop", "datePublished"),
+    ]:
+        meta = soup.find("meta", attrs={attr_key: attr_val})
+        content = str(meta.get("content", "")).strip() if meta else ""
+        if content:
+            result["published_time"] = content[:40]
+            break
+
+    # article:author — article-level author metadata
+    for attr_key, attr_val in [
+        ("property", "article:author"),
+        ("name", "author"),
+        ("itemprop", "author"),
+    ]:
+        meta = soup.find("meta", attrs={attr_key: attr_val})
+        content = str(meta.get("content", "")).strip() if meta else ""
+        if content and len(content) < 200:
+            result["author"] = content
+            break
+
+    # article:section — topic/category
+    meta = soup.find("meta", attrs={"property": "article:section"})
+    if meta:
+        content = str(meta.get("content", "")).strip()
+        if content and len(content) < 100:
+            result["section"] = content
+
+    return result
+
+
+def _extract_via_readability(html: str, url: str) -> str:
+    """Extract article text using readability-lxml (best quality).
+
+    Returns a non-empty description string on success, or empty string if
+    readability is not installed or extraction fails.
+    """
+    from bs4 import BeautifulSoup as BS4
+
+    try:
+        from readability import Document
+
+        doc = Document(html)
+        summary_html = doc.summary()
+        summary_soup = BS4(summary_html, "html.parser")
+        paragraphs = []
+        for p in summary_soup.find_all("p"):
+            text = _clean_meta_description(p.get_text(strip=True))
+            if len(text) > 50:
+                paragraphs.append(text)
+            if len(paragraphs) >= 5:
+                break
+        if paragraphs:
+            return smart_truncate(" ".join(paragraphs), 1000)
+    except ImportError:
+        # Declared dep missing: best-quality extraction disabled, callers fall
+        # through to bs4/paragraph extractors. Warn once (parity with
+        # text_lang's langdetect fail-open) instead of silently passing.
+        global _warned_readability_missing
+        if not _warned_readability_missing:
+            _warned_readability_missing = True
+            logger.warning(
+                "readability-lxml not installed; high-quality article extraction "
+                "disabled (falling back to bs4/paragraph). Install readability-lxml to restore."
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("readability extraction failed for %s: %s", url, exc)
+    return ""
+
+
+def _extract_via_bs4_article(soup: Any) -> str:
+    """Extract article text from BeautifulSoup <article> or article-class containers.
+
+    Returns a non-empty description string on success, or empty string if no
+    suitable article container is found.
+    """
+    article = soup.find("article")
+    if not article:
+        for tag in soup.find_all(
+            class_=re.compile(
+                r"article[-_]?(body|content|text)|post[-_]?(body|content|text)|entry[-_]?(body|content|text)"
+            )
+        ):
+            if not _EXCLUDE_CLASS_RE.search(str(tag.get("class", ""))):
+                article = tag
+                break
+    if not article:
+        for tag in soup.find_all(class_=re.compile(r"^(article|post|entry|content)$")):
+            if not _EXCLUDE_CLASS_RE.search(str(tag.get("class", ""))):
+                article = tag
+                break
+    if not article:
+        return ""
+
+    for noise in article.find_all(class_=_EXCLUDE_CLASS_RE):
+        noise.decompose()
+    paragraphs = []
+    for p in article.find_all("p"):
+        text = _clean_meta_description(p.get_text(strip=True))
+        if len(text) > 50:
+            paragraphs.append(text)
+        if len(paragraphs) >= 5:
+            break
+    if paragraphs:
+        return smart_truncate(" ".join(paragraphs), 1000)
+    return ""
+
+
+def _extract_via_paragraphs(soup: Any) -> str:
+    """Fallback: extract the first substantial <p> not inside a noise container.
+
+    Returns a non-empty description string on success, or empty string if none found.
+    """
+    for p in soup.find_all("p"):
+        if p.find_parent(class_=_EXCLUDE_CLASS_RE):
+            continue
+        text = _clean_meta_description(p.get_text(strip=True))
+        if len(text) > 50:
+            return smart_truncate(text, 1000)
+    return ""

--- a/scripts/common/enrichment_network.py
+++ b/scripts/common/enrichment_network.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -176,6 +177,17 @@ def _is_low_information_fragment(desc: str) -> bool:
         if token_count <= 6 and (has_generic or not has_specific):
             return True
     return False
+
+
+def _is_google_news_host(url: str) -> bool:
+    """True when ``url``'s host is Google News (``news.google.com`` or a subdomain).
+
+    Parses the hostname instead of a substring match so a URL that merely
+    contains ``news.google.com`` in its path/query is not misrouted through
+    Google News resolution (CodeQL ``py/incomplete-url-substring-sanitization``).
+    """
+    host = (urlparse(url).hostname or "").lower()
+    return host == "news.google.com" or host.endswith(".news.google.com")
 
 
 def _decode_google_news_base64(url: str) -> str:
@@ -661,7 +673,7 @@ def fetch_page_metadata(url: str, timeout: int = 8, title: str = "") -> Dict[str
     if not url:
         return result
     # Resolve Google News redirects (any news.google.com URL)
-    if "news.google.com" in url:
+    if _is_google_news_host(url):
         resolved = _resolve_google_news_url(url)
         if not resolved:
             return result

--- a/scripts/common/enrichment_network.py
+++ b/scripts/common/enrichment_network.py
@@ -10,14 +10,15 @@ split. ``common.enrichment`` re-exports the public names so existing
 ``from common.enrichment import ...`` call sites (collectors, ``rss_fetcher``, …)
 keep working unchanged.
 
-NOTE (batches 1-2): the URL-safety wrapper, meta-description cleaner, Google
+NOTE (batches 1-3): the URL-safety wrapper, meta-description cleaner, Google
 News base64 decoder, and the HTML metadata/content extractors (batch 1) plus
 the Google News resolver chain (``_resolve_google_news_url`` / ``_inner`` /
-``_resolve_via_gnewsdecoder``) and the og:image fetcher (batch 2) now live here.
-The page-metadata orchestrators (``fetch_page_metadata`` / ``fetch_page_description``)
-still live in the facade and are moved in later batches per
-``docs/refactoring-plan-2026-07.md`` §1.4. Patch-string relocation happens in
-the same commit as each symbol move to keep every batch's test gate hermetic.
+``_resolve_via_gnewsdecoder``) and the og:image fetcher (batch 2) and the
+page-metadata fetcher (``fetch_page_metadata``, batch 3) now live here.
+The thin ``fetch_page_description`` wrapper still lives in the facade and is
+moved in a later batch per ``docs/refactoring-plan-2026-07.md`` §1.4.
+Patch-string relocation happens in the same commit as each symbol move to
+keep every batch's test gate hermetic.
 """
 
 from __future__ import annotations
@@ -30,7 +31,7 @@ import requests
 
 from . import summary_quality as _summary_quality_mod
 from .config import get_verify_ssl
-from .encoding_guard import force_utf8_if_mislabelled
+from .encoding_guard import force_utf8_if_mislabelled, sanitize_mojibake
 from .enrichment_images import _is_valid_image_url, is_logo_like_url
 from .enrichment_synthetic import _is_title_related_description
 from .markdown_utils import smart_truncate
@@ -640,3 +641,87 @@ def _fetch_og_image(url: str, timeout: int = 8) -> str:
     except Exception as exc:
         logger.debug("og:image fetch failed for %s: %s", url, exc)
     return ""
+
+
+def fetch_page_metadata(url: str, timeout: int = 8, title: str = "") -> Dict[str, str]:
+    """Fetch meta description, image and article metadata from a URL page.
+
+    Returns a dict with keys ``description``, ``image``, ``published_time``,
+    ``author``, ``section`` (all may be empty). All article:* fields are
+    best-effort and default to empty string on failure or when the page
+    does not emit that tag.
+    """
+    result: Dict[str, str] = {
+        "description": "",
+        "image": "",
+        "published_time": "",
+        "author": "",
+        "section": "",
+    }
+    if not url:
+        return result
+    # Resolve Google News redirects (any news.google.com URL)
+    if "news.google.com" in url:
+        resolved = _resolve_google_news_url(url)
+        if not resolved:
+            return result
+        url = resolved
+
+    try:
+        from bs4 import BeautifulSoup as BS4
+
+        if is_private_url(url):
+            logger.warning("SSRF blocked: %s resolves to private IP", url[:80])
+            return result
+        resp = requests.get(
+            url,
+            timeout=timeout,
+            headers={"User-Agent": _USER_AGENT},
+            verify=_get_verify_ssl(),
+        )
+        resp.raise_for_status()
+        force_utf8_if_mislabelled(resp)
+        soup = BS4(resp.text, "html.parser")
+
+        # Extract OG metadata (image + description + article:* fields)
+        og = _extract_og_metadata(soup, title=title)
+        result["image"] = og["image"]
+        result["published_time"] = og.get("published_time", "")
+        result["author"] = og.get("author", "")
+        result["section"] = og.get("section", "")
+        if og["description"]:
+            cleaned = sanitize_mojibake(og["description"])
+            if cleaned:
+                result["description"] = cleaned
+                return result
+
+        # Try readability-lxml for high-quality article extraction
+        desc = sanitize_mojibake(_extract_via_readability(resp.text, url))
+        if desc:
+            if _is_title_related_description(title, desc):
+                result["description"] = desc
+            else:
+                logger.debug("Rejected readability description as unrelated to title")
+            return result
+
+        # Article body paragraphs (BS4 fallback)
+        desc = sanitize_mojibake(_extract_via_bs4_article(soup))
+        if desc:
+            if _is_title_related_description(title, desc):
+                result["description"] = desc
+            else:
+                logger.debug("Rejected article-body description as unrelated to title")
+            return result
+
+        # Last resort: any substantial <p> not in noise containers
+        desc = sanitize_mojibake(_extract_via_paragraphs(soup))
+        if desc:
+            if _is_title_related_description(title, desc):
+                result["description"] = desc
+            else:
+                logger.debug("Rejected paragraph description as unrelated to title")
+            return result
+
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Failed to fetch metadata from %s: %s", url, e)
+    return result

--- a/scripts/common/enrichment_network.py
+++ b/scripts/common/enrichment_network.py
@@ -10,28 +10,44 @@ split. ``common.enrichment`` re-exports the public names so existing
 ``from common.enrichment import ...`` call sites (collectors, ``rss_fetcher``, …)
 keep working unchanged.
 
-NOTE (batch 1 — leaf move): the URL-safety wrapper, meta-description cleaner,
-Google News base64 decoder, and the HTML metadata/content extractors now live
-here. The resolver chain and page-fetch orchestrators still live in the facade
-and are moved in later batches per ``docs/refactoring-plan-2026-07.md`` §1.4.
-Patch-string relocation happens in the same commit as each symbol move to keep
-every batch's test gate hermetic.
+NOTE (batches 1-2): the URL-safety wrapper, meta-description cleaner, Google
+News base64 decoder, and the HTML metadata/content extractors (batch 1) plus
+the Google News resolver chain (``_resolve_google_news_url`` / ``_inner`` /
+``_resolve_via_gnewsdecoder``) and the og:image fetcher (batch 2) now live here.
+The page-metadata orchestrators (``fetch_page_metadata`` / ``fetch_page_description``)
+still live in the facade and are moved in later batches per
+``docs/refactoring-plan-2026-07.md`` §1.4. Patch-string relocation happens in
+the same commit as each symbol move to keep every batch's test gate hermetic.
 """
 
 from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+import requests
 
 from . import summary_quality as _summary_quality_mod
-from .enrichment_images import _is_valid_image_url
+from .config import get_verify_ssl
+from .encoding_guard import force_utf8_if_mislabelled
+from .enrichment_images import _is_valid_image_url, is_logo_like_url
 from .enrichment_synthetic import _is_title_related_description
 from .markdown_utils import smart_truncate
 from .summary_quality import _is_site_boilerplate
 from .utils import is_private_url_target
 
 logger = logging.getLogger(__name__)
+
+_VERIFY_SSL: Optional[object] = None
+
+
+def _get_verify_ssl():
+    global _VERIFY_SSL
+    if _VERIFY_SSL is None:
+        _VERIFY_SSL = get_verify_ssl()
+    return _VERIFY_SSL
+
 
 # readability-lxml is a declared dependency (requirements.txt); its absence is
 # an environment regression that silently drops the best-quality extraction
@@ -400,4 +416,227 @@ def _extract_via_paragraphs(soup: Any) -> str:
         text = _clean_meta_description(p.get_text(strip=True))
         if len(text) > 50:
             return smart_truncate(text, 1000)
+    return ""
+
+
+def _resolve_google_news_url(url: str, timeout: int = 8) -> str:
+    """Follow Google News redirect to get the real article URL.
+
+    Strategy:
+    1. Return cached result if available.
+    2. Try base64 decoding of the RSS article path (fastest, no network).
+    3. Follow HTTP redirects with ``requests.head`` (max 3 hops) then ``requests.get``.
+    4. Parse HTML for canonical/og:url if still on Google domain.
+
+    Handles both ``/rss/articles/CBMi...`` and ``/read/CBMi...`` URL formats.
+    """
+    if not url or "news.google.com" not in url:
+        return url
+
+    # Check cache first
+    if url in _gnews_url_cache:
+        return _gnews_url_cache[url]
+
+    resolved = _resolve_google_news_url_inner(url, timeout)
+    _gnews_url_cache[url] = resolved
+    return resolved
+
+
+def _resolve_google_news_url_inner(url: str, timeout: int = 8) -> str:
+    """Inner implementation for Google News URL resolution (uncached)."""
+    # 1. Try base64 decoding (no network call needed)
+    decoded = _decode_google_news_base64(url)
+    if decoded:
+        logger.debug("Google News base64 decoded: %s -> %s", url[:60], decoded[:80])
+        return decoded
+
+    # Normalize /read/ URLs to /rss/articles/ and retry base64
+    if "/read/" in url:
+        rss_url = url.replace("/read/", "/rss/articles/")
+        decoded = _decode_google_news_base64(rss_url)
+        if decoded:
+            logger.debug("Google News /read/ base64 decoded: %s -> %s", url[:60], decoded[:80])
+            return decoded
+
+    # 2. Try googlenewsdecoder (handles newer protobuf-encoded URLs)
+    resolved = _resolve_via_gnewsdecoder(url)
+    if resolved:
+        return resolved
+
+    # 3. Follow HTTP redirects via HEAD manually (max 5 hops), checking each hop
+    try:
+        if is_private_url(url):
+            logger.warning("SSRF blocked: %s resolves to private IP", url[:80])
+            return ""
+        current_url = url
+        max_hops = 5
+        for _hop in range(max_hops):
+            head_resp = requests.head(
+                current_url,
+                timeout=timeout,
+                allow_redirects=False,
+                headers={"User-Agent": _BROWSER_UA},
+                verify=_get_verify_ssl(),
+            )
+            if head_resp.status_code in (301, 302, 303, 307, 308):
+                location = head_resp.headers.get("Location", "")
+                if not location:
+                    break
+                # Resolve relative redirects
+                if not location.startswith("http"):
+                    from urllib.parse import urljoin
+
+                    location = urljoin(current_url, location)
+                if is_private_url(location):
+                    logger.warning("SSRF blocked (redirect hop): %s -> %s", current_url[:60], location[:80])
+                    return ""
+                if "news.google.com" not in location:
+                    logger.debug("Google News HEAD redirect: %s -> %s", url[:60], location[:80])
+                    return location
+                current_url = location
+            else:
+                # No redirect; use final URL if not on Google domain
+                final_url = head_resp.url or current_url
+                if final_url and "news.google.com" not in final_url:
+                    if is_private_url(final_url):
+                        logger.warning("SSRF blocked (redirect): %s -> %s", url[:60], final_url[:80])
+                        return ""
+                    logger.debug("Google News HEAD resolved: %s -> %s", url[:60], final_url[:80])
+                    return final_url
+                break
+    except requests.exceptions.RequestException:
+        pass
+
+    # 4. Full GET and parse HTML for canonical/og:url
+    try:
+        if is_private_url(url):
+            logger.warning("SSRF blocked: %s resolves to private IP", url[:80])
+            return ""
+        resp = requests.get(
+            url,
+            timeout=timeout,
+            allow_redirects=True,
+            headers={"User-Agent": _BROWSER_UA},
+            verify=_get_verify_ssl(),
+        )
+        if resp.url and "news.google.com" not in resp.url:
+            if is_private_url(resp.url):
+                logger.warning("SSRF blocked (redirect): %s -> %s", url[:60], resp.url[:80])
+                return ""
+            return resp.url
+        # Try to find canonical or data-url in HTML
+        for pattern in [
+            r'<link[^>]+rel=["\']canonical["\'][^>]+href=["\']([^"\']+)',
+            r'<meta[^>]+property=["\']og:url["\'][^>]+content=["\']([^"\']+)',
+            r'data-url=["\']([^"\']+)',
+            r'<a[^>]+data-redirect=["\']([^"\']+)',
+        ]:
+            m = re.search(pattern, resp.text[:20_000])
+            if m:
+                found = m.group(1)
+                if found and "news.google.com" not in found:
+                    return found
+    except requests.exceptions.RequestException:
+        pass
+    return ""
+
+
+def _resolve_via_gnewsdecoder(url: str) -> str:
+    """Resolve Google News URL using googlenewsdecoder library.
+
+    This handles the newer protobuf-encoded URLs (2024+) that cannot be
+    decoded via simple base64. Falls back gracefully if the library is
+    unavailable or decoding fails.
+    """
+    try:
+        from googlenewsdecoder import gnewsdecoder
+
+        result = gnewsdecoder(url)
+        if result and result.get("status") and result.get("decoded_url"):
+            decoded_url = result["decoded_url"]
+            if is_private_url(decoded_url):
+                logger.warning("SSRF blocked (gnewsdecoder): %s -> %s", url[:60], decoded_url[:80])
+                return ""
+            logger.debug("Google News gnewsdecoder: %s -> %s", url[:60], decoded_url[:80])
+            return decoded_url
+    except ImportError:
+        logger.debug("googlenewsdecoder not installed, skipping")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("gnewsdecoder failed for %s: %s", url[:60], exc)
+    return ""
+
+
+def _fetch_og_image(url: str, timeout: int = 8) -> str:
+    """Fetch an article image URL from a page's meta tags.
+
+    Searches in priority order: og:image, og:image:secure_url, og:image:url,
+    twitter:image, twitter:image:src, article:image, itemprop=image, and
+    <link rel="image_src">. Returns the first URL that passes both
+    _is_valid_image_url (rejects placeholders/trackers) and is_logo_like_url
+    (rejects site logos/favicons). Returns empty string on network failure,
+    SSRF block, or when no valid article image is found.
+    """
+    if not url:
+        return ""
+    try:
+        if is_private_url(url):
+            logger.warning("SSRF blocked: %s resolves to private IP", url[:80])
+            return ""
+        resp = requests.get(
+            url,
+            timeout=timeout,
+            headers={"User-Agent": _BROWSER_UA},
+            verify=_get_verify_ssl(),
+        )
+        resp.raise_for_status()
+        force_utf8_if_mislabelled(resp)
+        # Search first 60KB — modern sites often have bloated <head> with many
+        # script/link tags before the image meta tags.
+        head_html = resp.text[:60_000]
+
+        def _accept(img_url: str) -> bool:
+            img_url = img_url.strip()
+            if not img_url.startswith(("http://", "https://")):
+                return False
+            if not _is_valid_image_url(img_url):
+                return False
+            if is_logo_like_url(img_url):
+                return False
+            return True
+
+        for attr_pattern, _label in _IMAGE_META_PATTERNS:
+            # Try both attribute orders (property-first or content-first)
+            for regex in (
+                rf'<meta[^>]+{attr_pattern}[^>]+content=["\']([^"\']+)',
+                rf'<meta[^>]+content=["\']([^"\']+)["\'][^>]+{attr_pattern}',
+            ):
+                match = re.search(regex, head_html, re.IGNORECASE)
+                if match and _accept(match.group(1)):
+                    return match.group(1).strip()
+
+        # <link rel="image_src" href="..."> — Pinterest/legacy schema
+        link_match = re.search(
+            r'<link[^>]+rel=["\']image_src["\'][^>]+href=["\']([^"\']+)',
+            head_html,
+            re.IGNORECASE,
+        )
+        if link_match and _accept(link_match.group(1)):
+            return link_match.group(1).strip()
+
+        # JSON-LD schema.org image (modern publisher pattern)
+        for ld_match in re.finditer(
+            r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+            head_html,
+            re.IGNORECASE | re.DOTALL,
+        ):
+            ld_text = ld_match.group(1)
+            for img_match in re.finditer(
+                r'"image"\s*:\s*(?:"([^"]+)"|\{[^{}]*"url"\s*:\s*"([^"]+)")',
+                ld_text,
+            ):
+                candidate = (img_match.group(1) or img_match.group(2) or "").strip()
+                if candidate and _accept(candidate):
+                    return candidate
+    except Exception as exc:
+        logger.debug("og:image fetch failed for %s: %s", url, exc)
     return ""

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import common.enrichment as _enrichment_mod
+import common.enrichment_network as _network_mod
 from common.enrichment import (
     _NOISE_DESC_PATTERNS,
     MAX_IMAGES_PER_DIGEST,
@@ -3474,11 +3475,13 @@ class TestReadabilityFailOpen:
 
         # Force `from readability import Document` to raise ImportError.
         monkeypatch.setitem(sys.modules, "readability", None)
-        # Reset the process-wide once-only warning latch.
-        monkeypatch.setattr(_enrichment_mod, "_warned_readability_missing", False)
+        # Reset the process-wide once-only warning latch. The latch and logger
+        # now live in ``common.enrichment_network`` (the facade re-exports the
+        # extractor), so setattr/caplog must target the network module.
+        monkeypatch.setattr(_network_mod, "_warned_readability_missing", False)
 
         html = "<html><body><article><p>" + ("x" * 80) + "</p></article></body></html>"
-        with caplog.at_level(logging.WARNING, logger=_enrichment_mod.logger.name):
+        with caplog.at_level(logging.WARNING, logger=_network_mod.logger.name):
             first = _enrichment_mod._extract_via_readability(html, "https://example.com/a")
             second = _enrichment_mod._extract_via_readability(html, "https://example.com/b")
 

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -399,7 +399,7 @@ class TestFetchPageMetadata:
         for key in ("description", "image", "published_time", "author", "section"):
             assert key in result
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_article_published_time_extracted(self, mock_get):
         html = """<html><head>
         <meta property="article:published_time" content="2026-04-21T09:30:00+09:00" />
@@ -412,7 +412,7 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article")
         assert result["published_time"] == "2026-04-21T09:30:00+09:00"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_article_author_extracted(self, mock_get):
         html = """<html><head>
         <meta property="article:author" content="홍길동 기자" />
@@ -425,7 +425,7 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article")
         assert result["author"] == "홍길동 기자"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_article_section_extracted(self, mock_get):
         html = """<html><head>
         <meta property="article:section" content="경제" />
@@ -438,7 +438,7 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article")
         assert result["section"] == "경제"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_modified_time_fallback_when_published_absent(self, mock_get):
         html = """<html><head>
         <meta property="article:modified_time" content="2026-04-21T10:00:00Z" />
@@ -451,7 +451,7 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article")
         assert result["published_time"] == "2026-04-21T10:00:00Z"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_http_error_returns_empty(self, mock_get):
         import requests as req_mod
 
@@ -459,7 +459,7 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article")
         assert result["description"] == ""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_og_description_extracted(self, mock_get):
         html = """<html><head>
         <meta property="og:description" content="Bitcoin surged 10% on institutional demand today." />
@@ -472,7 +472,7 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article")
         assert "Bitcoin" in result["description"]
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_meta_description_extracted(self, mock_get):
         html = """<html><head>
         <meta name="description" content="Ethereum network upgrade brings major improvements to the ecosystem." />
@@ -484,8 +484,8 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article")
         assert "Ethereum" in result["description"]
 
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.get")
     def test_irrelevant_meta_description_rejected_with_title(self, mock_get, _mock_private):  # noqa: PT019
         html = """<html><head>
         <meta name="description" content="Apple unveils new iPhone lineup at annual event." />
@@ -497,7 +497,7 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article", title="Bitcoin ETF approval drives market rally")
         assert result["description"] == ""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_og_image_extracted(self, mock_get):
         html = """<html><head>
         <meta property="og:image" content="https://example.com/article-image.jpg" />
@@ -510,7 +510,7 @@ class TestFetchPageMetadata:
         result = fetch_page_metadata("https://example.com/article")
         assert result["image"] == "https://example.com/article-image.jpg"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_short_description_skipped(self, mock_get):
         html = """<html><head>
         <meta name="description" content="Short." />
@@ -523,7 +523,7 @@ class TestFetchPageMetadata:
         # Short meta desc < 20 chars is skipped; body paragraph may be extracted
         assert isinstance(result["description"], str)
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_http_status_error_returns_empty(self, mock_get):
         import requests as req_mod
 
@@ -1260,7 +1260,7 @@ class TestFetchDescriptionsConcurrentExtended:
 class TestFetchPageMetadataExtended:
     """Extended tests for fetch_page_metadata covering more branches."""
 
-    @patch("common.enrichment._resolve_google_news_url")
+    @patch("common.enrichment_network._resolve_google_news_url")
     def test_google_news_url_resolved(self, mock_resolve):
         """Google News URL should be resolved before fetching."""
         from common.enrichment import fetch_page_metadata
@@ -1276,7 +1276,7 @@ class TestFetchPageMetadataExtended:
             "section": "",
         }
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_twitter_description_extracted(self, mock_get):
         """twitter:description meta tag should be used as fallback."""
         from common.enrichment import fetch_page_metadata
@@ -1291,7 +1291,7 @@ class TestFetchPageMetadataExtended:
         result = fetch_page_metadata("https://example.com/article")
         assert "Ethereum" in result["description"]
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_body_paragraph_fallback(self, mock_get):
         """If no meta description, fall back to first long body <p> tag."""
         from common.enrichment import fetch_page_metadata
@@ -1307,7 +1307,7 @@ class TestFetchPageMetadataExtended:
         result = fetch_page_metadata("https://example.com/article")
         assert "long enough paragraph" in result["description"]
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_article_tag_used_for_paragraphs(self, mock_get):
         """Prefers <article> tag body over generic <p> tags."""
         from common.enrichment import fetch_page_metadata
@@ -1325,7 +1325,7 @@ class TestFetchPageMetadataExtended:
         result = fetch_page_metadata("https://example.com/article")
         assert isinstance(result["description"], str)
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_twitter_image_extracted(self, mock_get):
         """twitter:image should be extracted when og:image is absent."""
         from common.enrichment import fetch_page_metadata
@@ -1977,9 +1977,9 @@ class TestNeedsEnrichmentDescEqualsTitle:
 class TestFetchPageMetadataGoogleNewsResolved:
     """Cover line 376: url = resolved after Google News resolution."""
 
-    @patch("common.enrichment.requests.get")
-    @patch("common.enrichment._resolve_google_news_url")
-    @patch("common.enrichment.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.get")
+    @patch("common.enrichment_network._resolve_google_news_url")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
     def test_google_news_resolved_url_used_for_fetch(self, mock_private, mock_resolve, mock_get):
         """Line 376: resolved URL replaces google news URL for metadata fetch."""
         mock_resolve.return_value = "https://real-article.com/news/story"
@@ -2008,7 +2008,7 @@ class TestFetchPageMetadataGoogleNewsResolved:
 class TestFetchPageMetadataReadabilityAndArticleBody:
     """Cover readability paragraph extraction (line 428) and BS4 article body (433-485)."""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_readability_used_when_available_five_paragraphs(self, mock_get):
         """Line 428: readability break after 5 paragraphs."""
         # Build HTML with 7 long paragraphs
@@ -2035,7 +2035,7 @@ class TestFetchPageMetadataReadabilityAndArticleBody:
             # Should have truncated after 5 paragraphs
             assert len(result["description"]) > 0
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_article_tag_body_extraction(self, mock_get):
         """Lines 461-475: <article> tag paragraph extraction."""
         html = """<html><head></head><body>
@@ -2054,7 +2054,7 @@ class TestFetchPageMetadataReadabilityAndArticleBody:
             result = fetch_page_metadata("https://example.com/article")
         assert "financial markets" in result["description"] or isinstance(result["description"], str)
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_article_class_body_extraction(self, mock_get):
         """Lines 448-455: article-body class used when no <article> tag."""
         html = """<html><head></head><body>
@@ -2071,7 +2071,7 @@ class TestFetchPageMetadataReadabilityAndArticleBody:
             result = fetch_page_metadata("https://example.com/article")
         assert isinstance(result["description"], str)
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_fallback_p_tags_when_no_article(self, mock_get):
         """Lines 478-485: fallback <p> outside article containers."""
         html = """<html><head></head><body>
@@ -2088,7 +2088,7 @@ class TestFetchPageMetadataReadabilityAndArticleBody:
             result = fetch_page_metadata("https://example.com/article")
         assert "standalone paragraph" in result["description"] or len(result["description"]) > 0
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_readability_exception_falls_through_to_bs4(self, mock_get):
         """Lines 435-436: readability raises non-ImportError, falls through to BS4."""
         html = """<html><head></head><body>
@@ -2315,7 +2315,7 @@ class TestGenerateSyntheticDescriptionFallbackBranches:
 class TestFetchPageMetadataRemainingLines:
     """Cover lines 434, 458-460, 464, 471, 481."""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_readability_import_error_pass_line_434(self, mock_get):
         """Line 434: readability ImportError -> pass, fall through to BS4.
 
@@ -2349,7 +2349,7 @@ class TestFetchPageMetadataRemainingLines:
 
         assert isinstance(result["description"], str)
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_exact_class_match_fallback_lines_458_460(self, mock_get):
         """Lines 458-460: exact class regex (^article|post|entry|content$) used
         when precise class pattern doesn't match."""
@@ -2367,7 +2367,7 @@ class TestFetchPageMetadataRemainingLines:
             result = fetch_page_metadata("https://example.com/article")
         assert isinstance(result["description"], str)
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_noise_element_decomposed_line_464(self, mock_get):
         """Line 464: noise.decompose() called when article has excluded class child."""
         html = """<html><head></head><body>
@@ -2385,7 +2385,7 @@ class TestFetchPageMetadataRemainingLines:
             result = fetch_page_metadata("https://example.com/article")
         assert isinstance(result["description"], str)
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_five_paragraphs_break_line_471(self, mock_get):
         """Line 471: break after collecting 5 paragraphs from article body."""
         # Build 7 paragraphs inside <article> so the break at 5 is triggered
@@ -2403,7 +2403,7 @@ class TestFetchPageMetadataRemainingLines:
             result = fetch_page_metadata("https://example.com/article")
         assert len(result["description"]) > 0
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_fallback_p_skips_excluded_parent_line_481(self, mock_get):
         """Line 481: continue when fallback <p> has excluded-class parent."""
         html = """<html><head></head><body>
@@ -3232,7 +3232,7 @@ class TestExtractViaBs4ArticleEmptyParagraphs:
 # ---------------------------------------------------------------------------
 class TestFetchPageMetadataSSRFBlock:
     def test_private_url_returns_empty_dict(self):
-        with patch("common.enrichment.is_private_url", return_value=True):
+        with patch("common.enrichment_network.is_private_url", return_value=True):
             result = fetch_page_metadata("https://internal.corp/article")
         assert result == {
             "description": "",
@@ -3247,8 +3247,8 @@ class TestFetchPageMetadataSSRFBlock:
 # Lines 864, 873, 882: readability/bs4/paragraph unrelated-to-title rejection
 # ---------------------------------------------------------------------------
 class TestFetchPageMetadataUnrelatedDescRejected:
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.get")
     def test_readability_desc_unrelated_to_title_rejected(self, mock_get, _mock_priv):  # noqa: PT019
         # Produce a page where og: desc is empty but readability succeeds with unrelated text
         html = (
@@ -3268,10 +3268,10 @@ class TestFetchPageMetadataUnrelatedDescRejected:
         # readability is available; patch _extract_via_readability to return an unrelated desc
         with (
             patch(
-                "common.enrichment._extract_via_readability",
+                "common.enrichment_network._extract_via_readability",
                 return_value="Apple released a new MacBook with an M4 chip for creative professionals.",
             ),
-            patch("common.enrichment.sanitize_mojibake", side_effect=lambda x: x),
+            patch("common.enrichment_network.sanitize_mojibake", side_effect=lambda x: x),
         ):
             result = fetch_page_metadata(
                 "https://example.com/article",
@@ -3280,8 +3280,8 @@ class TestFetchPageMetadataUnrelatedDescRejected:
         # Unrelated readability desc should be rejected, result description stays ""
         assert result["description"] == ""
 
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.get")
     def test_bs4_article_desc_unrelated_to_title_rejected(self, mock_get, _mock_priv):  # noqa: PT019
         html = (
             "<html><body>"
@@ -3295,12 +3295,12 @@ class TestFetchPageMetadataUnrelatedDescRejected:
         mock_get.return_value = mock_resp
 
         with (
-            patch("common.enrichment._extract_via_readability", return_value=""),
+            patch("common.enrichment_network._extract_via_readability", return_value=""),
             patch(
-                "common.enrichment._extract_via_bs4_article",
+                "common.enrichment_network._extract_via_bs4_article",
                 return_value="Apple released a new MacBook with M4 chip for creative professionals.",
             ),
-            patch("common.enrichment.sanitize_mojibake", side_effect=lambda x: x),
+            patch("common.enrichment_network.sanitize_mojibake", side_effect=lambda x: x),
         ):
             result = fetch_page_metadata(
                 "https://example.com/article",
@@ -3308,8 +3308,8 @@ class TestFetchPageMetadataUnrelatedDescRejected:
             )
         assert result["description"] == ""
 
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.get")
     def test_paragraph_desc_unrelated_to_title_rejected(self, mock_get, _mock_priv):  # noqa: PT019
         html = (
             "<html><body><p>Apple released a new MacBook with M4 chip targeting professional users.</p></body></html>"
@@ -3320,13 +3320,13 @@ class TestFetchPageMetadataUnrelatedDescRejected:
         mock_get.return_value = mock_resp
 
         with (
-            patch("common.enrichment._extract_via_readability", return_value=""),
-            patch("common.enrichment._extract_via_bs4_article", return_value=""),
+            patch("common.enrichment_network._extract_via_readability", return_value=""),
+            patch("common.enrichment_network._extract_via_bs4_article", return_value=""),
             patch(
-                "common.enrichment._extract_via_paragraphs",
+                "common.enrichment_network._extract_via_paragraphs",
                 return_value="Apple released a new MacBook with M4 chip for creative professionals.",
             ),
-            patch("common.enrichment.sanitize_mojibake", side_effect=lambda x: x),
+            patch("common.enrichment_network.sanitize_mojibake", side_effect=lambda x: x),
         ):
             result = fetch_page_metadata(
                 "https://example.com/article",

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -322,7 +322,7 @@ class TestResolveGoogleNewsUrl:
         result = _resolve_google_news_url("https://reuters.com/markets/bitcoin")
         assert result == "https://reuters.com/markets/bitcoin"
 
-    @patch("common.enrichment._decode_google_news_base64")
+    @patch("common.enrichment_network._decode_google_news_base64")
     def test_base64_decode_success_skips_http(self, mock_decode):
         """If base64 decode succeeds, no network calls are made."""
         mock_decode.return_value = "https://real-article.com/news/123"
@@ -330,9 +330,9 @@ class TestResolveGoogleNewsUrl:
         assert result == "https://real-article.com/news/123"
         mock_decode.assert_called_once()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder")
-    @patch("common.enrichment._decode_google_news_base64")
-    @patch("common.enrichment.requests.head")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder")
+    @patch("common.enrichment_network._decode_google_news_base64")
+    @patch("common.enrichment_network.requests.head")
     def test_http_head_redirect_used_when_base64_fails(self, mock_head, mock_decode, mock_gnews):
         """When base64 fails, follows HEAD redirect."""
         mock_gnews.return_value = ""
@@ -344,10 +344,10 @@ class TestResolveGoogleNewsUrl:
         result = _resolve_google_news_url("https://news.google.com/rss/articles/CBMiXXX")
         assert result == "https://real-site.com/article"
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder")
-    @patch("common.enrichment._decode_google_news_base64")
-    @patch("common.enrichment.requests.head")
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder")
+    @patch("common.enrichment_network._decode_google_news_base64")
+    @patch("common.enrichment_network.requests.head")
+    @patch("common.enrichment_network.requests.get")
     def test_get_fallback_when_head_stays_on_google(self, mock_get, mock_head, mock_decode, mock_gnews):
         """When HEAD stays on google, tries GET."""
         mock_gnews.return_value = ""
@@ -363,10 +363,10 @@ class TestResolveGoogleNewsUrl:
         result = _resolve_google_news_url("https://news.google.com/rss/articles/CBMiXXX")
         assert result == "https://real-site.com/article"
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder")
-    @patch("common.enrichment._decode_google_news_base64")
-    @patch("common.enrichment.requests.head")
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder")
+    @patch("common.enrichment_network._decode_google_news_base64")
+    @patch("common.enrichment_network.requests.head")
+    @patch("common.enrichment_network.requests.get")
     def test_network_exception_returns_empty(self, mock_get, mock_head, mock_decode, mock_gnews):
         """Network errors should be swallowed and return empty."""
         import requests as req_mod
@@ -893,10 +893,10 @@ class TestResolveGoogleNewsUrlHtmlBranch:
         # for the same URL do not bleed through as cache hits.
         _enrichment_mod._gnews_url_cache.clear()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder")
-    @patch("common.enrichment._decode_google_news_base64")
-    @patch("common.enrichment.requests.head")
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder")
+    @patch("common.enrichment_network._decode_google_news_base64")
+    @patch("common.enrichment_network.requests.head")
+    @patch("common.enrichment_network.requests.get")
     def test_canonical_link_extracted_from_html(self, mock_get, mock_head, mock_decode, mock_gnews):
         """If GET stays on Google but HTML has canonical link, use it."""
         mock_gnews.return_value = ""
@@ -912,10 +912,10 @@ class TestResolveGoogleNewsUrlHtmlBranch:
         result = _resolve_google_news_url("https://news.google.com/rss/articles/CBMiHTML1")
         assert result == "https://real-article.com/page"
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder")
-    @patch("common.enrichment._decode_google_news_base64")
-    @patch("common.enrichment.requests.head")
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder")
+    @patch("common.enrichment_network._decode_google_news_base64")
+    @patch("common.enrichment_network.requests.head")
+    @patch("common.enrichment_network.requests.get")
     def test_og_url_extracted_from_html(self, mock_get, mock_head, mock_decode, mock_gnews):
         """og:url meta tag is used as fallback."""
         mock_gnews.return_value = ""
@@ -931,10 +931,10 @@ class TestResolveGoogleNewsUrlHtmlBranch:
         result = _resolve_google_news_url("https://news.google.com/rss/articles/CBMiHTML2")
         assert result == "https://real-article.com/og"
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder")
-    @patch("common.enrichment._decode_google_news_base64")
-    @patch("common.enrichment.requests.head")
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder")
+    @patch("common.enrichment_network._decode_google_news_base64")
+    @patch("common.enrichment_network.requests.head")
+    @patch("common.enrichment_network.requests.get")
     def test_get_exception_returns_empty(self, mock_get, mock_head, mock_decode, mock_gnews):
         """If GET raises an exception, return empty string."""
         import requests as req_mod
@@ -967,7 +967,7 @@ class TestFetchOgImage:
         _fetch_og_image = self._import_func()
         assert _fetch_og_image("") == ""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_og_image_extracted(self, mock_get):
         from common.enrichment import _fetch_og_image
 
@@ -978,7 +978,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/photo.jpg"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_twitter_image_fallback(self, mock_get):
         from common.enrichment import _fetch_og_image
 
@@ -989,7 +989,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/tw.jpg"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_http_error_returns_empty(self, mock_get):
         import requests as req_mod
 
@@ -1001,7 +1001,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == ""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_connection_error_returns_empty(self, mock_get):
         import requests as req_mod
 
@@ -1011,7 +1011,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == ""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_invalid_image_url_skipped(self, mock_get):
         from common.enrichment import _fetch_og_image
 
@@ -1023,7 +1023,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == ""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_no_og_image_returns_empty(self, mock_get):
         from common.enrichment import _fetch_og_image
 
@@ -1034,7 +1034,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == ""
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_og_image_secure_url_used(self, mock_get):
         """og:image:secure_url should be picked when og:image is absent."""
         from common.enrichment import _fetch_og_image
@@ -1046,7 +1046,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/secure.jpg"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_article_image_used(self, mock_get):
         """article:image (OpenGraph article namespace) should be picked up."""
         from common.enrichment import _fetch_og_image
@@ -1058,7 +1058,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/article.jpg"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_itemprop_image_used(self, mock_get):
         """Schema.org itemprop=image should be used as a late fallback."""
         from common.enrichment import _fetch_og_image
@@ -1070,7 +1070,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/schema.jpg"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_link_image_src_used(self, mock_get):
         """<link rel="image_src"> legacy fallback should be picked up last."""
         from common.enrichment import _fetch_og_image
@@ -1082,7 +1082,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/link-src.jpg"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_priority_og_over_twitter(self, mock_get):
         """og:image must win over twitter:image when both are present."""
         from common.enrichment import _fetch_og_image
@@ -1097,7 +1097,7 @@ class TestFetchOgImage:
         result = _fetch_og_image("https://example.com/article")
         assert result == "https://cdn.example.com/og.jpg"
 
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.requests.get")
     def test_logo_url_rejected_falls_through(self, mock_get):
         """A logo-ish og:image should be skipped in favor of a later valid URL."""
         from common.enrichment import _fetch_og_image
@@ -2804,8 +2804,8 @@ class TestResolveGoogleNewsReadUrl:
     def setup_method(self):
         _enrich_mod._gnews_url_cache.clear()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64")
     def test_read_url_normalized_and_base64_retried(self, mock_decode, _mock_gnews):  # noqa: PT019
         # First call (original /read/ URL) returns "", second call (/rss/articles/) returns a URL
         mock_decode.side_effect = ["", "https://real-article.com/news/read-path"]
@@ -2824,8 +2824,8 @@ class TestResolveGoogleNewsInnerGnewsDecoderSuccess:
     def setup_method(self):
         _enrich_mod._gnews_url_cache.clear()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="https://decoded.com/article")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="https://decoded.com/article")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
     def test_gnewsdecoder_result_returned_directly(self, _mock_b64, _mock_gnews):  # noqa: PT019
         result = _enrich_mod._resolve_google_news_url_inner("https://news.google.com/rss/articles/CBMiGNEWS", timeout=1)
         assert result == "https://decoded.com/article"
@@ -2841,9 +2841,9 @@ class TestResolveGoogleNewsInnerSSRFBlock:
     def setup_method(self):
         _enrich_mod._gnews_url_cache.clear()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.is_private_url", return_value=True)
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.is_private_url", return_value=True)
     def test_ssrf_blocked_before_head_request_returns_empty(self, _mock_priv, _mock_b64, _mock_gnews):  # noqa: PT019
         result = _enrich_mod._resolve_google_news_url_inner("https://news.google.com/rss/articles/CBMiSSRF", timeout=1)
         assert result == ""
@@ -2859,10 +2859,10 @@ class TestResolveGoogleNewsInnerRedirectHops:
     def setup_method(self):
         _enrich_mod._gnews_url_cache.clear()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.head")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.head")
     def test_redirect_to_non_google_domain_returned(self, mock_head, _mock_priv, _mock_b64, _mock_gnews):  # noqa: PT019
         mock_resp = MagicMock()
         mock_resp.status_code = 301
@@ -2871,11 +2871,11 @@ class TestResolveGoogleNewsInnerRedirectHops:
         result = _enrich_mod._resolve_google_news_url_inner("https://news.google.com/rss/articles/CBMiHOP", timeout=1)
         assert result == "https://real-news.com/article/123"
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.head")
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.head")
+    @patch("common.enrichment_network.requests.get")
     def test_empty_location_header_breaks_loop(self, mock_get, mock_head, _mock_priv, _mock_b64, _mock_gnews):  # noqa: PT019
         mock_resp = MagicMock()
         mock_resp.status_code = 301
@@ -2891,10 +2891,10 @@ class TestResolveGoogleNewsInnerRedirectHops:
         result = _enrich_mod._resolve_google_news_url_inner("https://news.google.com/rss/articles/CBMiEMPTY", timeout=1)
         assert result == ""
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.head")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.head")
     def test_relative_redirect_resolved_to_absolute(self, mock_head, _mock_priv, _mock_b64, _mock_gnews):  # noqa: PT019
         # First hop: relative redirect
         hop1 = MagicMock()
@@ -2908,10 +2908,10 @@ class TestResolveGoogleNewsInnerRedirectHops:
         result = _enrich_mod._resolve_google_news_url_inner("https://news.google.com/rss/articles/CBMiREL", timeout=1)
         assert "real-news.com" in result
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.head")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.head")
     def test_redirect_hop_to_private_ip_returns_empty(self, mock_head, _mock_priv, _mock_b64, _mock_gnews):  # noqa: PT019
         # Simulate redirect to a private IP (SSRF via redirect hop)
         mock_resp = MagicMock()
@@ -2919,7 +2919,7 @@ class TestResolveGoogleNewsInnerRedirectHops:
         mock_resp.headers = {"Location": "http://192.168.1.1/secret"}
         mock_head.return_value = mock_resp
         # Override is_private_url: allow google URL but block the redirected one
-        with patch("common.enrichment.is_private_url", side_effect=lambda u: "192.168" in u):
+        with patch("common.enrichment_network.is_private_url", side_effect=lambda u: "192.168" in u):
             result = _enrich_mod._resolve_google_news_url_inner(
                 "https://news.google.com/rss/articles/CBMiPRIV", timeout=1
             )
@@ -2933,16 +2933,16 @@ class TestResolveGoogleNewsInnerHeadFinalUrlSSRF:
     def setup_method(self):
         _enrich_mod._gnews_url_cache.clear()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.requests.head")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.requests.head")
     def test_final_url_private_ip_returns_empty(self, mock_head, _mock_b64, _mock_gnews):  # noqa: PT019
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.url = "http://10.0.0.1/internal"
         mock_resp.headers = {}
         mock_head.return_value = mock_resp
-        with patch("common.enrichment.is_private_url", side_effect=lambda u: "10.0.0" in u):
+        with patch("common.enrichment_network.is_private_url", side_effect=lambda u: "10.0.0" in u):
             result = _enrich_mod._resolve_google_news_url_inner(
                 "https://news.google.com/rss/articles/CBMiFINAL", timeout=1
             )
@@ -2959,9 +2959,9 @@ class TestResolveGoogleNewsInnerGetSSRF:
     def setup_method(self):
         _enrich_mod._gnews_url_cache.clear()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.requests.head")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.requests.head")
     def test_get_fallback_ssrf_blocked(self, mock_head, _mock_b64, _mock_gnews):  # noqa: PT019
         # HEAD section: is_private_url returns False first (line 395) → HEAD proceeds
         # HEAD raises RequestException → caught at line 434 → falls to GET section
@@ -2971,16 +2971,16 @@ class TestResolveGoogleNewsInnerGetSSRF:
         mock_head.side_effect = req_mod.exceptions.ConnectionError("refused")
         # First call (line 395 in HEAD section): False → proceed
         # Second call (line 439 in GET section): True → SSRF block
-        with patch("common.enrichment.is_private_url", side_effect=[False, True]):
+        with patch("common.enrichment_network.is_private_url", side_effect=[False, True]):
             result = _enrich_mod._resolve_google_news_url_inner(
                 "https://news.google.com/rss/articles/CBMiGETSSRF", timeout=1
             )
         assert result == ""
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.requests.head")
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.requests.head")
+    @patch("common.enrichment_network.requests.get")
     def test_get_fallback_executed_after_head_exception(self, mock_get, mock_head, _mock_b64, _mock_gnews):  # noqa: PT019
         # HEAD throws → GET fallback is attempted; not SSRF-blocked → normal execution
         import requests as req_mod
@@ -2990,7 +2990,7 @@ class TestResolveGoogleNewsInnerGetSSRF:
         mock_get_resp.url = "https://real-news.com/article"
         mock_get_resp.text = ""
         mock_get.return_value = mock_get_resp
-        with patch("common.enrichment.is_private_url", return_value=False):
+        with patch("common.enrichment_network.is_private_url", return_value=False):
             result = _enrich_mod._resolve_google_news_url_inner(
                 "https://news.google.com/rss/articles/CBMiGETOK", timeout=1
             )
@@ -3007,10 +3007,10 @@ class TestResolveGoogleNewsInnerGetRespUrlSSRF:
     def setup_method(self):
         _enrich_mod._gnews_url_cache.clear()
 
-    @patch("common.enrichment._resolve_via_gnewsdecoder", return_value="")
-    @patch("common.enrichment._decode_google_news_base64", return_value="")
-    @patch("common.enrichment.requests.head")
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network._resolve_via_gnewsdecoder", return_value="")
+    @patch("common.enrichment_network._decode_google_news_base64", return_value="")
+    @patch("common.enrichment_network.requests.head")
+    @patch("common.enrichment_network.requests.get")
     def test_resp_url_private_returns_empty(self, mock_get, mock_head, _mock_b64, _mock_gnews):  # noqa: PT019
         import requests as req_mod
 
@@ -3019,7 +3019,7 @@ class TestResolveGoogleNewsInnerGetRespUrlSSRF:
         mock_get_resp.url = "http://172.16.0.1/internal"
         mock_get_resp.text = ""
         mock_get.return_value = mock_get_resp
-        with patch("common.enrichment.is_private_url", side_effect=lambda u: "172.16" in u):
+        with patch("common.enrichment_network.is_private_url", side_effect=lambda u: "172.16" in u):
             result = _enrich_mod._resolve_google_news_url_inner(
                 "https://news.google.com/rss/articles/CBMiGETRESP", timeout=1
             )
@@ -3048,7 +3048,7 @@ class TestResolveViaGnewsdecoder:
         }
         with (
             patch.dict("sys.modules", {"googlenewsdecoder": mock_gnews_mod}),
-            patch("common.enrichment.is_private_url", return_value=False),
+            patch("common.enrichment_network.is_private_url", return_value=False),
         ):
             result = _resolve_via_gnewsdecoder("https://news.google.com/rss/articles/CBMi")
         assert result == "https://real-article.com/news"
@@ -3062,7 +3062,7 @@ class TestResolveViaGnewsdecoder:
         }
         with (
             patch.dict("sys.modules", {"googlenewsdecoder": mock_gnews_mod}),
-            patch("common.enrichment.is_private_url", return_value=True),
+            patch("common.enrichment_network.is_private_url", return_value=True),
         ):
             result = _resolve_via_gnewsdecoder("https://news.google.com/rss/articles/CBMi")
         assert result == ""
@@ -3109,7 +3109,7 @@ class TestIsValidImageUrlLongGif:
 # ---------------------------------------------------------------------------
 class TestFetchOgImageSSRF:
     def test_private_url_returns_empty(self):
-        with patch("common.enrichment.is_private_url", return_value=True):
+        with patch("common.enrichment_network.is_private_url", return_value=True):
             result = _fetch_og_image("https://internal.corp/image")
         assert result == ""
 
@@ -3122,8 +3122,8 @@ class TestFetchOgImageSSRF:
 # Lines 560-561: _fetch_og_image — non-http og:image scheme rejected
 # ---------------------------------------------------------------------------
 class TestFetchOgImageNonHttpScheme:
-    @patch("common.enrichment.is_private_url", return_value=False)
-    @patch("common.enrichment.requests.get")
+    @patch("common.enrichment_network.is_private_url", return_value=False)
+    @patch("common.enrichment_network.requests.get")
     def test_relative_image_url_skipped_falls_through(self, mock_get, _mock_priv):  # noqa: PT019
         # og:image with relative URL → skipped → function returns ""
         html = (

--- a/tests/test_pattern_parity.py
+++ b/tests/test_pattern_parity.py
@@ -3,7 +3,9 @@
 Pins the contract that ``scripts/common/summary_quality.ARTICLE_SPECIFIC_RE``
 is the **single source of truth** consumed by:
 
-- ``scripts/common/enrichment.py`` — accesses via ``_summary_quality_mod.ARTICLE_SPECIFIC_RE``
+- ``scripts/common/enrichment_network.py`` — accesses via ``_summary_quality_mod.ARTICLE_SPECIFIC_RE``
+  (``_is_low_information_fragment`` moved here from ``enrichment.py`` in the P2-A
+  facade split; the facade re-exports it for backward compat)
 - ``scripts/fix_post_descriptions.py`` — accesses via ``_summary_quality_mod.ARTICLE_SPECIFIC_RE``
 
 If a stale local ``_ARTICLE_SPECIFIC_RE = re.compile(...)`` is re-introduced
@@ -28,7 +30,7 @@ if str(_SCRIPTS_DIR) not in sys.path:
 
 import fix_post_descriptions as _fix_post_descriptions_mod  # noqa: E402
 
-from common import enrichment as _enrichment_mod  # noqa: E402
+from common import enrichment_network as _enrichment_network_mod  # noqa: E402
 from common import summary_quality as _summary_quality_mod  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -89,10 +91,10 @@ _SAMPLE_IDS = [s[0] for s in SAMPLES]
 # 1. Identity: every consumer must point to the same compiled pattern object.
 # ---------------------------------------------------------------------------
 def test_enrichment_uses_canonical_pattern_object() -> None:
-    """enrichment.py's facade reference must resolve to the canonical object."""
-    facade_re = _enrichment_mod._summary_quality_mod.ARTICLE_SPECIFIC_RE
+    """enrichment_network.py's reference must resolve to the canonical object."""
+    facade_re = _enrichment_network_mod._summary_quality_mod.ARTICLE_SPECIFIC_RE
     assert facade_re is _summary_quality_mod.ARTICLE_SPECIFIC_RE, (
-        "enrichment.py references a different ARTICLE_SPECIFIC_RE object — "
+        "enrichment_network.py references a different ARTICLE_SPECIFIC_RE object — "
         "indicates a stale local _ARTICLE_SPECIFIC_RE was re-introduced."
     )
 
@@ -112,7 +114,7 @@ def test_fix_post_descriptions_uses_canonical_pattern_object() -> None:
 #    a tightly-scoped AST walk catches every real definition.
 # ---------------------------------------------------------------------------
 _CONSUMER_PATHS = [
-    _SCRIPTS_DIR / "common" / "enrichment.py",
+    _SCRIPTS_DIR / "common" / "enrichment_network.py",
     _SCRIPTS_DIR / "fix_post_descriptions.py",
 ]
 
@@ -156,7 +158,7 @@ def test_canonical_pattern_matches_sample(label: str, sample: str, expected: boo
 def test_consumers_match_in_parity_with_facade(label: str, sample: str, expected: bool) -> None:
     """Facade, enrichment, and fix_post_descriptions must agree on every sample."""
     via_facade = bool(_summary_quality_mod.ARTICLE_SPECIFIC_RE.search(sample))
-    via_enrichment = bool(_enrichment_mod._summary_quality_mod.ARTICLE_SPECIFIC_RE.search(sample))
+    via_enrichment = bool(_enrichment_network_mod._summary_quality_mod.ARTICLE_SPECIFIC_RE.search(sample))
     via_fix = bool(_fix_post_descriptions_mod._summary_quality_mod.ARTICLE_SPECIFIC_RE.search(sample))
     assert via_facade == via_enrichment == via_fix, (
         f"[{label}] parity broken — facade={via_facade}, enrichment={via_enrichment}, fix={via_fix}: {sample!r}"


### PR DESCRIPTION
## 개요
`docs/refactoring-plan-2026-07.md` §1 (P2-A)에 따라 `common/enrichment.py` 파사드의 네트워크 코어를 `common/enrichment_network.py`로 단계적 분리. 파사드는 전 심볼을 재-export하여 하위호환 유지(`from common.enrichment import ...` 호출부 무변경). `__all__` 불변(12).

## 배치별 변경
- **batch 1 (`32c1f81e5`)** — leaf 이동: 함수 8(`is_private_url`, `_clean_meta_description`, `_is_low_information_fragment`, `_decode_google_news_base64`, `_extract_og_metadata`, `_extract_via_{readability,bs4_article,paragraphs}`) + 상수 8. 순환 import 방지를 위해 두 헬퍼를 추출기와 동반 이동(critic 정정 §1.1).
- **batch 2 (`cb0d8738b`)** — resolver 체인: `_resolve_google_news_url`/`_inner`, `_resolve_via_gnewsdecoder`, `_fetch_og_image` + 부수 `_VERIFY_SSL`/`_get_verify_ssl`.
- **batch 3 (`f3afd3f82`)** — `fetch_page_metadata` 이동(byte-identical) + `_resolve_google_news_url` 6/2 split 완성. 파사드의 orphan된 `import requests`·encoding_guard import 제거(batch 4 조기 충족). `fetch_page_description`·`_fetch_and_parse_page`는 파사드 유지(Correction A).
- **docstring (`1638a399c`)** — `_resolve_google_news_url_inner` docstring hop-count 정정(3→5, pre-existing 드리프트).

## @patch 재배치 원칙 (핵심)
심볼이 아니라 **"호출자"가 이동한 배치에서** `@patch`을 `common.enrichment.*` → `common.enrichment_network.*`로 재배치. 재-export 바인딩은 facade 네임스페이스에서 해석되므로, 호출자가 facade에 남으면 facade patch가 여전히 유효.

## 검증
- 순차 배치마다 게이트 그린: import 무순환 / **715 passed** / ruff clean / basedpyright 0 errors.
- **@patch 정확성 검증**: `tests/conftest.py`의 autouse `_block_real_http` 가드 하에서 inert mock은 실HTTP→즉시 실패. 순수 함수(`is_private_url`)는 HTTP 미경유라 리뷰어가 `mock.called`(facade `.called==False` / network `.called==True`)로 별도 실증.
- 각 배치 독립 코드리뷰(Opus) APPROVE — 호출그래프 추적 + REPL 네임스페이스 실증, `fetch_page_metadata`는 byte-identical 이동 확인.

## 테스트 플랜
- [x] `python3 -c "import common.enrichment; import common.enrichment_network"` (무순환)
- [x] `pytest tests/test_enrichment*.py tests/test_rss_fetcher*.py tests/test_pattern_parity.py tests/test_import_compatibility.py` → 715 passed
- [x] `ruff check` + `ruff format --check` + `basedpyright` 클린
- [ ] CI 전체 스위트 + 커버리지 게이트 (PR CI에서 확인)

## 잔여/후속
- 알려진 out-of-scope LOW: `tests/test_rss_fetcher_extended.py:520`의 redundant `common.enrichment.is_private_url` 데코레이터(pre-existing, false-green 아님) — 별도 정리 대상.
- batch 4(정리)는 facade `import requests` 제거가 batch 3에서 조기 충족되어 잔여 작업 최소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)