### PR TITLE
test: translator _CACHE_PATH _state 런타임 쓰기 격리 + 회귀 가드

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,6 +207,55 @@ def _isolate_signal_history_state(request, tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_translation_cache(request, tmp_path, monkeypatch):
+    """Redirect translator ``_state/translation_cache.json`` writes to a tmp dir.
+
+    ``_save_cache()`` / ``_load_cache()`` read the module global
+    ``common.translator._CACHE_PATH`` *at call time* (no import-time default-arg
+    binding), so a plain attribute redirect covers any code path that persists
+    the cache. Integration tests that drive a real translation flow
+    (``translate_batch`` → ``save_translation_cache``) without patching
+    ``_CACHE_PATH`` themselves would otherwise write ``translation_cache.json``
+    into the committed ``_state/`` tree — the dirty-working-tree side effect the
+    dedup/signal fixtures also prevent. Pointing the module attribute at a
+    throwaway file keeps those writes hermetic.
+
+    The module memoizes the loaded cache in the ``_cache`` global (``_load_cache``
+    returns early when it is not ``None``). Reset ``_cache``/``_cache_dirty`` too,
+    or a cache loaded by an earlier test would leak forward and defeat the
+    redirect (the early return skips re-reading the now-repointed path).
+
+    Opt-out: tests marked ``no_state_isolation`` (e.g. the runtime
+    path-anchoring guard, which asserts ``_CACHE_PATH`` is under the repo root)
+    need the real repo-anchored value, so this redirect skips them — consistent
+    with ``_isolate_dedup_state`` / ``_isolate_signal_history_state``.
+    """
+    if request.node.get_closest_marker("no_state_isolation"):
+        return
+    try:
+        import common.translator as translator
+    except ImportError:
+        return
+
+    dest = tmp_path / "_state" / "translation_cache.json"
+    monkeypatch.setattr(translator, "_CACHE_PATH", dest)
+    monkeypatch.setattr(translator, "_cache", None)
+    monkeypatch.setattr(translator, "_cache_dirty", False)
+
+    # Some tests import via ``scripts.common.*`` (a distinct module object).
+    # Patch the twin defensively so both namespaces agree on the redirect.
+    try:
+        import scripts.common.translator as translator_scripts
+
+        if translator_scripts is not translator:
+            monkeypatch.setattr(translator_scripts, "_CACHE_PATH", dest)
+            monkeypatch.setattr(translator_scripts, "_cache", None)
+            monkeypatch.setattr(translator_scripts, "_cache_dirty", False)
+    except ImportError:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def _isolate_image_rejection_state(tmp_path, monkeypatch):
     """Redirect image_rejection_metrics state + archive paths to a per-test tmp dir.
 

--- a/tests/test_suite_isolation_guard.py
+++ b/tests/test_suite_isolation_guard.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import common.dedup as dedup
 import common.image_generator as ig
 import common.signal_tracker as st
+import common.translator as translator
 
 # Test-file-local anchor for the committed repo tree. We deliberately derive the
 # path from ``__file__`` instead of importing ``common.image_generator.REPO_ROOT``:
@@ -96,4 +97,28 @@ def test_signal_history_redirected_off_repo_tree():
         "_state tree during tests — the _isolate_signal_history_state conftest "
         "fixture is not active. No-arg SignalTracker() tests will pollute the "
         "working tree."
+    )
+
+
+def test_translation_cache_redirected_off_repo_tree():
+    """``_isolate_translation_cache`` must redirect translator writes off the tree.
+
+    ``_save_cache()`` resolves its output through ``common.translator.
+    _CACHE_PATH`` read at call time. A real translation flow
+    (``translate_batch`` → ``save_translation_cache``) that does not patch
+    ``_CACHE_PATH`` relies on the autouse fixture to point it at a throwaway
+    tmp file. If that fixture is removed, such tests write
+    ``translation_cache.json`` into the committed ``_state/`` tree, leaving
+    dirty working-tree side effects.
+
+    Asserting the active path is not inside the committed ``_state/`` tree turns
+    a silent regression into an immediate failure.
+    """
+    active = os.path.abspath(translator._CACHE_PATH)
+
+    assert not active.startswith(_REPO_STATE + os.sep), (
+        f"translator._CACHE_PATH ({active}) points inside the committed "
+        "_state tree during tests — the _isolate_translation_cache conftest "
+        "fixture is not active. translate_batch()/save_translation_cache() "
+        "tests will pollute the working tree."
     )


### PR DESCRIPTION
## 요약

translator 번역 캐시(`_state/translation_cache.json`)의 런타임 쓰기를 conftest autouse fixture로 선제 격리합니다. dedup(#1067)·signal에 이미 적용된 `_state` 격리 패턴을 translator까지 확장하여, 향후 통합 테스트가 경로를 명시적으로 패치하지 않아도 커밋된 `_state/` 트리를 오염시키지 않도록 합니다.

## production 무변경 — signal_tracker와의 결정적 차이

`translator._save_cache()` / `_load_cache()`는 모듈 전역 `_CACHE_PATH`를 **호출 시점에 직접** 읽습니다 (`scripts/common/translator.py:297,359`). signal_tracker의 `__init__(history_file=_HISTORY_FILE)` 같은 import-time default-arg 바인딩이 없으므로 **lazy-sentinel 리팩토링이 불필요**합니다. 속성 리다이렉트만으로 모든 저장 경로가 커버됩니다.

## 변경 내용 (테스트 인프라 2파일, +74줄)

**`tests/conftest.py`** — `_isolate_translation_cache` autouse fixture
- `translator._CACHE_PATH`를 per-test tmp로 리다이렉트
- `_cache`/`_cache_dirty` 전역도 리셋 — `_load_cache()`의 메모이제이션 조기 반환(`_cache is not None` 시)이 이전 테스트가 로드한 캐시를 새어보내 리다이렉트를 무효화하는 것을 방지
- `scripts.common.translator` 별칭 이중 패치
- `no_state_isolation` 마커 opt-out (dedup/signal fixture와 일관)

**`tests/test_suite_isolation_guard.py`** — `test_translation_cache_redirected_off_repo_tree`
- 테스트 중 `translator._CACHE_PATH`가 커밋된 `_state/` 밖임을 단언. fixture 무력화 시 즉시 FAIL.

## anchoring 충돌 선(先)해소

기존 `test_state_path_anchoring[translator._CACHE_PATH]`(`tests/test_state_path_anchoring.py:246,250`)는 이미 `@pytest.mark.no_state_isolation` 마킹되어 있어, 이번 autouse redirect와 충돌하지 않습니다. dedup에서 겪은 충돌이 translator엔 미리 대비돼 있었습니다.

## 검증

```
$ python3 -m pytest tests/test_suite_isolation_guard.py tests/test_translator.py tests/test_state_path_anchoring.py --no-cov -q
129 passed

# RED/GREEN 실증: fixture 본문 임시 early-return → 신규 가드가
# _CACHE_PATH=<repo>/_state/translation_cache.json 로 AssertionError FAIL → 복원 후 GREEN

$ python3 -m ruff check tests/conftest.py tests/test_suite_isolation_guard.py     # All checks passed!
$ python3 -m ruff format --check ...                                              # 2 files already formatted
$ python3 -m pytest tests/test_hermetic_test_writes_guard.py --no-cov -q          # 4 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
