### PR TITLE
fix(gitleaks): generic-api-key 오탐 정합화 — _posts CDN 이미지 token allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,34 +7,48 @@ title = "investing-dragon gitleaks config"
 useDefault = true
 
 # ---------------------------------------------------------------------------
-# Allowlist: linkedin-client-secret false positive on translation cache.
+# Allowlist: false positives on auto-generated, public-data-only files.
 # ---------------------------------------------------------------------------
-# Why:
-#   The linkedin-client-secret rule is a low-entropy 16-char alphanumeric
-#   pattern that fires on any token containing "LinkedIn" plus nearby
-#   characters. _state/translation_cache.json holds MT translations of news
-#   headlines that frequently reference LinkedIn (e.g., LinkedIn posts about
-#   bitcoin / KOSPI / IPO). These are not credentials.
+# Two distinct false positives, both on files that only ever contain public,
+# machine-generated content (never credentials):
 #
-# Why narrow (rule + path):
-#   - Path-only allowlist on the whole _state/ tree would drop scanning of an
-#     attacker-influenced surface (collectors ingest external RSS / API bodies
-#     into _state/translation_cache.json).
-#   - Rule-only allowlist would unsuppress real linkedin-client-secret leaks
-#     if they ever land in a different file.
-#   The two-condition allowlist (targetRules + paths) fires only when BOTH
-#   match — narrowest viable suppression. All other ~100 gitleaks rules stay
-#   active on _state/.
+#   1. linkedin-client-secret on _state/translation_cache.json
+#      A low-entropy 16-char alphanumeric pattern that fires on any token
+#      containing "LinkedIn" plus nearby characters. The translation cache
+#      holds MT translations of news headlines that frequently reference
+#      LinkedIn (e.g., posts about bitcoin / KOSPI / IPO).
 #
-# v8 compatibility:
-#   Tested locally with gitleaks v8.24.2 (CI) and v8.30.1. Uses the global
-#   [allowlist] (singular) form which is the most portable across v8.x and
-#   honors `targetRules` filtering since v8.18.
+#   2. generic-api-key on _posts/*.md
+#      Auto-generated news digests embed news-source thumbnail images as
+#      <img src="https://image-api.prod.kitco.com/...&token=<sig>">. The
+#      `token=` query param is a public image-signing token in the source
+#      URL, not a credential. generic-api-key flags the `token=` assignment.
 #
-# Verify:
+# Scope + tradeoff (single global [allowlist] is the only v8.24.2-compatible
+# form — see below):
+#   - targetRules gates suppression to exactly these two low-precision rules;
+#     all other ~100 rules (AWS, GCP, Slack, GitHub PAT, ...) stay fully active
+#     everywhere, including on both paths listed here.
+#   - paths conditions are OR'd within the single allowlist, so each of the two
+#     rules is technically suppressed on both paths (not just its own). This is
+#     an accepted, negligible loosening: both files are auto-generated from
+#     public RSS/API data and never carry real secrets. Per-rule path scoping
+#     would require [[rules.allowlists]] blocks, which cannot attach to
+#     useDefault rules without redefining them.
+#
+# v8 compatibility (IMPORTANT):
+#   Must use the singular global [allowlist] with targetRules. The plural
+#   [[allowlists]] form is BROKEN in gitleaks v8.24.2 (the CI-pinned version):
+#   its targetRules filtering regresses and it reported 817 findings in an
+#   empirical test on this repo. Verified working with v8.24.2 (CI) here.
+#
+# Verify (v8.24.2 = CI version):
 #   gitleaks detect --source . --config .gitleaks.toml --no-banner --redact
 #   → expect "no leaks found".
 [allowlist]
-description = "linkedin-client-secret false positive on translated headlines that quote LinkedIn"
-targetRules = ["linkedin-client-secret"]
-paths = ['''_state/translation_cache\.json''']
+description = "false positives on auto-generated public data (translation cache + post CDN image tokens)"
+targetRules = ["linkedin-client-secret", "generic-api-key"]
+paths = [
+  '''_state/translation_cache\.json''',
+  '''_posts/.*\.md''',
+]


### PR DESCRIPTION
## 배경

`gitleaks detect --source .`(security-scan.yml, git-history 전체 스캔)가 `_posts/*.md`의 자동 생성 뉴스 다이제스트에 임베드된 뉴스 소스 썸네일 이미지 URL을 `generic-api-key` 룰로 **13건 오탐**하고 있었습니다.

```
<img src="https://image-api.prod.kitco.com/image/....png?...&token=<서명>">
```

`token=` query 파라미터는 이미지 CDN의 **공개 서명 토큰**(URL에 노출되는 값)이며 자격증명이 아닙니다. PR과 무관하게 git-history 전체 스캔에서 상시 재현되던 오탐입니다.

## 변경

기존 단일 `[allowlist]`에 `generic-api-key` 룰 + `_posts/*.md` 경로를 추가했습니다.

- **v8.24.2 호환**: 플러럴 `[[allowlists]]`는 CI 고정 버전(v8.24.2)에서 `targetRules` 필터링이 회귀 — 이번에도 실측 시 **817건 오탐**으로 악화되어 사용 불가. 단일 `[allowlist]`(singular) 형식 유지.
- **좁힘 원칙**: `targetRules`로 `linkedin-client-secret` / `generic-api-key` 두 저정밀 룰에만 게이트. 나머지 ~100개 룰(AWS/GCP/Slack/GitHub PAT 등)은 모든 경로에서 그대로 활성.
- **잔여 tradeoff**: 단일 allowlist 내 `paths`는 OR이라 두 룰이 두 경로 모두에서 억제됨. 두 파일 모두 공개 RSS/API 데이터 기반 자동 생성물이라 실제 시크릿을 담지 않으므로 무시 가능한 loosening (config 주석에 명시).

## 검증 (gitleaks v8.24.2 = CI 버전)

- 리포 전체 스캔(6313 commits, 1.82GB): **`no leaks found`** (오탐 13건 → 0건)
- 카나리 테스트:
  - `generic-api-key` (`token=`)를 `scripts/*.py`에 주입 → **탐지 유지** ✓
  - 같은 패턴을 `_posts/*.md`에 → **억제** ✓
  - `aws-access-token` 등 무관 룰 → **탐지 유지** ✓

## 관련

- wiki: `gitleaks-v8-24-2-gitleaks-toml.md`
- 선행 PR: #973 (translation_cache linkedin-client-secret allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)