### PR TITLE
test: worldmonitor 프록시 테스트 이중 is_private_url patch 필요성 문서화 (P2-A batch 4 마무리)

### DIFF
--- a/tests/test_rss_fetcher_extended.py
+++ b/tests/test_rss_fetcher_extended.py
@@ -517,6 +517,13 @@ class TestResolveGoogleNewsUrl:
 class TestFetchRssFeedUncoveredBranches:
     """Covers remaining uncovered branches in fetch_rss_feed."""
 
+    # Both is_private_url patches are load-bearing (NOT redundant): the
+    # ``common.enrichment.is_private_url`` patch covers the lazy
+    # ``from .enrichment import is_private_url`` guard in fetch_rss_feed's
+    # worldmonitor-proxy branch (rss_fetcher.py:~177), which runs on the DECODED
+    # candidate URL; the ``common.rss_fetcher.is_private_url`` patch covers the
+    # per-candidate guard in the fetch loop. Dropping either makes the decoded/
+    # candidate URL hit the real resolver (real DNS → non-hermetic).
     @patch("common.enrichment.is_private_url", return_value=False)
     @patch("common.rss_fetcher.is_private_url", return_value=False)
     @patch("common.rss_fetcher.requests.get")


### PR DESCRIPTION
## 개요
P2-A(enrichment 분리, #1057 머지 완료) 마무리 작업. **기능 변경 없음** — 테스트 주석 1건만 추가.

## 배경
batch-3 리뷰가 `tests/test_rss_fetcher_extended.py`의 `@patch("common.enrichment.is_private_url")`를 "redundant"로 표기했으나, 실증 결과 **load-bearing**:
- `fetch_rss_feed`의 worldmonitor-proxy 분기가 decoded 후보 URL에 대해 lazy `from .enrichment import is_private_url`(`rss_fetcher.py:~177`)로 SSRF 가드.
- 이 patch 제거 시 decoded URL이 실제 resolver(실 DNS 조회)를 타 테스트가 비-hermetic해짐.
- 실증: mock `.called == True`, call args `('https://actual-source.example.com/feed.rss',)`.

→ 제거 대신 두 patch의 역할을 주석으로 명시해 향후 잘못된 cleanup을 방지.

## batch 4 검증 결론 (코드 변경 불필요)
- **이동 판단**: `fetch_page_description`·`_fetch_and_parse_page`는 facade 유지 = 설계된 end-state. facade=오케스트레이션, enrichment_network=네트워크 코어. `_fetch_and_parse_page`는 `@patch("common.enrichment.fetch_page_metadata")`+enrich_item 테스트에 밀결합(Correction A). 추가 이동 불필요.
- **`__all__`**: 12개 불변.
- **커버리지**: `enrichment.py` 98% / `enrichment_network.py` 99% / images·synthetic 100% — 재-export 설계로 회귀 없음.
- **batch 4 requests 제거**: batch 3(#1057)에서 조기 완료됨.

## 테스트 플랜
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/test_rss_fetcher_extended.py::TestFetchRssFeedUncoveredBranches` → 10 passed
- [x] 이중 patch load-bearing 실증(mock.called=True)

🤖 Generated with [Claude Code](https://claude.com/claude-code)