### PR TITLE
test: _state 런타임 쓰기 격리 일반화 (dedup + signal lazy-sentinel)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ norecursedirs = ["_site", ".git", "node_modules", "vendor", ".bundle"]
 timeout_method = "thread"
 markers = [
     "i18n_e2e: Playwright-driven end-to-end tests for the language toggle (tests/i18n/). Requires a running Jekyll preview at I18N_E2E_BASE_URL.",
+    "no_state_isolation: opt out of the autouse _state redirect fixtures (dedup/signal). For runtime guards that must read the real repo-anchored _state paths.",
 ]
 
 [tool.basedpyright]

--- a/scripts/common/signal_tracker.py
+++ b/scripts/common/signal_tracker.py
@@ -28,7 +28,7 @@ _HISTORY_FILE = os.path.join(_STATE_DIR, "signal_history.json")
 # 히스토리 보존 기간 (일)
 _MAX_AGE_DAYS = 365
 
-# ── TimeSeriesStore 스키마 및 인스턴스 ──────────────────────────────────────────
+# ── TimeSeriesStore 스키마 ──────────────────────────────────────────────────────
 
 _SIGNAL_SCHEMA = TimeSeriesSchema(
     required_fields=["date"],  # btc_price는 nullable이므로 required에 포함 안 함
@@ -39,8 +39,6 @@ _SIGNAL_SCHEMA = TimeSeriesSchema(
     allow_null_fields=["btc_price"],
     extra_fields_allowed=True,  # accuracy 중첩 필드 허용
 )
-
-_SIGNAL_STORE = TimeSeriesStore(Path(_HISTORY_FILE), _SIGNAL_SCHEMA, logger)
 
 
 # ── 데이터 클래스 ────────────────────────────────────────────────────────────
@@ -166,14 +164,18 @@ class SignalTracker:
         print(f"승률: {report.win_rate:.1%}")
     """
 
-    def __init__(self, history_path: str = _HISTORY_FILE) -> None:
+    def __init__(self, history_path: Optional[str] = None) -> None:
         """초기화.
 
         Args:
-            history_path: 히스토리 JSON 파일 경로. 기본값은 _state/signal_history.json.
+            history_path: 히스토리 JSON 파일 경로. None이면 호출 시점에 모듈 전역
+                ``_HISTORY_FILE`` (_state/signal_history.json)을 사용한다. 기본값을
+                import 시점이 아닌 호출 시점에 해석하므로, 테스트가
+                ``signal_tracker._HISTORY_FILE`` 을 monkeypatch 하면 무인자
+                ``SignalTracker()`` 생성도 리다이렉트된다 (dedup.STATE_DIR 격리와 동일).
         """
-        self._path = history_path
-        self._store = TimeSeriesStore(Path(history_path), _SIGNAL_SCHEMA, logger)
+        self._path = history_path if history_path is not None else _HISTORY_FILE
+        self._store = TimeSeriesStore(Path(self._path), _SIGNAL_SCHEMA, logger)
         self._entries: List[Dict[str, Any]] = self._store.load(validate=False)
         logger.debug("SignalTracker 초기화: %d개 항목 로드", len(self._entries))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,99 @@ def _isolate_generated_images(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_dedup_state(request, tmp_path, monkeypatch):
+    """Redirect dedup ``_state/*.json`` writes to a per-test tmp dir.
+
+    Every collector persists its cross-run dedup state through
+    ``DedupEngine``, which resolves its output file at construction time as
+    ``os.path.join(common.dedup.STATE_DIR, state_file)``. Integration tests
+    that drive a real collector's ``save_state()`` path (base collector,
+    collector integration, per-source collectors) without patching
+    ``STATE_DIR`` themselves would otherwise write ``*_seen.json`` files into
+    the committed ``_state/`` tree — the same dirty-working-tree side effect
+    the image fixtures prevent, and one the ``pre-commit-state-guard`` hook
+    would then block at commit time. Pointing the module attribute at a
+    throwaway directory keeps those writes hermetic.
+
+    Because ``DedupEngine.__init__`` reads the module global at call time,
+    this autouse redirect covers collectors constructed inside the test body.
+    Tests that patch ``STATE_DIR`` themselves (test_dedup, collector configs)
+    set it after this fixture, so their value wins and is restored to this
+    tmp on teardown before monkeypatch unwinds to the real path.
+
+    Opt-out: tests marked ``no_state_isolation`` need the *real*
+    repo-anchored value (e.g. the runtime path-anchoring guard in
+    ``test_state_path_anchoring.py`` asserts ``STATE_DIR`` is under the repo
+    root). This redirect would defeat that guard, so it skips such tests.
+
+    Scope note: this covers the shared dedup ``_state`` family. The signal
+    history ``_state`` file is redirected separately by
+    ``_isolate_signal_history_state``.
+    """
+    if request.node.get_closest_marker("no_state_isolation"):
+        return
+    try:
+        import common.dedup as dedup
+    except ImportError:
+        return
+
+    dest = str(tmp_path / "_state")
+    monkeypatch.setattr(dedup, "STATE_DIR", dest)
+
+    # Some tests import via ``scripts.common.*`` (a distinct module object).
+    # Patch the twin defensively so both namespaces agree on the redirect.
+    try:
+        import scripts.common.dedup as dedup_scripts
+
+        if dedup_scripts is not dedup:
+            monkeypatch.setattr(dedup_scripts, "STATE_DIR", dest)
+    except ImportError:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _isolate_signal_history_state(request, tmp_path, monkeypatch):
+    """Redirect signal_tracker ``_state/signal_history.json`` writes to a tmp dir.
+
+    ``SignalTracker`` persists the daily composite-signal history through a
+    ``TimeSeriesStore`` bound to ``history_path``, which defaults to the module
+    global ``common.signal_tracker._HISTORY_FILE`` resolved *at call time*
+    (lazy sentinel). Integration tests that construct a no-arg
+    ``SignalTracker()`` — as ``collect_market_indicators`` does in production —
+    without passing an explicit ``history_path`` would otherwise write
+    ``signal_history.json`` into the committed ``_state/`` tree. Pointing the
+    module attribute at a throwaway file keeps those writes hermetic.
+
+    Because the constructor reads ``_HISTORY_FILE`` at call time, this autouse
+    redirect covers no-arg trackers built inside the test body. Tests that pass
+    ``history_path=`` explicitly still win — their value is used verbatim.
+
+    Opt-out: tests marked ``no_state_isolation`` (e.g. the runtime
+    path-anchoring guard) need the real repo-anchored value, so this redirect
+    skips them — consistent with ``_isolate_dedup_state``.
+    """
+    if request.node.get_closest_marker("no_state_isolation"):
+        return
+    try:
+        import common.signal_tracker as st
+    except ImportError:
+        return
+
+    dest = str(tmp_path / "_state" / "signal_history.json")
+    monkeypatch.setattr(st, "_HISTORY_FILE", dest)
+
+    # Some tests import via ``scripts.common.*`` (a distinct module object).
+    # Patch the twin defensively so both namespaces agree on the redirect.
+    try:
+        import scripts.common.signal_tracker as st_scripts
+
+        if st_scripts is not st:
+            monkeypatch.setattr(st_scripts, "_HISTORY_FILE", dest)
+    except ImportError:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def _isolate_image_rejection_state(tmp_path, monkeypatch):
     """Redirect image_rejection_metrics state + archive paths to a per-test tmp dir.
 

--- a/tests/test_signal_tracker_time_series.py
+++ b/tests/test_signal_tracker_time_series.py
@@ -23,7 +23,6 @@ import pytest
 from scripts.common.signal_composer import CompositeResult, SignalResult
 from scripts.common.signal_tracker import (
     _SIGNAL_SCHEMA,
-    _SIGNAL_STORE,
     SignalTracker,
 )
 from scripts.common.time_series_state import TimeSeriesStore
@@ -317,14 +316,10 @@ class TestBackfillCompatibility:
         assert "correct" in acc
 
 
-# ── _SIGNAL_STORE 모듈 상수 확인 ──────────────────────────────────────────────
+# ── _SIGNAL_SCHEMA 모듈 상수 확인 ──────────────────────────────────────────────
 
 
 class TestSignalStoreModuleConstant:
-    def test_signal_store_is_time_series_store_instance(self):
-        """_SIGNAL_STORE가 TimeSeriesStore 인스턴스이어야 한다."""
-        assert isinstance(_SIGNAL_STORE, TimeSeriesStore)
-
     def test_signal_schema_allow_null_fields(self):
         """_SIGNAL_SCHEMA.allow_null_fields에 btc_price가 포함되어야 한다."""
         assert "btc_price" in _SIGNAL_SCHEMA.allow_null_fields

--- a/tests/test_state_path_anchoring.py
+++ b/tests/test_state_path_anchoring.py
@@ -247,6 +247,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
     ],
     ids=["dedup.STATE_DIR", "signal_tracker._STATE_DIR", "translator._CACHE_PATH"],
 )
+@pytest.mark.no_state_isolation
 def test_module_state_path_is_absolute_and_under_repo_root(import_path: str, attr: str) -> None:
     """The computed module-level state path must be absolute and under the repo root.
 
@@ -254,6 +255,10 @@ def test_module_state_path_is_absolute_and_under_repo_root(import_path: str, att
     the path attribute to confirm the value is rooted at the repo root, not at
     the test process cwd.  A stray ``<cwd>/_state/`` would produce a path that
     does NOT start with ``_REPO_ROOT``.
+
+    Marked ``no_state_isolation`` because the autouse dedup/signal ``_state``
+    redirect fixtures would otherwise repoint ``STATE_DIR`` at a tmp dir and
+    defeat this repo-anchoring assertion.
     """
     import importlib
 

--- a/tests/test_suite_isolation_guard.py
+++ b/tests/test_suite_isolation_guard.py
@@ -8,7 +8,9 @@ repo tree again.
 import os
 from pathlib import Path
 
+import common.dedup as dedup
 import common.image_generator as ig
+import common.signal_tracker as st
 
 # Test-file-local anchor for the committed repo tree. We deliberately derive the
 # path from ``__file__`` instead of importing ``common.image_generator.REPO_ROOT``:
@@ -17,6 +19,7 @@ import common.image_generator as ig
 # signal). ``tests/`` lives at the repo root, so its parent is the checkout root.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _REPO_IMAGES = str((_REPO_ROOT / "assets" / "images" / "generated").resolve())
+_REPO_STATE = str((_REPO_ROOT / "_state").resolve())
 
 
 def test_generated_images_redirected_off_repo_tree():
@@ -43,4 +46,54 @@ def test_generated_images_redirected_off_repo_tree():
     # tree, or writes would still dirty the working tree.
     assert not active.startswith(_REPO_IMAGES), (
         f"IMAGES_DIR ({active}) is nested inside the committed assets tree; writes would still dirty the working tree."
+    )
+
+
+def test_dedup_state_redirected_off_repo_tree():
+    """``_isolate_dedup_state`` must redirect dedup writes off the repo tree.
+
+    Every collector persists cross-run dedup state through ``DedupEngine``,
+    which resolves its output file as ``os.path.join(common.dedup.STATE_DIR,
+    state_file)``. Integration tests that drive a real collector's
+    ``save_state()`` without patching ``STATE_DIR`` rely on the autouse
+    fixture to point it at a throwaway tmp dir. If that fixture is removed,
+    those tests write ``*_seen.json`` files into the committed ``_state/``
+    tree, leaving dirty working-tree side effects.
+
+    Asserting the active dir is not (and is not nested inside) the committed
+    ``_state/`` tree turns a silent regression into an immediate failure.
+    """
+    active = os.path.abspath(dedup.STATE_DIR)
+
+    assert active != _REPO_STATE, (
+        "dedup.STATE_DIR points at the committed repo tree during tests — the "
+        "_isolate_dedup_state conftest fixture is not active. Collector "
+        "save_state() tests will pollute the working tree."
+    )
+    assert not active.startswith(_REPO_STATE + os.sep), (
+        f"STATE_DIR ({active}) is nested inside the committed _state tree; writes would still dirty the working tree."
+    )
+
+
+def test_signal_history_redirected_off_repo_tree():
+    """``_isolate_signal_history_state`` must redirect signal writes off the tree.
+
+    ``SignalTracker`` defaults ``history_path`` to ``common.signal_tracker.
+    _HISTORY_FILE`` resolved at call time (lazy sentinel). A no-arg
+    ``SignalTracker()`` — the form ``collect_market_indicators`` uses in
+    production — relies on the autouse fixture to point ``_HISTORY_FILE`` at a
+    throwaway tmp file. If that fixture is removed, such tests write
+    ``signal_history.json`` into the committed ``_state/`` tree, leaving dirty
+    working-tree side effects.
+
+    Asserting the active path is not inside the committed ``_state/`` tree turns
+    a silent regression into an immediate failure.
+    """
+    active = os.path.abspath(st._HISTORY_FILE)
+
+    assert not active.startswith(_REPO_STATE + os.sep), (
+        f"signal_tracker._HISTORY_FILE ({active}) points inside the committed "
+        "_state tree during tests — the _isolate_signal_history_state conftest "
+        "fixture is not active. No-arg SignalTracker() tests will pollute the "
+        "working tree."
     )


### PR DESCRIPTION
## 개요

수집기·신호 추적기의 `_state` 런타임 쓰기를 conftest autouse fixture로 **선제 격리**하여, 향후 통합 테스트가 경로를 명시적으로 패치하지 않아도 커밋된 `_state/` 트리를 오염시키지 않도록 일반화합니다. 기존 이미지 격리 fixture 패턴(`_isolate_generated_images`)을 `_state` 계열로 확장한 것입니다.

## 변경 내용

### 프로덕션 (`scripts/common/signal_tracker.py`)
- `SignalTracker.__init__` 기본 인자를 **import 시점 바인딩**(`= _HISTORY_FILE`)에서 **호출 시점 lazy-sentinel**(`= None` → 본문에서 모듈 전역 해석)로 변경. 무인자 `SignalTracker()`(프로덕션 `collect_market_indicators` 경로)도 테스트에서 `_HISTORY_FILE` monkeypatch로 리다이렉트 가능. **후방호환 유지**(명시적 `history_path=` 그대로 우선).
- 데드코드 `_SIGNAL_STORE` 제거 (파일 내 참조 0건, import-time 경로 트랩).

### 테스트 격리 (`tests/conftest.py`)
- `_isolate_dedup_state`: `dedup.STATE_DIR`을 per-test tmp로 리다이렉트 (12개 수집기 공유 `save_state` 경로 커버).
- `_isolate_signal_history_state`: `signal_tracker._HISTORY_FILE` 리다이렉트.
- `no_state_isolation` 마커 opt-out을 두 fixture에 추가.

### 회귀 가드 (`tests/test_suite_isolation_guard.py`)
- `dedup.STATE_DIR` / `signal_tracker._HISTORY_FILE`이 커밋 `_state/` 밖임을 단언. fixture 제거 시 즉시 FAIL (RED/GREEN 실증 완료).

### autouse fixture 충돌 해소
- `_isolate_dedup_state`가 `test_state_path_anchoring[dedup.STATE_DIR]` 런타임 anchoring 가드와 충돌(동일 attr을 한쪽은 리다이렉트, 한쪽은 repo-root 단언). `no_state_isolation` 마커를 `pyproject.toml`에 등록하고 해당 anchoring 테스트에 적용해 해소.
- `test_signal_tracker_time_series.py`: `_SIGNAL_STORE` 삭제로 고아가 된 import·데드코드 검사 테스트 정리.

## 검증

- 풀 스위트: **4906 passed, 16 skipped** (exit 0)
- `git status _state/`: **clean** (오염 0)
- signal/dedup 가드 RED/GREEN 실증: fixture 무력화 → FAIL, 복원 → PASS
- 무인자 `SignalTracker()` 실증: tmp로 리다이렉트되어 실제 `record()` 쓰기가 off-tree
- `ruff check` + `ruff format --check` + `basedpyright` 전부 통과

## Test plan

- [x] `python3 -m pytest tests/ --no-cov -q` → 4906 passed / 16 skipped
- [x] `python3 -m ruff check` / `ruff format --check` (CI Code Quality 패리티)
- [x] `python3 -m basedpyright scripts/common/signal_tracker.py`
- [x] 풀 스위트 후 `git status` `_state/` 무변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)