### PR TITLE
test: hermetic 가드에 module-alias attribute 접근 탐지 확장

### DIFF
--- a/tests/test_hermetic_test_writes_guard.py
+++ b/tests/test_hermetic_test_writes_guard.py
@@ -29,19 +29,34 @@ used by read-only config guards are assignments, not imports, so they are NOT
 flagged. This guard AST-scans (ignoring comments/strings), so the docstrings and
 ``monkeypatch.setattr("...REPO_ROOT...")`` string literals above never trip it.
 
-## Scope / known residual gap
+## Scope
 
-This guard inspects ``ast.ImportFrom`` only. It deliberately does NOT flag
-module-alias attribute access (``import common.post_generator as pg; pg.REPO_ROOT``
-or ``from common import post_generator; post_generator.REPO_ROOT``). No current
-test uses that form, and catching it would require resolving alias bindings at
-the risk of false-positives on the legitimate ``monkeypatch.setattr(mod,
-"REPO_ROOT", ...)`` object form. The direct ``from <prod> import <root>`` form is
-the canonical real-tree-write vector and the one the incident used.
+This guard flags two shapes of production real-tree-root access in tests:
 
-Direction: presence check — any banned production root import trips. If a future
+  1. Direct import — ``from <prod> import REPO_ROOT`` (incl. ``... as RR``).
+     The canonical vector the 2026-06-30 incident used.
+  2. Module-alias attribute access — reading the root off a production module
+     bound to a local name:
+       - ``import common.post_generator as pg; pg.REPO_ROOT``
+       - ``from common import post_generator; post_generator.REPO_ROOT``
+       - ``import common.post_generator; common.post_generator.REPO_ROOT``
+     These leak the *real* repo root into the test just as surely as form 1.
+
+Intentionally NOT flagged — the legitimate redirect: the object-form
+``monkeypatch.setattr(pg, "REPO_ROOT", str(tmp_path))`` (or the string-target
+``monkeypatch.setattr("common.post_generator.REPO_ROOT", ...)``). Neither
+produces a ``mod.REPO_ROOT`` *attribute-read* node — the module is passed as an
+argument and the name is a string literal — so the AST attribute scan never
+sees them. That asymmetry (read-attribute is banned, setattr object/string form
+is allowed) is what makes closing the alias gap safe.
+
+Attribute access to *non-root* module attributes (``dedup.STATE_DIR``,
+``signal_tracker._HISTORY_FILE``, ``image_generator.IMAGES_DIR``) is untouched —
+only names in ``_BANNED_NAMES`` trip the scan.
+
+Direction: presence check — any banned production root read trips. If a future
 test legitimately needs to *read* a repo file, derive a local ``__file__`` anchor
-instead of importing the production constant.
+instead of importing/aliasing the production constant.
 """
 
 from __future__ import annotations
@@ -71,20 +86,82 @@ def _py_files() -> list[Path]:
     return [p for p in TESTS_DIR.rglob("*.py") if "__pycache__" not in p.parts]
 
 
+def _dotted_name(node: ast.expr) -> str | None:
+    """Return the dotted path for a ``Name``/``Attribute`` chain (``a.b.c``), else None."""
+    parts: list[str] = []
+    cur: ast.expr = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _collect_prod_module_aliases(tree: ast.AST) -> set[str]:
+    """Local names bound to a *production module* (for alias-attribute detection).
+
+    Records the module-binding import forms:
+      - ``import common.post_generator as pg``       → ``{"pg"}``
+      - ``from common import post_generator``        → ``{"post_generator"}``
+      - ``from common import post_generator as pg``  → ``{"pg"}``
+
+    ``import common.post_generator`` (no ``as``) binds the top package ``common``
+    and is instead matched by the dotted-chain check in ``_scan_tree``, so it is
+    not recorded here. ``from <prod> import <ROOT>`` (a banned root name, not a
+    module) is the direct-import form and is skipped here — the ``ImportFrom``
+    branch in ``_scan_tree`` handles it.
+    """
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.asname and _is_production_module(a.name):
+                    aliases.add(a.asname)
+        elif isinstance(node, ast.ImportFrom) and _is_production_module(node.module):
+            for a in node.names:
+                if a.name in _BANNED_NAMES:
+                    continue  # direct root import — handled separately
+                aliases.add(a.asname or a.name)
+    return aliases
+
+
+def _scan_tree(tree: ast.AST, label: str) -> list[str]:
+    """Return ``label:line`` offenders for a single parsed module."""
+    offenders: list[str] = []
+    aliases = _collect_prod_module_aliases(tree)
+    for node in ast.walk(tree):
+        # Form 1 — direct ``from <prod> import REPO_ROOT``.
+        if isinstance(node, ast.ImportFrom) and _is_production_module(node.module):
+            if any(alias.name in _BANNED_NAMES for alias in node.names):
+                offenders.append(f"{label}:{node.lineno}")
+        # Form 2 — module-alias attribute *read* ``<mod>.REPO_ROOT``. The
+        # ``monkeypatch.setattr(mod, "REPO_ROOT", ...)`` object form has no such
+        # attribute node (module is an arg, name is a string), so it is not hit.
+        elif isinstance(node, ast.Attribute) and node.attr in _BANNED_NAMES:
+            base = node.value
+            if isinstance(base, ast.Name) and base.id in aliases:
+                offenders.append(f"{label}:{node.lineno}")  # 2a: aliased module
+            else:
+                dotted = _dotted_name(base)  # 2b: dotted no-alias (common.post_generator.*)
+                if dotted is not None and _is_production_module(dotted):
+                    offenders.append(f"{label}:{node.lineno}")
+    return offenders
+
+
 def _scan() -> tuple[list[str], list[str]]:
     """Return (offenders, unparseable) — both as ``path:line`` / ``path`` strings."""
     offenders: list[str] = []
     unparseable: list[str] = []
     for path in _py_files():
+        rel = str(path.relative_to(TESTS_DIR.parent))
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except (OSError, SyntaxError):
-            unparseable.append(str(path.relative_to(TESTS_DIR.parent)))
+            unparseable.append(rel)
             continue
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom) and _is_production_module(node.module):
-                if any(alias.name in _BANNED_NAMES for alias in node.names):
-                    offenders.append(f"{path.relative_to(TESTS_DIR.parent)}:{node.lineno}")
+        offenders.extend(_scan_tree(tree, rel))
     return offenders, unparseable
 
 
@@ -102,9 +179,52 @@ def test_tests_dir_scanned_nonvacuous():
 def test_no_test_imports_production_repo_root():
     offenders, _ = _scan()
     assert not offenders, (
-        "테스트가 production 실제-트리 루트 상수를 import 했습니다 (비-격리 실제-트리 쓰기 위험):\n"
+        "테스트가 production 실제-트리 루트 상수를 import/별칭-접근 했습니다 (비-격리 실제-트리 쓰기 위험):\n"
         + "\n".join(f"  - {o}" for o in offenders)
         + "\n\n실제 repo 트리에 쓰지 말고, 대상 모듈의 루트 상수를 tmp 로 monkeypatch 하세요:\n"
         '    monkeypatch.setattr("common.post_generator.REPO_ROOT", str(tmp_path))\n'
         f"금지 상수: {_BANNED_NAMES}. 의도된 변경이면 이 가드의 docstring/_BANNED_NAMES 를 함께 갱신하세요."
     )
+
+
+def _offenders_in(source: str) -> list[str]:
+    """Run the detector against an inline snippet (detector unit-test helper)."""
+    return _scan_tree(ast.parse(source), "<snippet>")
+
+
+def test_detector_flags_all_banned_forms():
+    """The detector must flag every real-tree-root access shape, direct and aliased."""
+    bad = (
+        # Form 1 — direct import (incl. `as`).
+        "from common.post_generator import REPO_ROOT\n",
+        "from common.post_generator import REPO_ROOT as RR\n",
+        # Form 2a — aliased module attribute read.
+        "import common.post_generator as pg\nx = pg.REPO_ROOT\n",
+        "from common import post_generator\nx = post_generator.POSTS_DIR\n",
+        "from common import post_generator as pg\nx = pg.SITE_DIR\n",
+        "from scripts.common import post_generator\nx = post_generator.REPO_ROOT\n",
+        # Form 2b — dotted no-alias chain.
+        "import common.post_generator\nx = common.post_generator.REPO_ROOT\n",
+    )
+    for snippet in bad:
+        assert _offenders_in(snippet), f"detector missed: {snippet!r}"
+
+
+def test_detector_spares_legitimate_forms():
+    """The detector must NOT flag the sanctioned redirect / non-root forms."""
+    good = (
+        # Object-form setattr — module is an arg, name is a string. No attr-read node.
+        'import common.post_generator as pg\nmonkeypatch.setattr(pg, "REPO_ROOT", str(tmp_path))\n',
+        # String-target setattr/patch — a literal, not an attribute access.
+        'monkeypatch.setattr("common.post_generator.REPO_ROOT", str(tmp_path))\n',
+        'patch("common.post_generator.POSTS_DIR", str(tmp_path))\n',
+        # Non-root attribute on a prod-module alias — out of scope.
+        "import common.dedup as dedup\nx = dedup.STATE_DIR\n",
+        "import common.signal_tracker as st\nx = st._HISTORY_FILE\n",
+        # Local __file__ anchor (the sanctioned pattern) — an assignment, not import/alias.
+        "_REPO_ROOT = Path(__file__).resolve().parent.parent\nx = _REPO_ROOT / '_state'\n",
+        # Banned name as an attribute on a NON-production module.
+        "import os\nx = os.REPO_ROOT\n",
+    )
+    for snippet in good:
+        assert not _offenders_in(snippet), f"detector false-positive: {snippet!r}"


### PR DESCRIPTION
## 요약

hermetic 테스트-쓰기 가드(`tests/test_hermetic_test_writes_guard.py`)가 지금까지 놓치던 **module-alias attribute 접근** 벡터를 탐지하도록 확장합니다. 기존 가드는 `ast.ImportFrom`만 검사해 `from <prod> import REPO_ROOT` 직접 import만 잡았고, alias를 통한 attribute read는 명시적 known-gap으로 남아 있었습니다.

## 변경 내용

탐지하는 두 가지 형태:
1. **직접 import** — `from <prod> import REPO_ROOT` (`... as RR` 포함). 2026-06-30 인시던트가 사용한 정규 벡터.
2. **module-alias attribute read** — production 모듈을 로컬 이름에 바인딩 후 루트 상수를 읽는 형태:
   - `import common.post_generator as pg; pg.REPO_ROOT`
   - `from common import post_generator; post_generator.REPO_ROOT`
   - `import common.post_generator; common.post_generator.REPO_ROOT` (dotted no-alias)

의도적으로 **탐지하지 않는** 합법 리다이렉트:
- object-form `monkeypatch.setattr(pg, "REPO_ROOT", str(tmp_path))` — 모듈이 인자, 이름이 문자열이라 attribute-read 노드가 없음
- string-target `monkeypatch.setattr("common.post_generator.REPO_ROOT", ...)` — 문자열 리터럴
- non-root attribute (`dedup.STATE_DIR`, `signal_tracker._HISTORY_FILE` 등) — `_BANNED_NAMES`에 없음

이 read-attribute(금지) vs setattr object/string(허용) 비대칭이 alias gap을 안전하게 닫을 수 있는 근거입니다.

### 구현
- `_dotted_name()` — `a.b.c` Name/Attribute 체인을 dotted path로 환원
- `_collect_prod_module_aliases()` — production 모듈에 바인딩된 로컬 이름 수집
- `_scan_tree()` — Form 1(ImportFrom) + Form 2(Attribute read) 통합 스캔
- 탐지기 단위 테스트 2건 추가: `test_detector_flags_all_banned_forms`, `test_detector_spares_legitimate_forms`

## 검증

```
$ python3 -m pytest tests/test_hermetic_test_writes_guard.py --no-cov -q
4 passed in 0.92s

$ python3 -m ruff check tests/test_hermetic_test_writes_guard.py
All checks passed!
$ python3 -m ruff format --check tests/test_hermetic_test_writes_guard.py
1 file already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
