### PR TITLE
docs: DNS 캐시 docstring을 lru_cache→TTLCache 기준으로 정정

### DIFF
--- a/scripts/common/utils.py
+++ b/scripts/common/utils.py
@@ -175,10 +175,15 @@ def is_private_url_target(url: str) -> bool:
     but necessary: an attacker who can influence DNS can also cause transient
     failures.
 
-    Note on CI environments: the ``@lru_cache`` on ``_resolve_hostname_ips``
-    can be cleared in tests via ``_resolve_hostname_ips.cache_clear()`` and
-    ``socket.getaddrinfo`` can be mocked with ``unittest.mock.patch`` to avoid
-    real network calls.
+    Note on CI environments: ``_resolve_hostname_ips`` memoizes into the
+    module-level ``_dns_cache`` (a ``cachetools.TTLCache``, not
+    ``functools.lru_cache``) via ``@cached``; it can be cleared in tests with
+    ``_resolve_hostname_ips.cache_clear()``, and ``socket.getaddrinfo`` can be
+    mocked with ``unittest.mock.patch`` to avoid real network calls. The suite
+    does both automatically — see the ``_deterministic_dns_resolution`` autouse
+    fixture in ``tests/conftest.py``, which pins the resolver and clears
+    ``_dns_cache`` on both the ``common.*`` and ``scripts.common.*`` module
+    twins at every test setup.
     """
     try:
         parsed = urlparse(url)


### PR DESCRIPTION
## 배경

PR #1070 리뷰에서 지적된 NIT(pre-existing) 항목의 후속 처리입니다.

`scripts/common/utils.py`의 `is_private_url_target` docstring이 아직 이렇게 설명합니다:

> the ``@lru_cache`` on ``_resolve_hostname_ips`` can be cleared in tests via ``_resolve_hostname_ips.cache_clear()``

하지만 캐시는 이미 `cachetools.TTLCache`로 교체되었습니다 (scripts/common/utils.py:112, `maxsize=256` / `ttl=300s`). 같은 파일 위쪽 주석(:110)이 *"Previous implementation used functools.lru_cache which cached for process lifetime — unsafe for DNS rebinding defense"* 라고 명시하고 있어 한 파일 안에서 서로 모순됩니다.

#1070이 추가한 conftest fixture docstring이 TTLCache를 정확히 기술하면서 이 불일치가 더 두드러졌습니다.

## 변경 내용

docstring 한 문단만 정정했습니다. **동작 변화 없음.**

- `@lru_cache` → `@cached` + 모듈 레벨 `_dns_cache` (`cachetools.TTLCache`)로 명칭 정정
- 스위트가 이를 자동 수행하는 지점(`tests/conftest.py`의 `_deterministic_dns_resolution` autouse fixture — 리졸버 핀 고정 + 두 모듈 트윈의 `_dns_cache` clear)을 함께 가리키도록 추가

`cache_clear()` 언급 자체는 **유효하므로 유지**했습니다. cachetools 7.0.5의 `@cached` 래퍼도 해당 속성을 제공함을 확인했습니다:

```
cachetools 7.0.5
has cache_clear: True
has cache attr : True
cache is _dns_cache: True
```

## 검증

| 항목 | 결과 |
|---|---|
| `pytest tests/test_utils_ssrf.py tests/test_suite_isolation_guard.py` | `57 passed` |
| `ruff check scripts/ tests/` | All checks passed |
| `ruff format --check scripts/ tests/` | 261 files already formatted |
| `basedpyright scripts/common/utils.py` | 0 errors, 0 warnings, 0 notes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)