### PR TITLE
test: 테스트 스위트 생성 이미지 격리 + 회귀 가드

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 48 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 123 |
+| 테스트 파일 (tests/test_*.py) | 124 |
 
 <!-- component-counts:end -->

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,42 @@ def _block_real_http(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_generated_images(tmp_path, monkeypatch):
+    """Redirect generated-image writes to a per-test tmp dir.
+
+    Every image_generator save resolves its output directory through
+    ``_base._get_pkg_attr("IMAGES_DIR")``, which reads the mutable package
+    attribute ``common.image_generator.IMAGES_DIR``. Integration tests that
+    exercise real render paths (daily summary, collectors, briefing cards)
+    without patching that attribute would otherwise write PNG/WEBP/AVIF files
+    into the committed ``assets/images/generated/`` tree, leaving dirty
+    working-tree side effects after the suite runs. Pointing the package
+    attribute at a throwaway directory keeps those writes hermetic.
+
+    Tests that already patch ``IMAGES_DIR`` themselves (test_image_generator*)
+    run their own ``monkeypatch.setattr`` after this fixture, which wins.
+    """
+    try:
+        import common.image_generator as ig
+    except ImportError:
+        return
+
+    dest = tmp_path / "generated"
+    monkeypatch.setattr(ig, "IMAGES_DIR", str(dest))
+
+    # Some tests import via ``scripts.common.*`` (a distinct module object).
+    # ``_get_pkg_attr`` only reads ``common.image_generator``, but patch the
+    # twin defensively so both namespaces agree on the redirect.
+    try:
+        import scripts.common.image_generator as ig_scripts
+
+        if ig_scripts is not ig:
+            monkeypatch.setattr(ig_scripts, "IMAGES_DIR", str(dest))
+    except ImportError:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def _isolate_image_rejection_state(tmp_path, monkeypatch):
     """Redirect image_rejection_metrics state + archive paths to a per-test tmp dir.
 

--- a/tests/test_suite_isolation_guard.py
+++ b/tests/test_suite_isolation_guard.py
@@ -1,0 +1,46 @@
+"""Regression guards for test-suite working-tree isolation invariants.
+
+These tests fail loudly if a conftest isolation fixture is removed or stops
+firing, so integration tests can never silently start polluting the committed
+repo tree again.
+"""
+
+import os
+from pathlib import Path
+
+import common.image_generator as ig
+
+# Test-file-local anchor for the committed repo tree. We deliberately derive the
+# path from ``__file__`` instead of importing ``common.image_generator.REPO_ROOT``:
+# importing a production real-tree root constant into a test is itself banned by
+# ``test_hermetic_test_writes_guard`` (it is the canonical non-hermetic-write
+# signal). ``tests/`` lives at the repo root, so its parent is the checkout root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_REPO_IMAGES = str((_REPO_ROOT / "assets" / "images" / "generated").resolve())
+
+
+def test_generated_images_redirected_off_repo_tree():
+    """``_isolate_generated_images`` must redirect writes off the repo tree.
+
+    Every image_generator save resolves its output dir through
+    ``common.image_generator.IMAGES_DIR``. Integration tests (daily summary,
+    collectors, briefing cards) that do not patch it themselves rely on the
+    autouse fixture to point it at a throwaway tmp dir. If that fixture is
+    removed, those tests write PNG/WEBP/AVIF files into the committed
+    ``assets/images/generated/`` tree, leaving dirty working-tree side effects.
+
+    Asserting the active dir is not the committed tree turns a silent
+    regression into an immediate, obvious failure.
+    """
+    active = os.path.abspath(ig.IMAGES_DIR)
+
+    assert active != _REPO_IMAGES, (
+        "image_generator.IMAGES_DIR points at the committed repo tree during "
+        "tests — the _isolate_generated_images conftest fixture is not active. "
+        "Image-generating tests will pollute the working tree."
+    )
+    # The redirect target must also never be nested inside the committed assets
+    # tree, or writes would still dirty the working tree.
+    assert not active.startswith(_REPO_IMAGES), (
+        f"IMAGES_DIR ({active}) is nested inside the committed assets tree; writes would still dirty the working tree."
+    )


### PR DESCRIPTION
## 배경
`fix/weekly-digest-test-isolation` 브랜치는 생성만 되어 있었고, 실제 이슈는 **테스트 스위트가 실제 `assets/images/generated/` 트리에 이미지를 부작용으로 남기는 것**이었다. 스위트 실행 후 워킹 트리에 다음이 오염됨:
- `news-briefing-daily-2026-01-15.{png,webp,avif}`
- `market-snapshot-2026-03-29.{png,webp,avif}`
- `news-briefing-regulatory-2026-03-29.{png,webp,avif}` (커밋 이미지 바이트 덮어쓰기)

## 근본 원인
image_generator의 모든 저장 경로는 `_get_pkg_attr("IMAGES_DIR")` → 패키지 속성 `common.image_generator.IMAGES_DIR`을 거친다. 이 속성을 패치하지 않는 통합 테스트(daily summary·수집기·브리핑 카드)가 실제 리포 디렉토리에 PNG/WEBP/AVIF를 썼다.

## 변경
1. **격리 (`tests/conftest.py`)** — 기존 `_isolate_image_rejection_state` 패턴을 그대로 따라 autouse fixture `_isolate_generated_images` 추가. `IMAGES_DIR`을 per-test tmp 디렉토리로 리다이렉트. `IMAGES_DIR`을 직접 패치하는 기존 `test_image_generator*` 테스트는 fixture 이후 자체 monkeypatch가 우선하므로 무영향.
2. **회귀 가드 (`tests/test_suite_isolation_guard.py`)** — 테스트 중 `IMAGES_DIR`이 커밋된 리포 트리를 가리키지 않는지 단언. fixture 제거/무력화 시 즉시 실패.
3. **드리프트 갱신 (`docs/component-counts.md`)** — 테스트 파일 123→124.

## 부작용 소스 감사 (#2)
전체 스위트 실행 후 `git status`가 `conftest.py`만 dirty → **이미지 외 working-tree 유출 없음** 확인. 교차 검증: `test_dedup`(`STATE_DIR=tmp_path`), `test_collect_defi_llama_tvl_store`(`_TVL_HISTORY_PATH` monkeypatch), `_state/image_rejection_metrics`(기존 fixture) 모두 tmp 격리됨.

## 검증 (실측)
- 전체 스위트: `4904 passed, 16 skipped in 174.12s`
- 스위트 실행 후 `git status -- assets/images/generated/` → **0건** (이전 9개 파일 오염)
- 회귀 가드 RED 확인: fixture 미적용 시 `IMAGES_DIR == 리포 경로` → 가드 실패
- `ruff check` + `ruff format --check` 통과
- `test_component_counts` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)