### PR TITLE
test: 커버리지 게이트 70 ratchet + 저커버리지 결정적 모듈 헤드룸 확보

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -77,13 +77,13 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          python3 -m coverage report --fail-under=65
+          python3 -m coverage report --fail-under=70
           python3 -m coverage html -d coverage-html
           python3 -m coverage json -o coverage.json
 
       - name: Enforce summary_sections coverage floor
         # summary_sections.py carries the daily-summary rendering logic and has
-        # heavy test investment (~98%). The global 55%/65% floors are far too
+        # heavy test investment (~98%). The global 55%/70% floors are far too
         # low to catch a silent per-module regression, so pin a dedicated 95%
         # floor. If this drops intentionally, lower BOTH this number and the
         # constant in tests/test_summary_sections_coverage_floor.py.

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 48 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 117 |
+| 테스트 파일 (tests/test_*.py) | 123 |
 
 <!-- component-counts:end -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ quote-style = "double"
 relative_files = true
 
 [tool.pytest.ini_options]
-addopts = "--cov=scripts --cov-fail-under=65"
+addopts = "--cov=scripts --cov-fail-under=70"
 # 베어 `pytest` 가 Jekyll 빌드 산출물(_site/) 내 복사된 테스트를 수집해
 # ImportError 로 깨지던 문제 방지. CI 는 명시적으로 `pytest tests/` 를 호출하므로 영향 없음.
 testpaths = ["tests"]

--- a/tests/test_check_relative_imports.py
+++ b/tests/test_check_relative_imports.py
@@ -1,0 +1,73 @@
+"""tests/test_check_relative_imports.py — check_relative_imports 단위 테스트.
+
+``scripts/common/`` 내부의 절대 ``scripts.*`` import(PR #773 회귀)를 AST로
+탐지하는 pre-commit 훅. 정상/위반/읽기 오류/구문 오류 경로와 CLI 종료 코드를
+결정적으로 구동한다.
+"""
+
+import check_relative_imports as cri
+
+# ---------------------------------------------------------------------------
+# _check_file
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFile:
+    def test_clean_file_has_no_violations(self, tmp_path):
+        f = tmp_path / "clean.py"
+        f.write_text("from .config import setup_logging\nimport os\n", encoding="utf-8")
+        assert cri._check_file(str(f)) == []
+
+    def test_detects_import_from_scripts(self, tmp_path):
+        f = tmp_path / "bad.py"
+        f.write_text("from scripts.common.config import x\n", encoding="utf-8")
+        violations = cri._check_file(str(f))
+        assert len(violations) == 1
+        assert "from scripts.common.config import" in violations[0]
+
+    def test_detects_plain_import_scripts(self, tmp_path):
+        f = tmp_path / "bad2.py"
+        f.write_text("import scripts.common.utils\n", encoding="utf-8")
+        violations = cri._check_file(str(f))
+        assert len(violations) == 1
+        assert "import scripts.common.utils" in violations[0]
+
+    def test_unreadable_file_reports_error(self, tmp_path):
+        missing = tmp_path / "ghost.py"
+        violations = cri._check_file(str(missing))
+        assert len(violations) == 1
+        assert "could not read file" in violations[0]
+
+    def test_syntax_error_is_ignored(self, tmp_path):
+        f = tmp_path / "broken.py"
+        f.write_text("def (:\n", encoding="utf-8")  # invalid syntax
+        assert cri._check_file(str(f)) == []
+
+    def test_docstring_example_not_flagged(self, tmp_path):
+        # docstring 안의 예시는 AST import 노드가 아니므로 위반 아님.
+        f = tmp_path / "doc.py"
+        f.write_text('"""example: from scripts.common.x import y"""\n', encoding="utf-8")
+        assert cri._check_file(str(f)) == []
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_clean_returns_0(self, tmp_path):
+        f = tmp_path / "clean.py"
+        f.write_text("from .config import x\n", encoding="utf-8")
+        assert cri.main(["prog", str(f)]) == 0
+
+    def test_violation_returns_1(self, tmp_path, capsys):
+        f = tmp_path / "bad.py"
+        f.write_text("from scripts.common.config import x\n", encoding="utf-8")
+        assert cri.main(["prog", str(f)]) == 1
+        err = capsys.readouterr().err
+        assert "absolute 'scripts.*' imports found" in err
+        assert "Fix: use relative imports" in err
+
+    def test_no_files_returns_0(self):
+        assert cri.main(["prog"]) == 0

--- a/tests/test_check_sitemap_local.py
+++ b/tests/test_check_sitemap_local.py
@@ -1,0 +1,94 @@
+"""tests/test_check_sitemap_local.py — check_sitemap_local 단위 테스트.
+
+빌드된 ``_site/sitemap.xml`` 의 각 ``<loc>`` URL이 디스크의 산출물과
+매핑되는지 검증하는 로컬 진단 도구. 순수 파서(``extract_locs``),
+URL→디스크 경로 변환(``url_to_disk_path``), 그리고 CLI(``main``)의
+성공/누락/미발견 종료 코드를 결정적으로 구동한다.
+"""
+
+from pathlib import Path
+
+import check_sitemap_local as csl
+
+_BASE = "https://investing.2twodragon.com"
+
+
+def _sitemap(directory, urls) -> Path:
+    body = "".join(f"<loc>{u}</loc>" for u in urls)
+    path = directory / "sitemap.xml"
+    path.write_text(f"<urlset>{body}</urlset>", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# extract_locs
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLocs:
+    def test_extracts_all(self, tmp_path):
+        sm = _sitemap(tmp_path, [f"{_BASE}/a/", f"{_BASE}/b/"])
+        assert csl.extract_locs(sm) == [f"{_BASE}/a/", f"{_BASE}/b/"]
+
+    def test_empty_sitemap(self, tmp_path):
+        sm = _sitemap(tmp_path, [])
+        assert csl.extract_locs(sm) == []
+
+
+# ---------------------------------------------------------------------------
+# url_to_disk_path
+# ---------------------------------------------------------------------------
+
+
+class TestUrlToDiskPath:
+    def test_trailing_slash_maps_to_index(self, tmp_path):
+        got = csl.url_to_disk_path(f"{_BASE}/foo/", _BASE, tmp_path)
+        assert got == tmp_path / "foo" / "index.html"
+
+    def test_file_path_direct(self, tmp_path):
+        got = csl.url_to_disk_path(f"{_BASE}/assets/x.png", _BASE, tmp_path)
+        assert got == tmp_path / "assets" / "x.png"
+
+    def test_root_maps_to_index(self, tmp_path):
+        got = csl.url_to_disk_path(_BASE, _BASE, tmp_path)
+        assert got == tmp_path / "index.html"
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def _run(self, monkeypatch, argv):
+        monkeypatch.setattr("sys.argv", ["check_sitemap_local.py", *argv])
+        return csl.main()
+
+    def test_missing_sitemap_returns_2(self, tmp_path, monkeypatch):
+        rc = self._run(monkeypatch, ["--site", str(tmp_path)])
+        assert rc == 2
+
+    def test_all_present_returns_0(self, tmp_path, monkeypatch):
+        (tmp_path / "foo").mkdir()
+        (tmp_path / "foo" / "index.html").write_text("ok", encoding="utf-8")
+        _sitemap(tmp_path, [f"{_BASE}/foo/"])
+        rc = self._run(monkeypatch, ["--site", str(tmp_path)])
+        assert rc == 0
+
+    def test_missing_file_returns_1(self, tmp_path, monkeypatch):
+        _sitemap(tmp_path, [f"{_BASE}/gone/"])
+        rc = self._run(monkeypatch, ["--site", str(tmp_path)])
+        assert rc == 1
+
+    def test_non_site_url_is_skipped(self, tmp_path, monkeypatch):
+        # 외부 URL은 스킵되므로 누락으로 집계되지 않아 성공(0).
+        _sitemap(tmp_path, ["https://example.com/other/"])
+        rc = self._run(monkeypatch, ["--site", str(tmp_path)])
+        assert rc == 0
+
+    def test_explicit_sitemap_arg(self, tmp_path, monkeypatch):
+        custom = _sitemap(tmp_path, [])
+        renamed = tmp_path / "custom-sitemap.xml"
+        custom.rename(renamed)
+        rc = self._run(monkeypatch, ["--site", str(tmp_path), "--sitemap", str(renamed)])
+        assert rc == 0

--- a/tests/test_component_counts.py
+++ b/tests/test_component_counts.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _MODULE_PATH = REPO_ROOT / "scripts" / "tools" / "component_counts.py"
 
@@ -42,3 +44,147 @@ def test_generated_doc_in_sync():
     counts = component_counts.compute_counts()
     drift = component_counts.check_targets(counts, [component_counts.DEFAULT_TARGET])
     assert drift == 0, "component-counts.md 드리프트 — --write 로 갱신 필요"
+
+
+# ---------------------------------------------------------------------------
+# render_table / _replace_block
+# ---------------------------------------------------------------------------
+
+_SAMPLE = {
+    "collectors": 1,
+    "generators": 2,
+    "common_modules": 3,
+    "workflows": 4,
+    "category_pages": 5,
+    "tests": 6,
+}
+
+
+class TestRenderTable:
+    def test_contains_markers_and_all_labels(self):
+        block = component_counts.render_table(_SAMPLE)
+        assert block.startswith(component_counts.START_MARKER)
+        assert block.rstrip().endswith(component_counts.END_MARKER)
+        # 각 라벨이 자신의 값과 같은 행에 렌더되는지 확인 (라벨↔값 매핑 오라클).
+        for key, label in component_counts._LABELS.items():
+            assert f"| {label} | {_SAMPLE[key]} |" in block
+
+
+class TestReplaceBlock:
+    def test_replaces_between_markers(self):
+        text = f"before\n{component_counts.START_MARKER}\nOLD\n{component_counts.END_MARKER}\nafter"
+        out = component_counts._replace_block(text, "NEWBLOCK")
+        assert out == "before\nNEWBLOCK\nafter"
+
+    def test_raises_without_markers(self):
+        with pytest.raises(ValueError, match="마커"):
+            component_counts._replace_block("no markers here", "X")
+
+
+# ---------------------------------------------------------------------------
+# write_targets
+# ---------------------------------------------------------------------------
+
+
+class TestWriteTargets:
+    @pytest.fixture(autouse=True)
+    def _repo_root(self, tmp_path, monkeypatch):
+        # write/check 함수는 출력용으로 target.relative_to(REPO_ROOT) 를 호출하므로
+        # tmp 타깃이 REPO_ROOT 하위에 있도록 REPO_ROOT 를 tmp_path 로 고정한다.
+        monkeypatch.setattr(component_counts, "REPO_ROOT", tmp_path)
+
+    def test_updates_existing_marker_block(self, tmp_path, capsys):
+        target = tmp_path / "doc.md"
+        target.write_text(
+            f"# Doc\n{component_counts.START_MARKER}\nstale\n{component_counts.END_MARKER}\n",
+            encoding="utf-8",
+        )
+        component_counts.write_targets(_SAMPLE, [target])
+        text = target.read_text(encoding="utf-8")
+        assert "stale" not in text
+        assert "| 6 |" in text
+        assert "updated" in capsys.readouterr().out
+
+    def test_creates_default_target_when_missing(self, tmp_path, monkeypatch, capsys):
+        fake_default = tmp_path / "docs" / "component-counts.md"
+        monkeypatch.setattr(component_counts, "DEFAULT_TARGET", fake_default)
+        component_counts.write_targets(_SAMPLE, [fake_default])
+        assert fake_default.is_file()
+        body = fake_default.read_text(encoding="utf-8")
+        assert component_counts.START_MARKER in body
+        assert "created" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# check_targets
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTargets:
+    @pytest.fixture(autouse=True)
+    def _repo_root(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(component_counts, "REPO_ROOT", tmp_path)
+
+    def test_ok_when_synced(self, tmp_path, capsys):
+        target = tmp_path / "doc.md"
+        target.write_text(f"# Doc\n{component_counts.render_table(_SAMPLE)}\n", encoding="utf-8")
+        assert component_counts.check_targets(_SAMPLE, [target]) == 0
+        assert "OK:" in capsys.readouterr().out
+
+    def test_drift_when_stale(self, tmp_path, capsys):
+        target = tmp_path / "doc.md"
+        target.write_text(
+            f"# Doc\n{component_counts.START_MARKER}\nstale\n{component_counts.END_MARKER}\n",
+            encoding="utf-8",
+        )
+        assert component_counts.check_targets(_SAMPLE, [target]) == 1
+        assert "DRIFT:" in capsys.readouterr().out
+
+    def test_missing_target(self, tmp_path, capsys):
+        target = tmp_path / "nope.md"
+        assert component_counts.check_targets(_SAMPLE, [target]) == 1
+        assert "MISSING:" in capsys.readouterr().out
+
+    def test_no_markers(self, tmp_path, capsys):
+        target = tmp_path / "doc.md"
+        target.write_text("no markers at all", encoding="utf-8")
+        assert component_counts.check_targets(_SAMPLE, [target]) == 1
+        assert "NO MARKERS" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_json_output(self, capsys):
+        assert component_counts.main(["--json"]) == 0
+        import json
+
+        parsed = json.loads(capsys.readouterr().out)
+        assert set(parsed) == set(_SAMPLE)
+
+    def test_default_table_output(self, capsys):
+        assert component_counts.main([]) == 0
+        assert component_counts.START_MARKER in capsys.readouterr().out
+
+    def test_write_then_check_roundtrip(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(component_counts, "REPO_ROOT", tmp_path)
+        target = tmp_path / "doc.md"
+        target.write_text(
+            f"# Doc\n{component_counts.START_MARKER}\nstale\n{component_counts.END_MARKER}\n",
+            encoding="utf-8",
+        )
+        assert component_counts.main(["--write", str(target)]) == 0
+        capsys.readouterr()
+        assert component_counts.main(["--check", str(target)]) == 0
+
+    def test_check_returns_1_on_drift(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(component_counts, "REPO_ROOT", tmp_path)
+        target = tmp_path / "doc.md"
+        target.write_text(
+            f"{component_counts.START_MARKER}\nstale\n{component_counts.END_MARKER}\n",
+            encoding="utf-8",
+        )
+        assert component_counts.main(["--check", str(target)]) == 1

--- a/tests/test_coverage_floor_guard.py
+++ b/tests/test_coverage_floor_guard.py
@@ -9,13 +9,13 @@ at or above :data:`_MIN_FLOOR`:
 * ``.github/workflows/code-quality.yml`` — a dedicated
   ``coverage report --fail-under=NN`` step re-checks the same data in CI.
 
-Total ``scripts`` coverage sits ~68% (2026-07); the floor was ratcheted
-55 -> 65 (P3-1/P3-2) to lock the existing coverage as a regression baseline.
-Without this guard the floor could be quietly dropped back — re-opening the gap
-between "tests deleted" and "build still green".
+Total ``scripts`` coverage sits ~70% (2026-07); the floor was ratcheted
+55 -> 65 (P3-1/P3-2) -> 70 (P3-3) to lock the existing coverage as a regression
+baseline. Without this guard the floor could be quietly dropped back —
+re-opening the gap between "tests deleted" and "build still green".
 
-Direction: floor is ``>=`` — ratcheting UP (65 -> 70 ...) stays green; only
-removing a gate or lowering it below 65 trips this test. If the floor is lowered
+Direction: floor is ``>=`` — ratcheting UP (70 -> 75 ...) stays green; only
+removing a gate or lowering it below 70 trips this test. If the floor is lowered
 intentionally, update ``_MIN_FLOOR`` here AND both ``--fail-under`` values
 together.
 
@@ -37,7 +37,7 @@ _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "code-quality.yml"
 
 # The global scripts coverage floor both gates must enforce.
-_MIN_FLOOR = 65
+_MIN_FLOOR = 70
 
 _COV_FAIL_UNDER_RE = re.compile(r"--cov-fail-under=(\d+)")
 _FAIL_UNDER_RE = re.compile(r"--fail-under=(\d+)")

--- a/tests/test_fix_post_number_format.py
+++ b/tests/test_fix_post_number_format.py
@@ -1,0 +1,124 @@
+"""tests/test_fix_post_number_format.py — fix_post_number_format 단위 테스트.
+
+유럽식 숫자 포맷(``BTC$71.018,21``)을 미국식(``BTC $71,018.21``)으로
+치환하는 순수 로직(``_fix_content``)과 mtime 기반 스캔(``scan_posts``),
+그리고 dry-run/apply CLI 경로(``main``)를 결정적으로 구동한다.
+"""
+
+import os
+import time
+from datetime import UTC, datetime
+
+import fix_post_number_format as fpnf
+
+# ---------------------------------------------------------------------------
+# _fix_content
+# ---------------------------------------------------------------------------
+
+
+class TestFixContent:
+    def test_prefixed_amount(self):
+        out, n = fpnf._fix_content("가격 BTC$71.018,21 상승")
+        assert out == "가격 BTC $71,018.21 상승"
+        assert n == 1
+
+    def test_bare_dollar_amount(self):
+        out, n = fpnf._fix_content("무려 $71.018,21 도달")
+        assert out == "무려 $71,018.21 도달"
+        assert n == 1
+
+    def test_no_double_substitution(self):
+        # 패턴1 치환 결과가 패턴2에 다시 걸리지 않아야 한다(총 1건).
+        out, n = fpnf._fix_content("ETH$3.456,78")
+        assert out == "ETH $3,456.78"
+        assert n == 1
+
+    def test_already_us_format_untouched(self):
+        text = "정상 $71,018.21 값"
+        out, n = fpnf._fix_content(text)
+        assert out == text
+        assert n == 0
+
+    def test_multiple_occurrences(self):
+        out, n = fpnf._fix_content("$1.234,56 그리고 BTC$9.999,00")
+        assert n == 2
+        assert "$1,234.56" in out
+        assert "BTC $9,999.00" in out
+
+
+# ---------------------------------------------------------------------------
+# _post_mtime / scan_posts
+# ---------------------------------------------------------------------------
+
+
+class TestScanPosts:
+    def _write(self, directory, name, *, age_days=0):
+        path = directory / name
+        path.write_text("dummy", encoding="utf-8")
+        if age_days:
+            old = time.time() - age_days * 86400
+            os.utime(path, (old, old))
+        return path
+
+    def test_post_mtime_is_utc(self, tmp_path):
+        p = self._write(tmp_path, "2026-01-01-a.md")
+        mt = fpnf._post_mtime(p)
+        assert isinstance(mt, datetime)
+        assert mt.tzinfo == UTC
+
+    def test_filters_by_age(self, tmp_path):
+        self._write(tmp_path, "2026-01-01-fresh.md", age_days=1)
+        self._write(tmp_path, "2026-01-01-stale.md", age_days=90)
+        found = fpnf.scan_posts(tmp_path, days=30)
+        names = [p.name for p in found]
+        assert "2026-01-01-fresh.md" in names
+        assert "2026-01-01-stale.md" not in names
+
+    def test_returns_sorted(self, tmp_path):
+        self._write(tmp_path, "2026-01-03-c.md")
+        self._write(tmp_path, "2026-01-01-a.md")
+        self._write(tmp_path, "2026-01-02-b.md")
+        found = fpnf.scan_posts(tmp_path, days=30)
+        assert [p.name for p in found] == sorted(p.name for p in found)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def _run(self, monkeypatch, argv):
+        monkeypatch.setattr("sys.argv", ["fix_post_number_format.py", *argv])
+        return fpnf.main()
+
+    def test_missing_dir_returns_2(self, tmp_path, monkeypatch, capsys):
+        missing = tmp_path / "nope"
+        rc = self._run(monkeypatch, ["--posts-dir", str(missing)])
+        assert rc == 2
+        assert "찾을 수 없습니다" in capsys.readouterr().err
+
+    def test_dry_run_does_not_write(self, tmp_path, monkeypatch, capsys):
+        post = tmp_path / "2026-01-01-x.md"
+        post.write_text("BTC$71.018,21", encoding="utf-8")
+        rc = self._run(monkeypatch, ["--posts-dir", str(tmp_path)])
+        assert rc == 0
+        assert post.read_text(encoding="utf-8") == "BTC$71.018,21"
+        out = capsys.readouterr().out
+        assert "DRY-RUN" in out
+        assert "예정" in out
+
+    def test_apply_writes_changes(self, tmp_path, monkeypatch, capsys):
+        post = tmp_path / "2026-01-01-x.md"
+        post.write_text("BTC$71.018,21", encoding="utf-8")
+        rc = self._run(monkeypatch, ["--posts-dir", str(tmp_path), "--apply"])
+        assert rc == 0
+        assert post.read_text(encoding="utf-8") == "BTC $71,018.21"
+        assert "수정됨" in capsys.readouterr().out
+
+    def test_apply_no_matches_is_noop(self, tmp_path, monkeypatch, capsys):
+        post = tmp_path / "2026-01-01-clean.md"
+        post.write_text("정상 텍스트 $1,234.56", encoding="utf-8")
+        rc = self._run(monkeypatch, ["--posts-dir", str(tmp_path), "--apply"])
+        assert rc == 0
+        assert "0개 파일 수정" in capsys.readouterr().out

--- a/tests/test_fix_scenario_na_placeholders.py
+++ b/tests/test_fix_scenario_na_placeholders.py
@@ -1,0 +1,87 @@
+"""tests/test_fix_scenario_na_placeholders.py — fix_scenario_na_placeholders 단위 테스트.
+
+시나리오 문장에 남은 ``(N/A)`` 아티팩트(``VIX(N/A)`` 등)를 제거하는
+순수 치환 로직(``_patch``)과 dry-run/apply CLI 경로(``main``)를 검증한다.
+"""
+
+import fix_scenario_na_placeholders as fix
+
+# ---------------------------------------------------------------------------
+# _patch
+# ---------------------------------------------------------------------------
+
+
+class TestPatch:
+    def test_strips_vix(self):
+        out, n = fix._patch("리스크는 VIX(N/A) 로 판단")
+        assert out == "리스크는 VIX 로 판단"
+        assert n == 1
+
+    def test_strips_momentum(self):
+        out, n = fix._patch("모멘텀(N/A) 우위")
+        assert out == "모멘텀 우위"
+        assert n == 1
+
+    def test_longer_greed_index_form(self):
+        out, n = fix._patch("공포·탐욕 지수(N/A) 기준")
+        assert out == "공포·탐욕 지수 기준"
+        assert n == 1
+
+    def test_bare_greed_form(self):
+        out, n = fix._patch("공포·탐욕(N/A) 지표")
+        assert out == "공포·탐욕 지표"
+        assert n == 1
+
+    def test_no_placeholder_untouched(self):
+        text = "VIX 는 안정적"
+        out, n = fix._patch(text)
+        assert out == text
+        assert n == 0
+
+    def test_counts_all_replacements(self):
+        out, n = fix._patch("VIX(N/A) / 모멘텀(N/A)")
+        assert n == 2
+        assert "(N/A)" not in out
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def _run(self, monkeypatch, argv):
+        monkeypatch.setattr("sys.argv", ["fix_scenario_na_placeholders.py", *argv])
+        return fix.main()
+
+    def test_missing_dir_returns_2(self, tmp_path, monkeypatch, capsys):
+        rc = self._run(monkeypatch, ["--posts-dir", str(tmp_path / "nope")])
+        assert rc == 2
+        assert "not found" in capsys.readouterr().err
+
+    def test_dry_run_does_not_write(self, tmp_path, monkeypatch, capsys):
+        post = tmp_path / "2026-01-01-x.md"
+        post.write_text("리스크는 VIX(N/A)", encoding="utf-8")
+        rc = self._run(monkeypatch, ["--posts-dir", str(tmp_path)])
+        assert rc == 0
+        assert post.read_text(encoding="utf-8") == "리스크는 VIX(N/A)"
+        out = capsys.readouterr().out
+        assert "would fix" in out
+        assert "re-run with --apply" in out
+
+    def test_apply_writes_changes(self, tmp_path, monkeypatch, capsys):
+        post = tmp_path / "2026-01-01-x.md"
+        post.write_text("리스크는 VIX(N/A)", encoding="utf-8")
+        rc = self._run(monkeypatch, ["--posts-dir", str(tmp_path), "--apply"])
+        assert rc == 0
+        assert post.read_text(encoding="utf-8") == "리스크는 VIX"
+        out = capsys.readouterr().out
+        assert "fixed" in out
+        assert "applied" in out
+
+    def test_apply_no_matches_is_noop(self, tmp_path, monkeypatch, capsys):
+        post = tmp_path / "2026-01-01-clean.md"
+        post.write_text("깨끗한 본문", encoding="utf-8")
+        rc = self._run(monkeypatch, ["--posts-dir", str(tmp_path), "--apply"])
+        assert rc == 0
+        assert "files=0" in capsys.readouterr().out

--- a/tests/test_og_image_formats.py
+++ b/tests/test_og_image_formats.py
@@ -1,0 +1,127 @@
+"""Unit tests for the real conversion logic in ``common.og_image_formats``.
+
+기존 테스트(``test_generate_thumbnail``/``test_og_compose``)는
+``_convert_formats_parallel``/``_convert_to_webp``/``_convert_to_avif`` 를
+**mock 으로 대체**만 하고 실제 Pillow 변환 경로는 실행하지 않는다. 이 파일은
+그 실 로직을 직접 구동한다:
+
+1. ``_convert_to_webp``  — 정상 변환(True + .webp 생성) / PIL 부재(False) /
+   손상 입력 예외(False + warning)
+2. ``_convert_to_avif``  — 동일한 3분기
+3. ``_convert_formats_parallel`` — 스레드풀로 두 포맷 실제 생성
+
+Pillow(webp/avif)가 없으면 성공 경로만 skip 하고 나머지는 그대로 검증한다.
+"""
+
+import os
+
+import pytest
+
+import common.og_image_formats as fmt
+
+# ---------------------------------------------------------------------------
+# Capability probes
+# ---------------------------------------------------------------------------
+
+try:
+    from PIL import features as _pil_features
+
+    _WEBP_OK = fmt._PIL_AVAILABLE and _pil_features.check("webp")
+    _AVIF_OK = fmt._PIL_AVAILABLE and _pil_features.check("avif")
+except Exception:  # pragma: no cover - PIL 자체가 없는 환경
+    _WEBP_OK = False
+    _AVIF_OK = False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_real_png(directory, name: str = "og-sample.png") -> str:
+    """실제 디코딩 가능한 최소 PNG 파일을 만들고 절대 경로를 반환한다."""
+    from PIL import Image
+
+    path = directory / name
+    Image.new("RGB", (8, 8), (10, 20, 30)).save(str(path), "PNG")
+    return str(path)
+
+
+def _make_corrupt_png(directory, name: str = "og-broken.png") -> str:
+    """PNG 시그니처만 있고 디코딩 불가능한 손상 파일 경로를 반환한다."""
+    path = directory / name
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")  # 서명뿐 — IHDR 없음
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# _convert_to_webp
+# ---------------------------------------------------------------------------
+
+
+class TestConvertToWebp:
+    @pytest.mark.skipif(not _WEBP_OK, reason="Pillow WebP 지원 없음")
+    def test_success_creates_webp_and_returns_true(self, tmp_path):
+        png = _make_real_png(tmp_path)
+        assert fmt._convert_to_webp(png) is True
+        assert os.path.exists(png[:-4] + ".webp")
+
+    def test_returns_false_when_pil_unavailable(self, tmp_path, monkeypatch):
+        png = _make_corrupt_png(tmp_path)
+        monkeypatch.setattr(fmt, "PILImage", None)
+        assert fmt._convert_to_webp(png) is False
+        assert not os.path.exists(png[:-4] + ".webp")
+
+    @pytest.mark.skipif(not fmt._PIL_AVAILABLE, reason="Pillow 미설치")
+    def test_returns_false_on_corrupt_input(self, tmp_path, caplog):
+        png = _make_corrupt_png(tmp_path)
+        with caplog.at_level("WARNING", logger="og-image-gen"):
+            assert fmt._convert_to_webp(png) is False
+        assert any("WebP conversion failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _convert_to_avif
+# ---------------------------------------------------------------------------
+
+
+class TestConvertToAvif:
+    @pytest.mark.skipif(not _AVIF_OK, reason="Pillow AVIF 지원 없음")
+    def test_success_creates_avif_and_returns_true(self, tmp_path):
+        png = _make_real_png(tmp_path)
+        assert fmt._convert_to_avif(png) is True
+        assert os.path.exists(png[:-4] + ".avif")
+
+    def test_returns_false_when_pil_unavailable(self, tmp_path, monkeypatch):
+        png = _make_corrupt_png(tmp_path)
+        monkeypatch.setattr(fmt, "PILImage", None)
+        assert fmt._convert_to_avif(png) is False
+        assert not os.path.exists(png[:-4] + ".avif")
+
+    @pytest.mark.skipif(not fmt._PIL_AVAILABLE, reason="Pillow 미설치")
+    def test_returns_false_on_corrupt_input(self, tmp_path, caplog):
+        png = _make_corrupt_png(tmp_path)
+        with caplog.at_level("WARNING", logger="og-image-gen"):
+            assert fmt._convert_to_avif(png) is False
+        assert any("AVIF conversion failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _convert_formats_parallel
+# ---------------------------------------------------------------------------
+
+
+class TestConvertFormatsParallel:
+    @pytest.mark.skipif(not (_WEBP_OK and _AVIF_OK), reason="Pillow WebP+AVIF 지원 없음")
+    def test_creates_both_formats(self, tmp_path):
+        png = _make_real_png(tmp_path)
+        assert fmt._convert_formats_parallel(png) is None
+        assert os.path.exists(png[:-4] + ".webp")
+        assert os.path.exists(png[:-4] + ".avif")
+
+    def test_no_output_when_pil_unavailable(self, tmp_path, monkeypatch):
+        png = _make_corrupt_png(tmp_path)
+        monkeypatch.setattr(fmt, "PILImage", None)
+        assert fmt._convert_formats_parallel(png) is None
+        assert not os.path.exists(png[:-4] + ".webp")
+        assert not os.path.exists(png[:-4] + ".avif")

--- a/tests/test_postbuild_fix_feed_enclosures.py
+++ b/tests/test_postbuild_fix_feed_enclosures.py
@@ -1,0 +1,115 @@
+"""tests/test_postbuild_fix_feed_enclosures.py — postbuild_fix_feed_enclosures 단위 테스트.
+
+jekyll-feed가 항상 ``length="0"`` 으로 내보내는 RSS enclosure를 실제
+바이트 크기로 다시 쓰는 postbuild 픽서. 경로 매핑(``_resolve_local_path``,
+path-traversal 방어 포함), 실제 재작성(``fix_feed``), CLI(``main``)의
+없음/성공/누락 경로를 결정적으로 구동한다.
+"""
+
+import postbuild_fix_feed_enclosures as pfe
+
+
+def _enclosure(url, type_="audio/mpeg", length="0") -> str:
+    return f'<enclosure url="{url}" type="{type_}" length="{length}"/>'
+
+
+def _feed(directory, *tags) -> "object":
+    path = directory / "feed.xml"
+    path.write_text(f"<rss><channel>{''.join(tags)}</channel></rss>", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _resolve_local_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLocalPath:
+    def test_maps_relative_url_to_file(self, tmp_path):
+        (tmp_path / "assets").mkdir()
+        f = tmp_path / "assets" / "a.mp3"
+        f.write_bytes(b"xyz")
+        got = pfe._resolve_local_path(tmp_path, "/assets/a.mp3")
+        assert got == f.resolve()
+
+    def test_empty_path_returns_none(self, tmp_path):
+        assert pfe._resolve_local_path(tmp_path, "https://x.com/") is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert pfe._resolve_local_path(tmp_path, "/assets/missing.mp3") is None
+
+    def test_path_traversal_blocked(self, tmp_path):
+        # site_dir 밖을 가리키는 ../ 경로는 relative_to 검증에서 차단돼 None.
+        site = tmp_path / "site"
+        site.mkdir()
+        assert pfe._resolve_local_path(site, "/../secret.txt") is None
+
+
+# ---------------------------------------------------------------------------
+# fix_feed
+# ---------------------------------------------------------------------------
+
+
+class TestFixFeed:
+    def test_rewrites_length(self, tmp_path):
+        (tmp_path / "a.mp3").write_bytes(b"12345")  # 5 bytes
+        feed = _feed(tmp_path, _enclosure("/a.mp3", length="0"))
+        total, fixed, missing = pfe.fix_feed(feed, tmp_path)
+        assert (total, fixed, missing) == (1, 1, 0)
+        assert 'length="5"' in feed.read_text(encoding="utf-8")
+
+    def test_unchanged_when_already_correct(self, tmp_path):
+        (tmp_path / "a.mp3").write_bytes(b"1234")  # 4 bytes
+        feed = _feed(tmp_path, _enclosure("/a.mp3", length="4"))
+        total, fixed, missing = pfe.fix_feed(feed, tmp_path)
+        assert (total, fixed, missing) == (1, 0, 0)
+
+    def test_missing_file_counted(self, tmp_path):
+        feed = _feed(tmp_path, _enclosure("/gone.mp3", length="0"))
+        total, fixed, missing = pfe.fix_feed(feed, tmp_path)
+        assert (total, fixed, missing) == (1, 0, 1)
+        assert 'length="0"' in feed.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# _emit
+# ---------------------------------------------------------------------------
+
+
+def test_emit_writes_line(capsys):
+    pfe._emit("hello")
+    assert capsys.readouterr().out == "hello\n"
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_feed_not_found_returns_0(self, tmp_path):
+        assert pfe.main(["--site", str(tmp_path)]) == 0
+
+    def test_success_reports_counts(self, tmp_path, capsys):
+        (tmp_path / "a.mp3").write_bytes(b"12345")
+        _feed(tmp_path, _enclosure("/a.mp3", length="0"))
+        rc = pfe.main(["--site", str(tmp_path)])
+        assert rc == 0
+        assert "total=1 fixed=1" in capsys.readouterr().out
+
+    def test_missing_enclosure_warns(self, tmp_path, capsys):
+        _feed(tmp_path, _enclosure("/gone.mp3", length="0"))
+        rc = pfe.main(["--site", str(tmp_path)])
+        assert rc == 0
+        assert "missing=1" in capsys.readouterr().out
+
+    def test_explicit_feed_arg(self, tmp_path, capsys):
+        (tmp_path / "a.mp3").write_bytes(b"12345")
+        custom = tmp_path / "rss.xml"
+        custom.write_text(
+            f"<rss><channel>{_enclosure('/a.mp3', length='0')}</channel></rss>",
+            encoding="utf-8",
+        )
+        rc = pfe.main(["--site", str(tmp_path), "--feed", str(custom)])
+        assert rc == 0
+        assert 'length="5"' in custom.read_text(encoding="utf-8")


### PR DESCRIPTION
## 요약

`scripts` 전역 커버리지 게이트를 **65 → 70**으로 상향(ratchet)하고, 게이트가 baseline 노이즈(런당 ~1.3pt 변동)로 flaky-red 되지 않도록 저커버리지 결정적 모듈 6개에 단위 테스트를 추가해 raw 총계를 **71.04%**로 확보했습니다.

## 게이트 ratchet (3지점 동시 이동)

기존 3개 게이트를 동시에 옮겨 정합성 유지:
- `pyproject.toml`: `--cov-fail-under` 65 → 70
- `.github/workflows/code-quality.yml`: `--fail-under` 65 → 70
- `tests/test_coverage_floor_guard.py`: `_MIN_FLOOR` 65 → 70

> 게이트는 `>=` 방향이라 이후 71→75 상향은 그린 유지, 70 미만으로 내리거나 게이트 제거 시에만 guard가 red.

## 헤드룸 테스트 (모두 `tmp_path` 격리, 네트워크/모킹 없음)

| 모듈 | 커버리지 |
|------|----------|
| `fix_post_number_format` | 0 → 98% |
| `fix_scenario_na_placeholders` | 0 → 98% |
| `tools/check_sitemap_local` | 0 → 96% |
| `tools/postbuild_fix_feed_enclosures` | 0 → 95% |
| `tools/check_relative_imports` | 0 → 97% |
| `tools/component_counts` | 51 → 99% |
| `common/og_image_formats` | 실 변환 경로 테스트 추가 |

## 문서

테스트 파일 수 증가 → `docs/component-counts.md` 재생성(117 → 123).

## 검증

- ✅ **4904 passed** / 16 skipped / 0 failed (188s)
- ✅ 커버리지 **71.04%** (≥70 게이트, raw)
- ✅ `ruff check` + `ruff format --check` 통과

## Test plan

- [x] `python3 -m pytest -q --cov=scripts` → 71.04%, 게이트 통과
- [x] `python3 -m ruff check scripts/ tests/`
- [x] `python3 -m ruff format --check scripts/ tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
