### PR TITLE
test: 0% 커버리지 tools 모듈 3개 유닛 테스트 추가 (raw 71→73%)

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 52 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 136 |
+| 테스트 파일 (tests/test_*.py) | 139 |
 
 <!-- component-counts:end -->

--- a/tests/test_gsc_api.py
+++ b/tests/test_gsc_api.py
@@ -1,0 +1,360 @@
+"""tests/test_gsc_api.py — gsc_api 단위 테스트.
+
+Google Search Console API CLI. ``_require_googleapi``의 ImportError 분기는
+설치 여부에 의존하지 말고 ``sys.modules``에 ``None``을 심어 결정적으로
+강제한다(설치 상태와 무관하게 재현 가능). 인증이 필요한 경로는
+``_build_service``를 fake 서비스 객체로 교체해 네트워크 없이 검증한다.
+"""
+
+import json
+import sys
+
+import gsc_api as ga
+
+_SITE = "https://investing.2twodragon.com"
+
+
+class _Namespace:
+    """argparse.Namespace 대용 — 필요한 속성만 최소로 구성."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("GSC_SITE_URL", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _site_url
+# ---------------------------------------------------------------------------
+
+
+class TestSiteUrl:
+    def test_explicit_site_arg(self, monkeypatch):
+        _clean_env(monkeypatch)
+        args = _Namespace(site=f"{_SITE}/foo")
+        assert ga._site_url(args) == f"{_SITE}/foo/"
+
+    def test_explicit_site_arg_trailing_slash_preserved(self, monkeypatch):
+        _clean_env(monkeypatch)
+        args = _Namespace(site=f"{_SITE}/")
+        assert ga._site_url(args) == f"{_SITE}/"
+
+    def test_env_var_fallback(self, monkeypatch):
+        monkeypatch.setenv("GSC_SITE_URL", "https://example.com")
+        args = _Namespace(site=None)
+        assert ga._site_url(args) == "https://example.com/"
+
+    def test_default_site(self, monkeypatch):
+        _clean_env(monkeypatch)
+        args = _Namespace(site=None)
+        assert ga._site_url(args) == ga.DEFAULT_SITE_URL
+
+
+# ---------------------------------------------------------------------------
+# _emit
+# ---------------------------------------------------------------------------
+
+
+class TestEmit:
+    def test_default_blank_line(self, capsys):
+        ga._emit()
+        assert capsys.readouterr().out == "\n"
+
+    def test_writes_line_with_newline(self, capsys):
+        ga._emit("hello")
+        assert capsys.readouterr().out == "hello\n"
+
+
+# ---------------------------------------------------------------------------
+# _require_googleapi
+# ---------------------------------------------------------------------------
+
+
+class TestRequireGoogleapi:
+    def test_missing_dependency_exits_2(self, monkeypatch):
+        import pytest
+
+        # Force the ImportError branch deterministically regardless of whether
+        # google-api-python-client / google-auth happen to be installed in this
+        # venv: a ``None`` entry in sys.modules makes the import machinery raise
+        # ImportError even if the real package is importable.
+        monkeypatch.setitem(sys.modules, "google.oauth2", None)
+        monkeypatch.setitem(sys.modules, "googleapiclient.discovery", None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            ga._require_googleapi()
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# _build_service — auth/env preconditions
+# ---------------------------------------------------------------------------
+
+
+class TestBuildService:
+    def test_missing_env_exits_2(self, monkeypatch):
+        _clean_env(monkeypatch)
+        import pytest
+
+        with pytest.raises(SystemExit) as exc_info:
+            ga._build_service()
+        assert exc_info.value.code == 2
+
+    def test_missing_credentials_file_exits_2(self, monkeypatch, tmp_path):
+        _clean_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "gone.json"))
+        import pytest
+
+        with pytest.raises(SystemExit) as exc_info:
+            ga._build_service()
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# cmd_submit_sitemap — --confirm gate (no _build_service mock needed for
+# the without-confirm path since it returns before authenticating)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdSubmitSitemap:
+    def test_without_confirm_returns_1(self):
+        args = _Namespace(confirm=False, feedpath=f"{_SITE}/sitemap.xml", site=None)
+        assert ga.cmd_submit_sitemap(args) == 1
+
+    def test_with_confirm_calls_service(self, monkeypatch):
+        calls = {}
+
+        class _FakeSubmitCall:
+            def execute(self):
+                calls["executed"] = True
+
+        class _FakeSitemaps:
+            def submit(self, siteUrl, feedpath):
+                calls["siteUrl"] = siteUrl
+                calls["feedpath"] = feedpath
+                return _FakeSubmitCall()
+
+        class _FakeService:
+            def sitemaps(self):
+                return _FakeSitemaps()
+
+        monkeypatch.setattr(ga, "_build_service", lambda: _FakeService())
+        _clean_env(monkeypatch)
+        args = _Namespace(confirm=True, feedpath=f"{_SITE}/sitemap.xml", site=None)
+        rc = ga.cmd_submit_sitemap(args)
+        assert rc == 0
+        assert calls["executed"] is True
+        assert calls["feedpath"] == f"{_SITE}/sitemap.xml"
+
+
+# ---------------------------------------------------------------------------
+# cmd_sitemap_status
+# ---------------------------------------------------------------------------
+
+
+class _ExecuteWrapper:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def execute(self):
+        return self._payload
+
+
+class TestCmdSitemapStatus:
+    def test_empty_sitemaps(self, monkeypatch, capsys):
+        class _FakeSitemaps:
+            def list(self, siteUrl):
+                return _ExecuteWrapper({"sitemap": []})
+
+        class _FakeService:
+            def sitemaps(self):
+                return _FakeSitemaps()
+
+        monkeypatch.setattr(ga, "_build_service", lambda: _FakeService())
+        _clean_env(monkeypatch)
+        args = _Namespace(site=None)
+        rc = ga.cmd_sitemap_status(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No sitemaps registered" in out
+
+    def test_populated_with_missing_keys(self, monkeypatch, capsys):
+        payload = {
+            "sitemap": [
+                {
+                    "path": f"{_SITE}/sitemap.xml",
+                    "contents": [{"type": "web", "submitted": "10", "indexed": "8"}],
+                },
+                {
+                    "path": f"{_SITE}/other.xml",
+                    "type": "sitemap",
+                    "lastSubmitted": "2026-01-01",
+                    "isPending": False,
+                    "errors": 0,
+                    "warnings": 1,
+                },
+            ]
+        }
+
+        class _FakeSitemaps:
+            def list(self, siteUrl):
+                return _ExecuteWrapper(payload)
+
+        class _FakeService:
+            def sitemaps(self):
+                return _FakeSitemaps()
+
+        monkeypatch.setattr(ga, "_build_service", lambda: _FakeService())
+        _clean_env(monkeypatch)
+        args = _Namespace(site=None)
+        rc = ga.cmd_sitemap_status(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "(unknown)" in out  # missing 'type' on first entry
+        assert "(none)" in out  # missing 'lastSubmitted' on first entry
+        assert "web: submitted=10 indexed=8" in out
+        assert "2026-01-01" in out
+
+
+# ---------------------------------------------------------------------------
+# cmd_inspect
+# ---------------------------------------------------------------------------
+
+
+class TestCmdInspect:
+    def test_emits_formatted_json(self, monkeypatch, capsys):
+        resp = {"inspectionResult": {"indexStatusResult": {"verdict": "PASS"}}}
+
+        class _FakeInspectCall:
+            def execute(self):
+                return resp
+
+        class _FakeIndex:
+            def inspect(self, body):
+                assert body["inspectionUrl"] == f"{_SITE}/foo/"
+                return _FakeInspectCall()
+
+        class _FakeUrlInspection:
+            def index(self):
+                return _FakeIndex()
+
+        class _FakeService:
+            def urlInspection(self):
+                return _FakeUrlInspection()
+
+        monkeypatch.setattr(ga, "_build_service", lambda: _FakeService())
+        _clean_env(monkeypatch)
+        args = _Namespace(site=None, url=f"{_SITE}/foo/")
+        rc = ga.cmd_inspect(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert json.loads(out) == resp
+
+
+# ---------------------------------------------------------------------------
+# cmd_analytics
+# ---------------------------------------------------------------------------
+
+
+class TestCmdAnalytics:
+    def test_no_rows(self, monkeypatch, capsys):
+        class _FakeSearchAnalytics:
+            def query(self, siteUrl, body):
+                return _ExecuteWrapper({"rows": []})
+
+        class _FakeService:
+            def searchanalytics(self):
+                return _FakeSearchAnalytics()
+
+        monkeypatch.setattr(ga, "_build_service", lambda: _FakeService())
+        _clean_env(monkeypatch)
+        args = _Namespace(site=None, days=7, dimension="query", row_limit=25)
+        rc = ga.cmd_analytics(args)
+        assert rc == 0
+        assert "No data for" in capsys.readouterr().out
+
+    def test_populated_rows_formatting(self, monkeypatch, capsys):
+        payload = {
+            "rows": [
+                {"keys": ["bitcoin news"], "clicks": 12, "impressions": 340, "ctr": 0.0353, "position": 4.2},
+            ]
+        }
+
+        class _FakeSearchAnalytics:
+            def query(self, siteUrl, body):
+                return _ExecuteWrapper(payload)
+
+        class _FakeService:
+            def searchanalytics(self):
+                return _FakeSearchAnalytics()
+
+        monkeypatch.setattr(ga, "_build_service", lambda: _FakeService())
+        _clean_env(monkeypatch)
+        args = _Namespace(site=None, days=7, dimension="query", row_limit=25)
+        rc = ga.cmd_analytics(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Top 1 querys" in out
+        assert "bitcoin news" in out
+        assert "3.53%" in out
+
+
+# ---------------------------------------------------------------------------
+# main — dispatch wiring
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_dispatches_sitemap_status(self, monkeypatch):
+        called = {}
+
+        def _fake(args):
+            called["ok"] = "sitemap-status"
+            return 0
+
+        monkeypatch.setattr(ga, "cmd_sitemap_status", _fake)
+        rc = ga.main(["sitemap-status"])
+        assert rc == 0
+        assert called["ok"] == "sitemap-status"
+
+    def test_dispatches_inspect(self, monkeypatch):
+        called = {}
+
+        def _fake(args):
+            called["url"] = args.url
+            return 0
+
+        monkeypatch.setattr(ga, "cmd_inspect", _fake)
+        rc = ga.main(["inspect", f"{_SITE}/foo/"])
+        assert rc == 0
+        assert called["url"] == f"{_SITE}/foo/"
+
+    def test_dispatches_analytics(self, monkeypatch):
+        called = {}
+
+        def _fake(args):
+            called["days"] = args.days
+            called["dimension"] = args.dimension
+            called["row_limit"] = args.row_limit
+            return 0
+
+        monkeypatch.setattr(ga, "cmd_analytics", _fake)
+        rc = ga.main(["analytics", "--days", "3", "--dimension", "page", "--row-limit", "10"])
+        assert rc == 0
+        assert called == {"days": 3, "dimension": "page", "row_limit": 10}
+
+    def test_dispatches_submit_sitemap(self, monkeypatch):
+        called = {}
+
+        def _fake(args):
+            called["feedpath"] = args.feedpath
+            called["confirm"] = args.confirm
+            return 0
+
+        monkeypatch.setattr(ga, "cmd_submit_sitemap", _fake)
+        rc = ga.main(["submit-sitemap", f"{_SITE}/sitemap.xml", "--confirm"])
+        assert rc == 0
+        assert called == {"feedpath": f"{_SITE}/sitemap.xml", "confirm": True}

--- a/tests/test_indexnow_submit.py
+++ b/tests/test_indexnow_submit.py
@@ -1,0 +1,363 @@
+"""tests/test_indexnow_submit.py — indexnow_submit 단위 테스트.
+
+IndexNow URL 제출 도구. 실제 네트워크 호출(``_submit_batch``)과 git 서브
+프로세스(``urls_from_changed_posts``)는 항상 모킹한다. sitemap 파싱은
+로컬 파일 경로 분기만 검증하고, https 스킴 분기(실 urllib 경로)는
+의도적으로 건드리지 않는다.
+"""
+
+import subprocess
+import sys
+
+import indexnow_submit as idx
+
+_HOST = idx.HOST
+
+
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("INDEXNOW_KEY", raising=False)
+
+
+class _Namespace:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+# ---------------------------------------------------------------------------
+# _get_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetKey:
+    def test_cli_flag_wins(self, monkeypatch):
+        _clean_env(monkeypatch)
+        monkeypatch.setenv("INDEXNOW_KEY", "envkey")
+        args = _Namespace(key="clikey")
+        assert idx._get_key(args) == "clikey"
+
+    def test_env_var_fallback(self, monkeypatch):
+        monkeypatch.setenv("INDEXNOW_KEY", "envkey")
+        args = _Namespace(key="")
+        assert idx._get_key(args) == "envkey"
+
+    def test_default_key(self, monkeypatch):
+        _clean_env(monkeypatch)
+        args = _Namespace(key="")
+        assert idx._get_key(args) == idx._DEFAULT_KEY
+
+
+# ---------------------------------------------------------------------------
+# _validate_url
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrl:
+    def test_https_host_ok(self):
+        assert idx._validate_url(f"https://{_HOST}/foo/") is True
+
+    def test_http_host_ok(self):
+        assert idx._validate_url(f"http://{_HOST}/foo/") is True
+
+    def test_other_host_rejected(self):
+        assert idx._validate_url("https://example.com/foo/") is False
+
+    def test_host_substring_not_prefix_rejected(self):
+        assert idx._validate_url(f"https://evil-{_HOST}/foo/") is False
+
+
+# ---------------------------------------------------------------------------
+# _batch
+# ---------------------------------------------------------------------------
+
+
+class TestBatch:
+    def test_exact_multiple(self):
+        chunks = list(idx._batch([1, 2, 3, 4], 2))
+        assert chunks == [[1, 2], [3, 4]]
+
+    def test_remainder(self):
+        chunks = list(idx._batch([1, 2, 3], 2))
+        assert chunks == [[1, 2], [3]]
+
+    def test_empty(self):
+        assert list(idx._batch([], 2)) == []
+
+
+# ---------------------------------------------------------------------------
+# _permalink_from_post
+# ---------------------------------------------------------------------------
+
+
+class TestPermalinkFromPost:
+    def test_explicit_permalink(self, tmp_path):
+        p = tmp_path / "2026-07-27-daily-social-media-digest.md"
+        p.write_text(
+            '---\ntitle: "test"\npermalink: "/social-media/2026/07/27/daily-social-media-digest/"\n---\nbody',
+            encoding="utf-8",
+        )
+        assert idx._permalink_from_post(p) == f"https://{_HOST}/social-media/2026/07/27/daily-social-media-digest/"
+
+    def test_explicit_permalink_normalizes_trailing_slash(self, tmp_path):
+        p = tmp_path / "2026-07-27-foo.md"
+        p.write_text('---\npermalink: "/foo/bar"\n---\nbody', encoding="utf-8")
+        assert idx._permalink_from_post(p) == f"https://{_HOST}/foo/bar/"
+
+    def test_category_fallback(self, tmp_path):
+        p = tmp_path / "2026-07-27-crypto-roundup.md"
+        p.write_text("---\ncategories: [crypto-news]\n---\nbody", encoding="utf-8")
+        assert idx._permalink_from_post(p) == f"https://{_HOST}/crypto-news/2026/07/27/crypto-roundup/"
+
+    def test_no_categories_defaults_to_news(self, tmp_path):
+        p = tmp_path / "2026-07-27-plain-post.md"
+        p.write_text("---\ntitle: no categories here\n---\nbody", encoding="utf-8")
+        assert idx._permalink_from_post(p) == f"https://{_HOST}/news/2026/07/27/plain-post/"
+
+    def test_no_front_matter_falls_back_to_filename(self, tmp_path):
+        p = tmp_path / "2026-07-27-no-frontmatter.md"
+        p.write_text("just a body, no front matter", encoding="utf-8")
+        assert idx._permalink_from_post(p) == f"https://{_HOST}/news/2026/07/27/no-frontmatter/"
+
+    def test_malformed_filename_returns_none(self, tmp_path):
+        p = tmp_path / "not-a-dated-post.md"
+        p.write_text("---\ntitle: x\n---\nbody", encoding="utf-8")
+        assert idx._permalink_from_post(p) is None
+
+    def test_unreadable_file_returns_none(self, tmp_path):
+        missing = tmp_path / "2026-07-27-gone.md"
+        assert idx._permalink_from_post(missing) is None
+
+
+# ---------------------------------------------------------------------------
+# urls_from_recent_posts
+# ---------------------------------------------------------------------------
+
+
+class TestUrlsFromRecentPosts:
+    def test_returns_newest_n_sorted_desc(self, tmp_path):
+        for name in [
+            "2026-07-25-a.md",
+            "2026-07-26-b.md",
+            "2026-07-27-c.md",
+        ]:
+            (tmp_path / name).write_text("---\ncategories: [news]\n---\nbody", encoding="utf-8")
+        urls = idx.urls_from_recent_posts(2, tmp_path)
+        assert urls == [
+            f"https://{_HOST}/news/2026/07/27/c/",
+            f"https://{_HOST}/news/2026/07/26/b/",
+        ]
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        assert idx.urls_from_recent_posts(5, tmp_path) == []
+
+    def test_skips_undecodable_posts(self, tmp_path):
+        (tmp_path / "not-dated.md").write_text("---\n---\nbody", encoding="utf-8")
+        assert idx.urls_from_recent_posts(5, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# urls_from_sitemap — LOCAL FILE branch only
+# ---------------------------------------------------------------------------
+
+
+class TestUrlsFromSitemapLocal:
+    def test_namespaced_locs(self, tmp_path):
+        sm = tmp_path / "sitemap.xml"
+        sm.write_text(
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            f"<url><loc>https://{_HOST}/a/</loc></url>"
+            f"<url><loc>https://{_HOST}/b/</loc></url>"
+            "</urlset>",
+            encoding="utf-8",
+        )
+        urls = idx.urls_from_sitemap(str(sm))
+        assert urls == [f"https://{_HOST}/a/", f"https://{_HOST}/b/"]
+
+    def test_non_namespaced_locs(self, tmp_path):
+        sm = tmp_path / "sitemap.xml"
+        sm.write_text(f"<urlset><url><loc>https://{_HOST}/c/</loc></url></urlset>", encoding="utf-8")
+        assert idx.urls_from_sitemap(str(sm)) == [f"https://{_HOST}/c/"]
+
+    def test_malformed_xml_returns_empty(self, tmp_path):
+        sm = tmp_path / "sitemap.xml"
+        sm.write_text("<urlset><url><loc>not closed", encoding="utf-8")
+        assert idx.urls_from_sitemap(str(sm)) == []
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert idx.urls_from_sitemap(str(tmp_path / "gone.xml")) == []
+
+
+# ---------------------------------------------------------------------------
+# urls_from_changed_posts — subprocess.run mocked, git never invoked
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TestUrlsFromChangedPosts:
+    def test_normal_diff(self, tmp_path, monkeypatch):
+        posts_dir = tmp_path / "_posts"
+        posts_dir.mkdir()
+        post = posts_dir / "2026-07-27-changed.md"
+        post.write_text("---\ncategories: [news]\n---\nbody", encoding="utf-8")
+
+        def _fake_run(cmd, capture_output, text, timeout):
+            assert cmd[:2] == ["git", "diff"]
+            return _FakeCompletedProcess(returncode=0, stdout="_posts/2026-07-27-changed.md\n")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        urls = idx.urls_from_changed_posts("HEAD~1", posts_dir)
+        assert urls == [f"https://{_HOST}/news/2026/07/27/changed/"]
+
+    def test_non_md_lines_skipped(self, tmp_path, monkeypatch):
+        posts_dir = tmp_path / "_posts"
+        posts_dir.mkdir()
+
+        def _fake_run(cmd, capture_output, text, timeout):
+            return _FakeCompletedProcess(returncode=0, stdout="README.md\n_posts/not-there.txt\n")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        # README.md doesn't exist under posts_dir.parent/README.md's actual
+        # location won't matter since _permalink_from_post will fail to read
+        # it and log+return None (posts_dir.parent may not contain it).
+        urls = idx.urls_from_changed_posts("HEAD~1", posts_dir)
+        assert urls == []
+
+    def test_nonzero_returncode_returns_empty(self, tmp_path, monkeypatch):
+        posts_dir = tmp_path / "_posts"
+        posts_dir.mkdir()
+
+        def _fake_run(cmd, capture_output, text, timeout):
+            return _FakeCompletedProcess(returncode=1, stderr="fatal: bad revision")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        assert idx.urls_from_changed_posts("bad-ref", posts_dir) == []
+
+    def test_timeout_returns_empty(self, tmp_path, monkeypatch):
+        posts_dir = tmp_path / "_posts"
+        posts_dir.mkdir()
+
+        def _fake_run(cmd, capture_output, text, timeout):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        assert idx.urls_from_changed_posts("HEAD~1", posts_dir) == []
+
+    def test_git_not_found_returns_empty(self, tmp_path, monkeypatch):
+        posts_dir = tmp_path / "_posts"
+        posts_dir.mkdir()
+
+        def _fake_run(cmd, capture_output, text, timeout):
+            raise FileNotFoundError("git not installed")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        assert idx.urls_from_changed_posts("HEAD~1", posts_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# submit_urls — with _submit_batch stubbed (no real urllib access)
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitUrls:
+    def test_invalid_host_filtered_out(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(idx, "_submit_batch", lambda urls, key: calls.append(urls) or True)
+        ok = idx.submit_urls([f"https://{_HOST}/ok/", "https://example.com/bad/"], "key")
+        assert ok is True
+        assert calls == [[f"https://{_HOST}/ok/"]]
+
+    def test_dedup_preserves_order(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(idx, "_submit_batch", lambda urls, key: calls.append(urls) or True)
+        urls_in = [f"https://{_HOST}/a/", f"https://{_HOST}/b/", f"https://{_HOST}/a/"]
+        idx.submit_urls(urls_in, "key")
+        assert calls == [[f"https://{_HOST}/a/", f"https://{_HOST}/b/"]]
+
+    def test_empty_after_filtering_returns_true(self, monkeypatch):
+        monkeypatch.setattr(
+            idx, "_submit_batch", lambda urls, key: (_ for _ in ()).throw(AssertionError("should not be called"))
+        )
+        assert idx.submit_urls(["https://example.com/only-invalid/"], "key") is True
+
+    def test_multi_batch_chunking(self, monkeypatch):
+        monkeypatch.setattr(idx, "MAX_URLS_PER_BATCH", 2)
+        calls = []
+        monkeypatch.setattr(idx, "_submit_batch", lambda urls, key: calls.append(list(urls)) or True)
+        urls_in = [f"https://{_HOST}/{i}/" for i in range(5)]
+        ok = idx.submit_urls(urls_in, "key")
+        assert ok is True
+        assert calls == [
+            [f"https://{_HOST}/0/", f"https://{_HOST}/1/"],
+            [f"https://{_HOST}/2/", f"https://{_HOST}/3/"],
+            [f"https://{_HOST}/4/"],
+        ]
+
+    def test_partial_failure_returns_false(self, monkeypatch):
+        monkeypatch.setattr(idx, "MAX_URLS_PER_BATCH", 1)
+        results = iter([True, False])
+        monkeypatch.setattr(idx, "_submit_batch", lambda urls, key: next(results))
+        urls_in = [f"https://{_HOST}/a/", f"https://{_HOST}/b/"]
+        assert idx.submit_urls(urls_in, "key") is False
+
+
+# ---------------------------------------------------------------------------
+# parser / main wiring
+# ---------------------------------------------------------------------------
+
+
+class TestParserAndMain:
+    def test_mutually_exclusive_group_rejects_two_sources(self):
+        parser = idx._build_parser()
+        import pytest
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--urls", "https://x/", "--from-recent-posts", "5"])
+
+    def test_main_urls_source(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["indexnow_submit.py", "--urls", f"https://{_HOST}/a/"])
+        captured = {}
+        monkeypatch.setattr(idx, "submit_urls", lambda urls, key: captured.setdefault("urls", urls) or True)
+        rc = idx.main(["--urls", f"https://{_HOST}/a/"])
+        assert rc == 0
+        assert captured["urls"] == [f"https://{_HOST}/a/"]
+
+    def test_main_from_recent_posts_source(self, monkeypatch):
+        monkeypatch.setattr(
+            idx,
+            "urls_from_recent_posts",
+            lambda n, posts_dir: [f"https://{_HOST}/recent/{n}/"],
+        )
+        monkeypatch.setattr(idx, "submit_urls", lambda urls, key: True)
+        rc = idx.main(["--from-recent-posts", "3"])
+        assert rc == 0
+
+    def test_main_from_sitemap_source_explicit(self, monkeypatch, tmp_path):
+        called = {}
+        monkeypatch.setattr(idx, "urls_from_sitemap", lambda source: called.setdefault("source", source) or [])
+        monkeypatch.setattr(idx, "submit_urls", lambda urls, key: True)
+        custom = str(tmp_path / "custom-sitemap.xml")
+        rc = idx.main(["--from-sitemap", custom])
+        assert rc == 0
+        assert called["source"] == custom
+
+    def test_main_from_changed_posts_source(self, monkeypatch):
+        called = {}
+        monkeypatch.setattr(
+            idx,
+            "urls_from_changed_posts",
+            lambda base_ref, posts_dir: called.setdefault("base_ref", base_ref) or [],
+        )
+        monkeypatch.setattr(idx, "submit_urls", lambda urls, key: True)
+        rc = idx.main(["--from-changed-posts", "HEAD~1"])
+        assert rc == 0
+        assert called["base_ref"] == "HEAD~1"
+
+    def test_main_returns_1_on_submit_failure(self, monkeypatch):
+        monkeypatch.setattr(idx, "submit_urls", lambda urls, key: False)
+        rc = idx.main(["--urls", f"https://{_HOST}/a/"])
+        assert rc == 1

--- a/tests/test_verify_secret_activation.py
+++ b/tests/test_verify_secret_activation.py
@@ -1,0 +1,433 @@
+"""tests/test_verify_secret_activation.py — verify_secret_activation 단위 테스트.
+
+Secret 활성화(TWITTER_BEARER_TOKEN, GSC_SERVICE_ACCOUNT_JSON) 전후 효과를
+비교하는 리포트 생성기. ``gh`` CLI 호출은 ``subprocess.run``을 모킹해
+절대 실제로 실행되지 않도록 하고, 시간 의존 로직은 ``datetime``을 고정
+서브클래스로 교체해 결정적으로 구동한다.
+"""
+
+import datetime as dt_module
+import json
+import subprocess
+import sys
+
+import verify_secret_activation as vsa
+
+_HOST_UNUSED = None  # placeholder to keep import block simple
+
+
+class _Namespace:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _fixed_datetime(monkeypatch, year=2026, month=7, day=20, hour=12, minute=0):
+    """Freeze ``vsa.datetime.now()`` while keeping strptime/replace semantics.
+
+    Subclassing the real ``datetime`` preserves ``strptime`` and ``replace``
+    behaviour (they return instances of ``cls``), so only ``now`` needs
+    overriding.
+    """
+
+    class _FixedDateTime(dt_module.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(year, month, day, hour, minute, tzinfo=tz)
+
+    monkeypatch.setattr(vsa, "datetime", _FixedDateTime)
+    return _FixedDateTime(year, month, day, hour, minute, tzinfo=dt_module.UTC)
+
+
+# ---------------------------------------------------------------------------
+# _extract_int
+# ---------------------------------------------------------------------------
+
+
+class TestExtractInt:
+    def test_match_returns_int(self):
+        assert vsa._extract_int(vsa._TOTAL_RE, "총 14건이 수집되었습니다") == 14
+
+    def test_no_match_returns_default(self):
+        assert vsa._extract_int(vsa._TOTAL_RE, "no match here", default=7) == 7
+
+    def test_no_match_default_zero(self):
+        assert vsa._extract_int(vsa._TWITTER_RE, "nothing") == 0
+
+
+# ---------------------------------------------------------------------------
+# _avg
+# ---------------------------------------------------------------------------
+
+
+class TestAvg:
+    def test_empty_list(self):
+        assert vsa._avg([]) == 0.0
+
+    def test_average(self):
+        assert vsa._avg([1, 2, 3]) == 2.0
+
+
+# ---------------------------------------------------------------------------
+# _delta_pct
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaPct:
+    def test_both_zero_returns_na(self):
+        assert vsa._delta_pct(0, 0) == "N/A"
+
+    def test_baseline_zero_recent_positive_returns_infinity(self):
+        assert vsa._delta_pct(0, 5) == "+∞"
+
+    def test_positive_delta_has_plus_sign(self):
+        assert vsa._delta_pct(10, 20) == "+100.0%"
+
+    def test_negative_delta_has_minus_sign(self):
+        assert vsa._delta_pct(10, 5) == "-50.0%"
+
+
+# ---------------------------------------------------------------------------
+# parse_social_digest
+# ---------------------------------------------------------------------------
+
+
+class TestParseSocialDigest:
+    def test_total_present_uses_stat_grid_breakdown(self, tmp_path):
+        p = tmp_path / "2026-07-20-daily-social-media-digest.md"
+        p.write_text(
+            "총 14건이 수집되었습니다\n\n"
+            '<div class="stat-item"><span class="stat-value">1</span>'
+            '<span class="stat-label">소셜 미디어</span></div>\n'
+            '<div class="stat-item"><span class="stat-value">13</span>'
+            '<span class="stat-label">정치·경제</span></div>\n'
+            '<div class="stat-item"><span class="stat-value">0</span>'
+            '<span class="stat-label">텔레그램</span></div>\n',
+            encoding="utf-8",
+        )
+        m = vsa.parse_social_digest(p)
+        assert m.date == "2026-07-20"
+        assert m.total_items == 14
+        assert m.social_items == 1
+        assert m.political_items == 13
+        assert m.telegram_items == 0
+
+    def test_zero_total_falls_back_to_stat_sum(self, tmp_path):
+        p = tmp_path / "2026-07-20-daily-social-media-digest.md"
+        p.write_text(
+            '<div class="stat-item"><span class="stat-value">2</span>'
+            '<span class="stat-label">소셜 미디어</span></div>\n'
+            '<div class="stat-item"><span class="stat-value">3</span>'
+            '<span class="stat-label">정치·경제</span></div>\n'
+            '<div class="stat-item"><span class="stat-value">1</span>'
+            '<span class="stat-label">텔레그램</span></div>\n',
+            encoding="utf-8",
+        )
+        m = vsa.parse_social_digest(p)
+        assert m.total_items == 6  # 2 + 1 + 3, summed as fallback
+        assert m.social_items == 2
+        assert m.telegram_items == 1
+        assert m.political_items == 3
+
+    def test_missing_spans_all_zero(self, tmp_path):
+        p = tmp_path / "2026-07-20-daily-social-media-digest.md"
+        p.write_text("no structured data here at all", encoding="utf-8")
+        m = vsa.parse_social_digest(p)
+        assert m.total_items == 0
+        assert m.social_items == 0
+        assert m.telegram_items == 0
+        assert m.political_items == 0
+        assert m.twitter_items == 0
+
+    def test_date_fallback_when_filename_does_not_match_pattern(self, tmp_path):
+        p = tmp_path / "2026-07-20-something-else.md"
+        p.write_text("no data", encoding="utf-8")
+        m = vsa.parse_social_digest(p)
+        assert m.date == "2026-07-20"  # falls back to path.name[:10]
+
+    def test_sentence_level_twitter_and_telegram_override_stat_default(self, tmp_path):
+        p = tmp_path / "2026-07-20-daily-social-media-digest.md"
+        # "총 N건이 수집" only matches at line-start (^ with MULTILINE), so it
+        # must be on its own line — separate from the sentence-level twitter/
+        # telegram counts, which match anywhere in the text.
+        p.write_text(
+            "소셜 미디어 5건, 텔레그램 9건, 정치·경제 0건\n총 14건이 수집되었습니다\n",
+            encoding="utf-8",
+        )
+        m = vsa.parse_social_digest(p)
+        assert m.total_items == 14
+        assert m.twitter_items == 5
+        assert m.telegram_items == 9
+
+
+# ---------------------------------------------------------------------------
+# collect_social_metrics — POSTS_DIR monkeypatched to tmp_path, time frozen
+# ---------------------------------------------------------------------------
+
+
+class TestCollectSocialMetrics:
+    def test_baseline_recent_bucketing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vsa, "POSTS_DIR", tmp_path)
+        _fixed_datetime(monkeypatch, year=2026, month=7, day=20, hour=12)
+
+        recent_post = tmp_path / "2026-07-20-daily-social-media-digest.md"
+        recent_post.write_text("총 1건이 수집되었습니다", encoding="utf-8")
+
+        baseline_post = tmp_path / "2026-07-15-daily-social-media-digest.md"
+        baseline_post.write_text("총 2건이 수집되었습니다", encoding="utf-8")
+
+        too_old_post = tmp_path / "2026-07-10-daily-social-media-digest.md"
+        too_old_post.write_text("총 3건이 수집되었습니다", encoding="utf-8")
+
+        baseline, recent = vsa.collect_social_metrics(baseline_days=7, observe_hours=24)
+
+        assert [m.date for m in recent] == ["2026-07-20"]
+        assert [m.date for m in baseline] == ["2026-07-15"]
+
+    def test_no_matching_posts_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vsa, "POSTS_DIR", tmp_path)
+        _fixed_datetime(monkeypatch)
+        (tmp_path / "not-a-digest.md").write_text("irrelevant", encoding="utf-8")
+        baseline, recent = vsa.collect_social_metrics(baseline_days=7, observe_hours=24)
+        assert baseline == []
+        assert recent == []
+
+
+# ---------------------------------------------------------------------------
+# render_twitter_report
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTwitterReport:
+    def test_empty_baseline_and_recent_warns(self):
+        out = vsa.render_twitter_report([], [], observe_hours=24)
+        assert "경고: baseline 포스트 없음" in out
+        assert "최근 24h 포스트 없음" in out
+        assert "TWITTER_BEARER_TOKEN 등록 후" in out
+
+    def test_verdict_improved(self):
+        baseline = [vsa.PostMetrics("2026-07-10", 5, 1, 1, 3, 1)]
+        recent = [vsa.PostMetrics("2026-07-20", 10, 5, 1, 4, 5)]
+        out = vsa.render_twitter_report(baseline, recent, observe_hours=24)
+        assert "판정: 개선" in out
+
+    def test_verdict_inactive_when_both_zero(self):
+        baseline = [vsa.PostMetrics("2026-07-10", 5, 0, 1, 3, 0)]
+        recent = [vsa.PostMetrics("2026-07-20", 5, 0, 1, 3, 0)]
+        out = vsa.render_twitter_report(baseline, recent, observe_hours=24)
+        assert "판정: 미활성" in out
+
+    def test_verdict_no_change(self):
+        baseline = [vsa.PostMetrics("2026-07-10", 5, 3, 1, 3, 3)]
+        recent = [vsa.PostMetrics("2026-07-20", 5, 2, 1, 3, 2)]
+        out = vsa.render_twitter_report(baseline, recent, observe_hours=24)
+        assert "판정: 변화 없음" in out
+
+
+# ---------------------------------------------------------------------------
+# render_gsc_report
+# ---------------------------------------------------------------------------
+
+
+class TestRenderGscReport:
+    def test_no_runs_at_all(self):
+        out = vsa.render_gsc_report([], [], observe_hours=24)
+        assert "gh CLI 미응답" in out
+
+    def test_verdict_active(self):
+        recent = [vsa.GscRunInfo("1", "success", "2026-07-20T00:00:00Z", None)]
+        out = vsa.render_gsc_report([], recent, observe_hours=24)
+        assert "판정: 활성" in out
+
+    def test_verdict_running_but_error(self):
+        recent = [vsa.GscRunInfo("1", "failure", "2026-07-20T00:00:00Z", None)]
+        out = vsa.render_gsc_report([], recent, observe_hours=24)
+        assert "판정: 실행 중이나 오류" in out
+
+    def test_verdict_waiting(self):
+        baseline = [vsa.GscRunInfo("1", "success", "2026-07-10T00:00:00Z", None)]
+        out = vsa.render_gsc_report(baseline, [], observe_hours=24)
+        assert "판정: 대기 중" in out
+
+
+# ---------------------------------------------------------------------------
+# build_parser
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_defaults(self):
+        parser = vsa.build_parser()
+        args = parser.parse_args([])
+        assert args.secret == "both"  # noqa: S105 -- CLI choice value, not a credential
+        assert args.baseline_days == 7
+        assert args.observe_hours == 24
+        assert args.output == "markdown"
+
+
+# ---------------------------------------------------------------------------
+# _run_gh
+# ---------------------------------------------------------------------------
+
+
+class TestRunGh:
+    def test_success(self, monkeypatch):
+        def _fake_run(cmd, capture_output, text, timeout):
+            assert cmd[0] == "gh"
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        ok, out = vsa._run_gh(["run", "list"])
+        assert ok is True
+        assert out == "ok"
+
+    def test_failure_returncode(self, monkeypatch):
+        def _fake_run(cmd, capture_output, text, timeout):
+            return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="bad\n")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        ok, out = vsa._run_gh(["run", "list"])
+        assert ok is False
+        assert out == "bad"
+
+    def test_gh_not_found(self, monkeypatch):
+        def _fake_run(cmd, capture_output, text, timeout):
+            raise FileNotFoundError("gh missing")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        ok, out = vsa._run_gh(["run", "list"])
+        assert ok is False
+        assert "설치" in out
+
+    def test_timeout(self, monkeypatch):
+        def _fake_run(cmd, capture_output, text, timeout):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        ok, out = vsa._run_gh(["run", "list"])
+        assert ok is False
+        assert "타임아웃" in out
+
+
+# ---------------------------------------------------------------------------
+# fetch_gsc_runs
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGscRuns:
+    def test_json_ok(self, monkeypatch):
+        payload = [{"databaseId": 1, "conclusion": "success", "startedAt": "2026-07-20T00:00:00Z"}]
+        monkeypatch.setattr(vsa, "_run_gh", lambda args: (True, json.dumps(payload)))
+        result = vsa.fetch_gsc_runs(limit=5)
+        assert result == payload
+
+    def test_gh_failure_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(vsa, "_run_gh", lambda args: (False, "error"))
+        assert vsa.fetch_gsc_runs() == []
+
+    def test_malformed_json_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(vsa, "_run_gh", lambda args: (True, "not json"))
+        assert vsa.fetch_gsc_runs() == []
+
+
+# ---------------------------------------------------------------------------
+# collect_gsc_runs
+# ---------------------------------------------------------------------------
+
+
+class TestCollectGscRuns:
+    def test_iso8601_bucketing_and_malformed_skip(self, monkeypatch):
+        _fixed_datetime(monkeypatch, year=2026, month=7, day=20, hour=12)
+        runs = [
+            {"databaseId": 1, "conclusion": "success", "startedAt": "2026-07-20T00:00:00Z"},  # recent
+            {"databaseId": 2, "conclusion": "success", "startedAt": "2026-07-15T00:00:00Z"},  # baseline
+            {"databaseId": 3, "conclusion": "success", "startedAt": "2026-07-01T00:00:00Z"},  # too old
+            {"databaseId": 4, "conclusion": "success", "startedAt": "not-a-date"},  # malformed, skipped
+            {"databaseId": 5, "status": "in_progress", "startedAt": "2026-07-20T01:00:00Z"},  # no conclusion
+        ]
+        monkeypatch.setattr(vsa, "fetch_gsc_runs", lambda limit=30: runs)
+        baseline, recent = vsa.collect_gsc_runs(baseline_days=7, observe_hours=24)
+        assert [r.run_id for r in recent] == ["1", "5"]
+        assert [r.run_id for r in baseline] == ["2"]
+        assert [r for r in recent if r.run_id == "5"][0].conclusion == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_artifact_indexed_count
+# ---------------------------------------------------------------------------
+
+
+class TestFetchArtifactIndexedCount:
+    def test_success_parses_indexed_count(self, monkeypatch):
+        def _fake_run(cmd, capture_output, text, timeout):
+            assert cmd[0] == "gh"
+            dir_index = cmd.index("--dir") + 1
+            target_dir = cmd[dir_index]
+            (__import__("pathlib").Path(target_dir) / "summary.txt").write_text(
+                "Run summary\nIndexed: 42\n", encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        assert vsa._fetch_artifact_indexed_count("123") == 42
+
+    def test_download_failure_returns_none(self, monkeypatch):
+        def _fake_run(cmd, capture_output, text, timeout):
+            return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="fail")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        assert vsa._fetch_artifact_indexed_count("123") is None
+
+    def test_no_matching_pattern_returns_none(self, monkeypatch):
+        def _fake_run(cmd, capture_output, text, timeout):
+            dir_index = cmd.index("--dir") + 1
+            target_dir = cmd[dir_index]
+            (__import__("pathlib").Path(target_dir) / "summary.txt").write_text("no relevant data\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        assert vsa._fetch_artifact_indexed_count("123") is None
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_secret_twitter_only(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["verify_secret_activation.py", "--secret", "twitter"])
+        monkeypatch.setattr(vsa, "collect_social_metrics", lambda baseline_days, observe_hours: ([], []))
+        monkeypatch.setattr(
+            vsa,
+            "collect_gsc_runs",
+            lambda baseline_days, observe_hours: (_ for _ in ()).throw(AssertionError("gsc should not run")),
+        )
+        rc = vsa.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Twitter/X Secret" in out
+        assert "GSC Secret" not in out
+
+    def test_secret_gsc_only(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["verify_secret_activation.py", "--secret", "gsc"])
+        monkeypatch.setattr(
+            vsa,
+            "collect_social_metrics",
+            lambda baseline_days, observe_hours: (_ for _ in ()).throw(AssertionError("twitter should not run")),
+        )
+        monkeypatch.setattr(vsa, "collect_gsc_runs", lambda baseline_days, observe_hours: ([], []))
+        rc = vsa.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "GSC Secret" in out
+        assert "Twitter/X Secret" not in out
+
+    def test_secret_both(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["verify_secret_activation.py", "--secret", "both"])
+        monkeypatch.setattr(vsa, "collect_social_metrics", lambda baseline_days, observe_hours: ([], []))
+        monkeypatch.setattr(vsa, "collect_gsc_runs", lambda baseline_days, observe_hours: ([], []))
+        rc = vsa.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Twitter/X Secret" in out
+        assert "GSC Secret" in out


### PR DESCRIPTION
## 요약

`scripts` 0% 커버리지 tools 모듈 3개에 결정적·네트워크 프리 유닛 테스트를 추가해 raw 총계를 **71.04% → 73.15%**로 끌어올렸습니다. 게이트 70 대비 헤드룸을 ~1pt에서 ~3pt로 넓혀, baseline 노이즈(런당 ~1.3pt 변동)로 인한 flaky-red 확률을 낮춥니다.

> ⚠️ 후속: 스윙의 근본 원인(`generate_weekly_digest.collect_weekly_posts`가 라이브 `_posts/` + `datetime.now()` 의존)은 별도 PR에서 테스트 격리로 제거 예정. 본 PR은 헤드룸 확보에 한정.

## 신규 테스트 (모두 `tmp_path`/`monkeypatch` 격리)

| 모듈 | Before → After | tests |
|------|----------------|-------|
| `tools/gsc_api` | 0 → 95% | 20 |
| `tools/indexnow_submit` | 0 → 84% | 40 |
| `tools/verify_secret_activation` | 0 → 98% | 39 |

- `gsc_api`: `_build_service` mock. google 라이브러리 설치 여부와 무관하게 `_require_googleapi` ImportError 브랜치를 `monkeypatch.setitem(sys.modules, ..., None)`로 강제(이 venv엔 transitively 설치됨).
- `indexnow_submit`: 리프 `_submit_batch` mock으로 orchestration 커버. urllib POST 실경로·https sitemap 브랜치는 의도적 제외(로컬 파일 브랜치만).
- `verify_secret_activation`: `POSTS_DIR`·`subprocess.run` monkeypatch로 gh CLI 미호출.

**네트워크 안전:** conftest 가드는 `requests.HTTPAdapter.send`만 차단 → 이 3개는 `urllib.urlopen`/`subprocess`를 쓰므로 각 테스트가 seam을 명시적으로 mock. 신규 3파일 단독 실행 99 tests / 0.15s (I/O 누수·hang 없음).

## 문서

테스트 파일 수 123 → 126 → `docs/component-counts.md` 재생성.

## 검증

- ✅ **5003 passed** / 16 skipped / 0 failed (178s)
- ✅ 커버리지 **73.15%** (≥70 게이트)
- ✅ `ruff check` + `ruff format --check` 통과

## Test plan

- [x] `python3 -m pytest tests/test_{gsc_api,indexnow_submit,verify_secret_activation}.py --no-cov` → 99 passed / 0.15s
- [x] `python3 -m pytest -q --cov=scripts` → 73.15%
- [x] `ruff check` + `ruff format --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
