### PR TITLE
test: SSRF DNS 해석을 결정적 스텁으로 격리 (오프라인 flaky 제거)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,8 +60,8 @@ def _block_real_http(monkeypatch):
     public host that the SSRF guard permits (``example.com`` resolves publicly) —
     a slow, flaky "green". Blocking the transport layer turns that into an
     immediate, obvious failure. Tests that mock ``requests`` never reach this
-    adapter, so they are unaffected; DNS-resolution guards (``socket.getaddrinfo``)
-    are also untouched.
+    adapter, so they are unaffected. The DNS layer is handled separately by
+    ``_deterministic_dns_resolution`` (SSRF guard resolution).
     """
     try:
         from requests.adapters import HTTPAdapter
@@ -75,6 +75,60 @@ def _block_real_http(monkeypatch):
         )
 
     monkeypatch.setattr(HTTPAdapter, "send", _blocked)
+
+
+# A globally-routable public IP. ``_is_non_public_ip`` returns False for it, so a
+# hostname resolving here is treated as a public (allowed) SSRF target. The
+# ``_ssrf_dns_stub`` marker below lets the isolation guard confirm the resolver
+# is stubbed without depending on the runner's live DNS.
+_PUBLIC_TEST_IP = "93.184.216.34"
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_dns_resolution(monkeypatch):
+    """Pin the SSRF guard's DNS resolution so it never depends on live network.
+
+    ``common.utils.is_private_url_target`` resolves multi-label public hostnames
+    via ``socket.getaddrinfo`` and *fails closed* — treating the URL as private
+    and blocking it — when resolution fails. On a runner with no outbound DNS
+    (offline local dev, a sandboxed CI job) a public test URL such as
+    ``https://example.com/feed.rss`` is then blocked, so ``fetch_rss_feed`` /
+    ``fetch_page_metadata`` return nothing and the collector/enrichment tests
+    that drive them fail. When DNS *is* reachable the same tests pass. That
+    network coupling is a latent flaky-green: the outcome depends on the
+    runner's resolver, not the code under test.
+
+    Pinning ``socket.getaddrinfo`` to a fixed public IP makes any hostname that
+    reaches the DNS step resolve deterministically to a non-blocked address.
+    Private targets (literal IPs, single-label names, ``.internal`` / rebind
+    suffixes) are rejected *before* the DNS step, so they are unaffected. Tests
+    that assert the DNS branch itself (``test_utils_ssrf``) install their own
+    ``patch("socket.getaddrinfo", ...)`` inside the test body, which overrides
+    this fixture for that scope and restores it on exit.
+
+    The guard memoizes results in a module-level ``TTLCache``; clear it (on both
+    the ``common.*`` and ``scripts.common.*`` module twins) so a value cached
+    under a prior real/offline resolution cannot leak across tests.
+    """
+    import importlib
+    import socket
+
+    def _fake_getaddrinfo(host, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (_PUBLIC_TEST_IP, 0))]
+
+    _fake_getaddrinfo._ssrf_dns_stub = True  # tripwire for the isolation guard
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    for mod_name in ("common.utils", "scripts.common.utils"):
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        cache = getattr(mod, "_dns_cache", None)
+        lock = getattr(mod, "_dns_cache_lock", None)
+        if cache is not None and lock is not None:
+            with lock:
+                cache.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,15 +106,37 @@ def _deterministic_dns_resolution(monkeypatch):
     ``patch("socket.getaddrinfo", ...)`` inside the test body, which overrides
     this fixture for that scope and restores it on exit.
 
+    Loopback and literal-IP lookups pass through to the real resolver: a test
+    that connects to a local server (``127.0.0.1``, ``localhost``) must not have
+    that address rewritten to an off-box public IP, which fails as an opaque
+    ``Can't assign requested address``. Only name lookups — the ones the SSRF
+    guard's DNS step actually performs — are pinned.
+
     The guard memoizes results in a module-level ``TTLCache``; clear it (on both
     the ``common.*`` and ``scripts.common.*`` module twins) so a value cached
     under a prior real/offline resolution cannot leak across tests.
     """
     import importlib
+    import ipaddress
     import socket
 
-    def _fake_getaddrinfo(host, *args, **kwargs):
-        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (_PUBLIC_TEST_IP, 0))]
+    real_getaddrinfo = socket.getaddrinfo
+    _LOCAL_HOSTNAMES = {"localhost", "localhost.localdomain", "ip6-localhost"}
+
+    def _fake_getaddrinfo(host, port=None, *args, **kwargs):
+        name = (host or "").strip().rstrip(".").lower()
+        if name in _LOCAL_HOSTNAMES:
+            return real_getaddrinfo(host, port, *args, **kwargs)
+        try:
+            ipaddress.ip_address(name)
+        except ValueError:
+            pass
+        else:  # already a literal address — no name resolution to pin
+            return real_getaddrinfo(host, port, *args, **kwargs)
+        # Preserve the requested port so a caller that dials the returned
+        # sockaddr reaches the port it asked for (service names -> 0).
+        sock_port = port if isinstance(port, int) else 0
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (_PUBLIC_TEST_IP, sock_port))]
 
     _fake_getaddrinfo._ssrf_dns_stub = True  # tripwire for the isolation guard
     monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)

--- a/tests/test_suite_isolation_guard.py
+++ b/tests/test_suite_isolation_guard.py
@@ -145,6 +145,33 @@ def test_ssrf_dns_resolution_pinned_off_live_network():
         "live network and flake when DNS is unavailable."
     )
 
+    # The fixture also clears the guard's DNS TTLCache on both module twins, but
+    # it looks the cache up with getattr(..., None) — renaming ``_dns_cache`` or
+    # ``_dns_cache_lock`` would turn that clear into a silent no-op and let a
+    # resolution cached under a prior (real or offline) resolver leak across
+    # tests. Assert the attributes still exist and the cache really is empty at
+    # test start, before this test itself populates it below.
+    import importlib
+
+    checked = 0
+    for mod_name in ("common.utils", "scripts.common.utils"):
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        checked += 1
+        assert hasattr(mod, "_dns_cache") and hasattr(mod, "_dns_cache_lock"), (
+            f"{mod_name} no longer exposes _dns_cache/_dns_cache_lock — the "
+            "_deterministic_dns_resolution cache clear is a silent no-op."
+        )
+        assert not mod._dns_cache, (
+            f"{mod_name}._dns_cache is non-empty at test start — the "
+            "_deterministic_dns_resolution fixture did not clear it, so a "
+            "stale resolution can leak between tests."
+        )
+
+    assert checked, "neither common.utils nor scripts.common.utils was importable"
+
     # Behavioural corollary: a public URL must not be blocked by the guard.
     from common.utils import is_private_url_target
 

--- a/tests/test_suite_isolation_guard.py
+++ b/tests/test_suite_isolation_guard.py
@@ -122,3 +122,33 @@ def test_translation_cache_redirected_off_repo_tree():
         "fixture is not active. translate_batch()/save_translation_cache() "
         "tests will pollute the working tree."
     )
+
+
+def test_ssrf_dns_resolution_pinned_off_live_network():
+    """``_deterministic_dns_resolution`` must pin SSRF DNS off the live network.
+
+    ``common.utils.is_private_url_target`` resolves public hostnames via
+    ``socket.getaddrinfo`` and fails closed when resolution fails, so without the
+    autouse fixture a runner with no outbound DNS blocks ``example.com`` and the
+    collector/enrichment tests that fetch it fail (they pass again once DNS is
+    reachable — a flaky-green). This asserts the resolver is the fixture's stub,
+    which is network-independent: a live-DNS ``getaddrinfo`` carries no
+    ``_ssrf_dns_stub`` marker, so removing the fixture fails here in CI too, not
+    only offline.
+    """
+    import socket
+
+    assert getattr(socket.getaddrinfo, "_ssrf_dns_stub", False), (
+        "socket.getaddrinfo is the real resolver during tests — the "
+        "_deterministic_dns_resolution conftest fixture is not active. SSRF "
+        "DNS-dependent collector/enrichment tests will couple to the runner's "
+        "live network and flake when DNS is unavailable."
+    )
+
+    # Behavioural corollary: a public URL must not be blocked by the guard.
+    from common.utils import is_private_url_target
+
+    assert is_private_url_target("https://example.com/feed.rss") is False, (
+        "example.com is blocked by the SSRF guard under the pinned resolver — "
+        "the deterministic DNS stub is not returning a public address."
+    )


### PR DESCRIPTION
## 배경

`common.utils.is_private_url_target`는 멀티라벨 공개 호스트명을 `socket.getaddrinfo`로 해석하고, 해석 실패 시 **fail-closed**(private로 간주해 차단)합니다.

그 결과 아웃바운드 DNS가 없는 러너(오프라인 로컬 개발, 샌드박스 CI 잡)에서는 `https://example.com/feed.rss` 같은 공개 테스트 URL이 차단되고, `fetch_rss_feed` / `fetch_page_metadata`가 빈 결과를 반환해 이를 구동하는 수집기·enrichment 테스트가 실패합니다. DNS가 되는 환경에서는 같은 테스트가 통과합니다.

즉 테스트 결과가 **코드가 아니라 러너의 리졸버에 의존**하는 잠복 flaky-green이었습니다. 오프라인 환경에서 51건이 이 원인으로 실패했습니다.

## 변경 내용

### 1. `_deterministic_dns_resolution` autouse fixture (`tests/conftest.py`)

- `socket.getaddrinfo`를 고정 공인 IP(`93.184.216.34`)로 핀 고정 → DNS 단계에 도달한 호스트명은 항상 non-blocked 주소로 결정적으로 해석
- loopback 호스트명(`localhost` 등)과 **리터럴 IP는 원본 리졸버로 패스스루** → 로컬 서버로 접속하는 테스트가 off-box로 리다이렉트되지 않음 (리터럴 IP는 `getaddrinfo`가 수치 파싱만 하므로 오프라인 안전성 유지)
- 요청 포트를 sockaddr에 보존 (서비스명 문자열은 0으로 폴백)
- 모듈 레벨 `_dns_cache`(TTLCache)를 `common.utils` / `scripts.common.utils` **양쪽 모두** clear — 두 모듈은 같은 파일에서 로드되지만 별개 모듈 객체이고 캐시도 별개 객체임을 확인했습니다

### 2. 격리 가드 테스트 (`tests/test_suite_isolation_guard.py`)

`test_ssrf_dns_resolution_pinned_off_live_network` — 리졸버가 fixture의 스텁인지(`_ssrf_dns_stub` 마커) 확인. 실제 `socket.getaddrinfo`에는 이 속성이 없으므로 **DNS가 정상인 CI에서도** fixture가 제거되면 실패합니다. 행위 corollary로 `is_private_url_target("https://example.com/feed.rss") is False`도 함께 검증합니다.

## 설계 노트

**왜 RFC 5737 문서화 대역(TEST-NET)을 쓰지 않았나**
Python 3.13의 `ipaddress`에서 `203.0.113.0/24`, `192.0.2.0/24`, `198.51.100.0/24`는 모두 `is_private=True`, `233.252.0.1`은 multicast입니다. `_is_non_public_ip`(scripts/common/utils.py:91-103)가 전부 차단하므로 문서화 대역은 사용할 수 없습니다.

**false-green 위험이 없는 이유**
`tests/test_utils_ssrf.py`의 음성/fail-closed 케이스는 테스트 본문에서 자체적으로 `patch("socket.getaddrinfo", ...)`를 설치합니다(:138, :227-282, :299). 해당 스코프에서 이 fixture를 덮어쓰므로 private IP 탐지·DNS rebinding·fail-closed 분기는 계속 실제로 검증됩니다.

**다른 autouse fixture와의 상호작용**
`_block_real_http`(전송 계층 차단)와 계층이 분리되어 충돌 없음. `tests/i18n/conftest.py:50`의 session-scoped `base_url` 헬스체크는 function-scoped fixture보다 먼저 실행되므로 영향받지 않습니다.

## 검증

| 항목 | 결과 |
|---|---|
| `python3 -m pytest tests/ -q --no-cov` (랜덤 순서) | `4910 passed, 16 skipped` (exit 0) |
| 동일 명령 `-p no:randomly` (고정 순서) | `4910 passed, 16 skipped` (exit 0) |
| `python3 -m ruff check scripts/ tests/` | All checks passed |
| `python3 -m ruff format --check scripts/ tests/` | 261 files already formatted |
| loopback 패스스루 | 임시 테스트로 `127.0.0.1`/`localhost` 로컬 서버 접속 성공, `example.com:443` → `(93.184.216.34, 443)` 고정 확인 후 파일 제거 |

16 skipped는 Jekyll 프리뷰 서버가 없을 때 스킵되는 i18n E2E 스위트입니다 (본 변경과 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)