### PR TITLE
docs: 격리 fixture 규약 문서화 + 가드 갭 3건 보강 (falsifiability 8/8 실증)

### DIFF
--- a/docs/test-isolation.md
+++ b/docs/test-isolation.md
@@ -1,0 +1,177 @@
+# 테스트 격리 fixture 규약
+
+`tests/conftest.py`의 autouse fixture들은 테스트가 **커밋된 레포 트리를 오염시키거나 실제 네트워크에 결합하는 것**을 막는다. 이 문서는 그 8종의 인벤토리와, 새 격리 fixture를 추가할 때 반드시 따라야 할 규약을 정리한다.
+
+관련 가드: `tests/test_suite_isolation_guard.py` (fixture가 제거되면 즉시 red)
+
+---
+
+## 1. 인벤토리
+
+| # | fixture | 대상 심볼 | 마커 게이트 | 대응 가드 |
+|---|---------|-----------|-------------|-----------|
+| 0 | *(모듈 레벨, import 시점)* | `image_rejection_metrics._STATE_PATH` / `._ARCHIVE_DIR` | — | `test_image_rejection_atexit_baseline_off_repo_tree` |
+| 1 | `_block_real_http` | `requests.adapters.HTTPAdapter.send` | — | `test_real_http_transport_blocked` |
+| 2 | `_deterministic_dns_resolution` | `socket.getaddrinfo` + `utils._dns_cache` | — | `test_ssrf_dns_resolution_pinned_off_live_network` |
+| 3 | `_isolate_generated_images` | `image_generator.IMAGES_DIR` | — | `test_generated_images_redirected_off_repo_tree` |
+| 4 | `_isolate_dedup_state` | `dedup.STATE_DIR` | `no_state_isolation` | `test_dedup_state_redirected_off_repo_tree` |
+| 5 | `_isolate_signal_history_state` | `signal_tracker._HISTORY_FILE` | `no_state_isolation` | `test_signal_history_redirected_off_repo_tree` |
+| 6 | `_isolate_translation_cache` | `translator._CACHE_PATH` + `_cache` / `_cache_dirty` | `no_state_isolation` | `test_translation_cache_redirected_off_repo_tree` |
+| 7 | `_isolate_image_rejection_state` | `image_rejection_metrics._STATE_PATH` / `._ARCHIVE_DIR` | — | `test_image_rejection_state_redirected_off_repo_tree` |
+
+#0과 #7은 같은 모듈을 다루지만 역할이 다르다 — 규약 6 참조.
+
+fixture 정의 순서 = setup 실행 순서이고, teardown은 정확히 역순이다 (`pytest --setup-show`로 확인 가능). 따라서 #1·#2가 가장 먼저 설치되고 가장 나중에 해제된다 — 어떤 `_isolate_*`의 teardown도 실제 네트워크에 도달할 수 없다.
+
+---
+
+## 2. 규약
+
+### 규약 1 — 호출부가 아니라 **모듈 속성**을 리다이렉트한다
+
+프로덕션 코드가 전역을 **호출 시점에** 읽어야 autouse 리다이렉트가 성립한다. 이미 만족하는 사례:
+
+- `DedupEngine.__init__`이 `os.path.join(dedup.STATE_DIR, ...)`를 생성 시점에 평가
+- `signal_tracker._HISTORY_FILE`은 lazy sentinel — 무인자 `SignalTracker()`가 호출 시점에 해석
+- `translator._CACHE_PATH`는 `_save_cache()` / `_load_cache()`가 호출 시점에 읽음 (import 시점 기본 인자 바인딩 아님)
+
+**반례:** `def f(path=STATE_DIR)` 처럼 기본 인자로 바인딩하면 import 시점에 값이 고정되어 리다이렉트가 무력화된다. 이런 코드는 fixture가 아니라 프로덕션 쪽을 고쳐야 한다.
+
+### 규약 2 — 모듈 트윈 **양쪽**을 패치한다
+
+`common.X`와 `scripts.common.X`는 **같은 파일에서 로드된 별개 모듈 객체**다. 실측:
+
+```
+same module obj: False | same _dns_cache: False | same lock: False
+both __file__ == scripts/common/utils.py
+```
+
+일부 테스트는 `scripts.common.*`로 import하므로 한쪽만 패치하면 그 테스트에서 격리가 새어나간다. 8종 전부 다음 형태를 따른다:
+
+```python
+try:
+    import scripts.common.X as x_scripts
+    if x_scripts is not x:
+        monkeypatch.setattr(x_scripts, "ATTR", dest)
+except ImportError:
+    pass
+```
+
+### 규약 3 — **파생 메모 상태**도 함께 리셋한다
+
+경로만 바꾸고 메모 캐시를 남기면 early-return이 리다이렉트를 무력화한다.
+
+- `translator`: `_cache` / `_cache_dirty`를 리셋하지 않으면, `_load_cache()`가 `_cache is not None`으로 조기 반환해 재지정된 경로를 다시 읽지 않는다
+- `_deterministic_dns_resolution`: `_dns_cache`(cachetools TTLCache)를 clear하지 않으면 이전 리졸버로 캐시된 값이 누수된다
+
+clear는 **setup 시점에만** 해도 충분하다 — 모든 테스트의 setup이 무조건 실행되므로, 앞선 테스트가 오염시킨 항목은 다음 테스트 시작 전에 이미 제거된다. teardown clear는 중복이다.
+
+### 규약 4 — `no_state_isolation` 마커는 **경로 리다이렉트 fixture에만**
+
+`tests/test_state_path_anchoring.py`의 런타임 앵커링 가드는 `STATE_DIR` 등이 **실제 레포 루트 아래**에 있는지 검사한다. 경로를 tmp로 돌리는 fixture는 이 가드를 무력화하므로 마커로 opt-out해야 한다.
+
+반대로 경로를 건드리지 않는 fixture(#1 HTTP, #2 DNS)에 마커 게이트를 다는 것은 **오류**다. 앵커링 가드와 충돌할 표면이 없는데 격리만 잃는다.
+
+> 판정 기준: **레포 앵커 경로를 재지정하는가?** → Yes면 게이트, No면 무조건 적용.
+
+### 규약 5 — fixture마다 **환경 독립적인** 가드 테스트를 짝지운다
+
+가드는 fixture가 제거되면 **CI에서도** 실패해야 한다. 오프라인에서만 실패하는 가드는 무의미하다.
+
+- 경로형: 활성 경로가 커밋된 트리 아래가 아님을 단언
+- 스텁형: 스텁 함수에 마커 속성을 달고 그것을 단언 — `_ssrf_dns_stub`, `_http_block_stub`. 실제 `socket.getaddrinfo` / `HTTPAdapter.send`에는 이 속성이 없으므로 네트워크 상태와 무관하게 판별된다
+
+**행위 프로브를 쓰지 말 것**: "실제로 요청해서 RuntimeError가 나는지" 검사하면, fixture가 없을 때 가드 자신이 막으려던 실제 외부 호출을 수행한다.
+
+가드는 프로덕션의 `REPO_ROOT` / `POSTS_DIR` 상수를 import하면 안 된다 (`test_hermetic_test_writes_guard`가 이를 비-hermetic 신호로 차단). `__file__` 앵커로 도출한다:
+
+```python
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+```
+
+단언이 vacuous하지 않은지도 확인한다. 예: `_dns_cache` 공백 단언은 `is_private_url_target` 1회 호출로 길이가 `0 → 1`이 되므로 clear가 no-op이면 실제로 red가 된다.
+
+**실증 방법 — 워크트리에서 fixture를 실제로 꺼본다.** 8종 전부에 대해 검증했고, 실제로 vacuous한 가드를 1건 찾아냈다 (함정 6 참조).
+
+```bash
+git worktree add --detach /tmp/inv-falsify HEAD
+# fixture별로 autouse=True → False 로 바꿔 해당 가드만 실행,
+# patched_rc != 0 (red) && control_rc == 0 (green) 이어야 통과
+git worktree remove /tmp/inv-falsify
+```
+
+주의: `tests/conftest.py`를 짧은 간격으로 반복해 덮어쓰면 `__pycache__`가 무효화되지 않아(pyc 검증은 mtime+size 기반) 결과가 실행마다 뒤집힌다. `python3 -B` + `PYTHONDONTWRITEBYTECODE=1` + 매 실행 전 `__pycache__` 삭제로 고정하고, 패치 해제 상태(control)도 함께 돌려 green을 확인해야 한다.
+
+### 규약 6 — `atexit` flush 모듈은 **import 시점** 리다이렉트가 추가로 필요하다
+
+`atexit` 훅은 인터프리터 종료 시, 즉 **모든 per-test monkeypatch가 해제된 뒤** 실행된다. 따라서 per-test fixture만으로는 부족하고, monkeypatch가 *복원할 대상 값* 자체가 이미 off-tree여야 한다. `image_rejection_metrics`가 유일한 사례이며 `tests/conftest.py` 최상단에서 처리한다.
+
+이 import 시점 블록은 `except ImportError: pass`로 감싸여 있어 조용히 실패할 수 있다. `_STATE_TMP`는 import 성공 이후에만 바인딩되므로 정확한 tripwire가 된다.
+
+---
+
+## 3. 신규 격리 fixture 체크리스트
+
+- [ ] 프로덕션이 대상 전역을 **호출 시점에** 읽는가? (규약 1)
+- [ ] `common.*` / `scripts.common.*` 트윈을 모두 패치했는가? (규약 2)
+- [ ] 파생 메모 캐시를 리셋했는가? (규약 3)
+- [ ] 레포 앵커 경로를 재지정한다면 `no_state_isolation` 게이트를 달았는가? 아니라면 **달지 않았는가**? (규약 4)
+- [ ] `test_suite_isolation_guard.py`에 환경 독립적 가드를 추가했는가? (규약 5)
+- [ ] `atexit`/종료 시점 훅이 있는 모듈이면 import 시점 리다이렉트도 했는가? (규약 6)
+- [ ] **전체 스위트를 랜덤 순서와 고정 순서 양쪽으로** 돌렸는가? (아래 함정 3)
+- [ ] `ruff check` + `ruff format --check` + `basedpyright` 통과? (함정 4)
+
+---
+
+## 4. 함정 사례집
+
+실제로 CI red 또는 flaky를 유발했던 사례들.
+
+**함정 1 — autouse fixture vs 런타임 앵커링 가드**
+`dedup.STATE_DIR` autouse 리다이렉트가 `test_state_path_anchoring.py`와 충돌했다. → `no_state_isolation` 마커 도입. autouse fixture를 추가한 뒤에는 **반드시 전체 스위트를 돌릴 것**.
+
+**함정 2 — 리졸버 스텁이 loopback까지 리다이렉트 (PR #1070)**
+`socket.getaddrinfo`를 호스트 무관하게 고정 IP로 스텁하면 `127.0.0.1` / `localhost` 접속까지 off-box로 나가 `[Errno 49] Can't assign requested address`로 실패한다. 로컬 서버를 띄우는 테스트를 추가하는 순간 원인을 알기 어렵게 깨진다.
+→ loopback 호스트명과 리터럴 IP는 원본 리졸버로 패스스루하고, sockaddr에 요청 포트를 보존한다. 리터럴 IP는 `getaddrinfo`가 수치 파싱만 하므로 오프라인 안전성은 유지된다.
+
+**함정 3 — 고정 공인 IP 선택**
+RFC 5737 문서화 대역(`203.0.113.x`, `192.0.2.x`, `198.51.100.x`)은 Python `ipaddress`에서 전부 `is_private=True`, `233.252.0.1`은 multicast다. `utils._is_non_public_ip`가 모두 차단하므로 **문서화 대역은 쓸 수 없다**. 실제 공인 IP를 써야 한다 (현재 `93.184.216.34`). 스텁이므로 실제 트래픽은 발생하지 않는다.
+
+**함정 4 — 로컬 검증 ≠ CI**
+`ruff check`만으로는 부족하다. CI Code Quality는 `ruff format --check`도 실행하며 포맷 누락이 흔한 red 원인이다. 옵셔널 import 폴백(`X = None`)은 `basedpyright`의 `reportOptionalMemberAccess`를 유발한다. 푸시 전 3종을 모두 돌린다.
+
+**함정 5 — 가드 테스트가 프로덕션 상수를 import**
+새 가드가 `REPO_ROOT` / `POSTS_DIR` / `SITE_DIR`를 프로덕션에서 import하면 hermetic 가드가 CI red를 낸다. `__file__` 앵커로 도출하고, 격리는 문자열 monkeypatch로 한다.
+
+**함정 6 — 이중 방어가 가드를 vacuous하게 만든다**
+`_isolate_image_rejection_state`의 첫 가드는 "`_STATE_PATH`가 커밋된 `_state/` 아래가 아님"만 단언했는데, **모듈 레벨 리다이렉트(#0)가 이미 이를 보장**하므로 per-test fixture를 꺼도 green이었다 (실증 확인).
+→ 같은 대상을 두 겹으로 보호할 때는, 각 계층이 **고유하게 제공하는 것**을 단언해야 한다. 여기서는 per-test 격리이므로 "활성 경로가 import 시점 baseline과 다름"을 추가했다.
+
+---
+
+## 5. 검증 명령
+
+```bash
+# 격리 가드만
+python3 -m pytest tests/test_suite_isolation_guard.py -q --no-cov
+
+# fixture 실행/해제 순서 확인
+python3 -m pytest tests/test_suite_isolation_guard.py --setup-show --no-cov -p no:randomly
+
+# 전체 (랜덤 순서 — 기본)
+python3 -m pytest tests/ -q --no-cov
+
+# 전체 (고정 순서 — 순서 의존 버그 분리용)
+python3 -m pytest tests/ -q --no-cov -p no:randomly
+
+# 린트/타입
+python3 -m ruff check scripts/ tests/
+python3 -m ruff format --check scripts/ tests/
+python3 -m basedpyright
+```
+
+작업 후 커밋된 트리가 깨끗한지 확인:
+
+```bash
+git status --short   # _state/, assets/images/generated/ 에 변경이 없어야 함
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ norecursedirs = ["_site", ".git", "node_modules", "vendor", ".bundle"]
 timeout_method = "thread"
 markers = [
     "i18n_e2e: Playwright-driven end-to-end tests for the language toggle (tests/i18n/). Requires a running Jekyll preview at I18N_E2E_BASE_URL.",
-    "no_state_isolation: opt out of the autouse _state redirect fixtures (dedup/signal). For runtime guards that must read the real repo-anchored _state paths.",
+    "no_state_isolation: opt out of the autouse _state path-redirect fixtures (dedup/signal/translation). For runtime guards that must read the real repo-anchored _state paths. Only path-redirecting fixtures honour this marker — see docs/test-isolation.md.",
 ]
 
 [tool.basedpyright]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,10 @@ def _block_real_http(monkeypatch):
             "A requests mock is missing or patched on the wrong module namespace."
         )
 
+    # Tripwire for the isolation guard: lets it confirm the transport is blocked
+    # without issuing a request (which, if the fixture were gone, would be a real
+    # outbound call). Mirrors ``_ssrf_dns_stub`` below.
+    _blocked._http_block_stub = True
     monkeypatch.setattr(HTTPAdapter, "send", _blocked)
 
 

--- a/tests/test_suite_isolation_guard.py
+++ b/tests/test_suite_isolation_guard.py
@@ -179,3 +179,97 @@ def test_ssrf_dns_resolution_pinned_off_live_network():
         "example.com is blocked by the SSRF guard under the pinned resolver — "
         "the deterministic DNS stub is not returning a public address."
     )
+
+
+def test_real_http_transport_blocked():
+    """``_block_real_http`` must keep the ``requests`` transport blocked.
+
+    Enrichment/collector tests reach the network only through ``requests`` and
+    all mock it. A misplaced patch can silently go inert, letting a real GET hit
+    a public host the SSRF guard permits — a slow, flaky "green" that depends on
+    the runner's connectivity rather than the code under test.
+
+    Asserted via the fixture's ``_http_block_stub`` marker rather than by issuing
+    a request: if the fixture were gone, a behavioural probe would itself perform
+    the real outbound call this guard exists to prevent.
+    """
+    try:
+        from requests.adapters import HTTPAdapter
+    except ImportError:  # pragma: no cover - requests is a hard test dependency
+        import pytest
+
+        pytest.skip("requests not installed")
+
+    assert getattr(HTTPAdapter.send, "_http_block_stub", False), (
+        "HTTPAdapter.send is the real transport during tests — the "
+        "_block_real_http conftest fixture is not active. A missing requests "
+        "mock will silently make a real outbound call instead of failing."
+    )
+
+
+def test_image_rejection_state_redirected_off_repo_tree():
+    """``_isolate_image_rejection_state`` must redirect metrics writes off-tree.
+
+    ``image_rejection_metrics`` persists counters to ``_STATE_PATH`` and archives
+    to ``_ARCHIVE_DIR``. Tests that record a rejection without patching those
+    themselves rely on the autouse fixture; without it they write into the
+    committed ``_state/`` tree, which the ``pre-commit-state-guard`` hook then
+    blocks at commit time.
+
+    Off-tree alone is not a sufficient assertion here: the import-time redirect
+    (see ``test_image_rejection_atexit_baseline_off_repo_tree``) already moves
+    ``_STATE_PATH`` off the repo tree, so that check stays green even with this
+    fixture disabled — verified empirically. What the per-test fixture uniquely
+    provides is *per-test* isolation, so also assert the active path has moved
+    off the import-time baseline.
+    """
+    import common.image_rejection_metrics as m
+    import tests.conftest as root_conftest
+
+    for attr in ("_STATE_PATH", "_ARCHIVE_DIR"):
+        active = os.path.abspath(str(getattr(m, attr)))
+        assert not active.startswith(_REPO_STATE + os.sep), (
+            f"image_rejection_metrics.{attr} ({active}) points inside the "
+            "committed _state tree during tests — the "
+            "_isolate_image_rejection_state conftest fixture is not active."
+        )
+
+    baseline = getattr(root_conftest, "_STATE_TMP", None)
+    if baseline is not None:
+        active_state = os.path.abspath(str(m._STATE_PATH))
+        assert active_state != os.path.abspath(str(baseline)), (
+            "image_rejection_metrics._STATE_PATH still equals the import-time "
+            f"baseline ({baseline}) — the _isolate_image_rejection_state "
+            "fixture is not active, so every test shares one metrics file "
+            "instead of getting its own tmp copy."
+        )
+
+
+def test_image_rejection_atexit_baseline_off_repo_tree():
+    """The conftest *module-level* redirect must survive monkeypatch teardown.
+
+    ``image_rejection_metrics`` registers an ``atexit`` flush that runs at
+    interpreter shutdown — after every per-test ``monkeypatch`` has been undone.
+    So the per-test fixture alone is not enough: the value monkeypatch restores
+    *to* must already be off-tree. ``tests/conftest.py`` handles this by
+    reassigning ``_STATE_PATH`` at import time, before any test runs.
+
+    That import-time block is wrapped in ``except ImportError: pass``, so if the
+    module ever fails to import the redirect silently does not happen and the
+    atexit flush lands in the committed ``_state/``. ``_STATE_TMP`` is only bound
+    after that import succeeds, which makes it an exact tripwire.
+    """
+    import tests.conftest as root_conftest
+
+    baseline = getattr(root_conftest, "_STATE_TMP", None)
+
+    assert baseline is not None, (
+        "tests/conftest.py did not bind _STATE_TMP — its module-level "
+        "image_rejection_metrics redirect did not run (the import-time block "
+        "swallowed an ImportError). The atexit flush will write into the "
+        "committed _state/ tree at interpreter shutdown."
+    )
+    assert not os.path.abspath(str(baseline)).startswith(_REPO_STATE + os.sep), (
+        f"the atexit restore target ({baseline}) is inside the committed "
+        "_state tree; per-test isolation cannot prevent shutdown pollution."
+    )


### PR DESCRIPTION
## 배경

PR #1070 리뷰 과정에서 드러난 문제입니다. `tests/conftest.py`의 격리 fixture는 **8종**(모듈 레벨 1 + autouse 7)인데 가드 테스트는 **5개**뿐이었고, 규약이 코드 어디에도 명시돼 있지 않아 리뷰어가 매번 `pytest --setup-show`로 fixture 순서와 마커 게이트 근거를 재도출해야 했습니다.

## 1. `docs/test-isolation.md` (신규)

인벤토리 8종 표(대상 심볼 / 마커 게이트 / 대응 가드), 규약 6개, 신규 fixture 체크리스트, 함정 사례집 6건, 검증 명령 모음.

**규약 6개**

1. 호출부가 아니라 **모듈 속성**을 리다이렉트 — 프로덕션이 호출 시점에 전역을 읽어야 성립
2. **모듈 트윈 양쪽** 패치 — `common.X`와 `scripts.common.X`는 같은 파일에서 로드된 별개 객체
3. **파생 메모 상태**도 리셋 — 안 하면 early-return이 리다이렉트를 무력화
4. `no_state_isolation` 마커는 **경로 리다이렉트 fixture에만** — DNS/HTTP에 게이트를 다는 건 오히려 오류
5. fixture마다 **환경 독립적** 가드 — 오프라인에서만 실패하는 가드는 무의미
6. `atexit` flush 모듈은 **import 시점** 리다이렉트가 추가로 필요

## 2. 가드 3종 추가 (5 → 8)

| 가드 | 대상 |
|---|---|
| `test_real_http_transport_blocked` | `_block_real_http` |
| `test_image_rejection_state_redirected_off_repo_tree` | `_isolate_image_rejection_state` (per-test 격리) |
| `test_image_rejection_atexit_baseline_off_repo_tree` | 모듈 레벨 redirect (atexit 대비) |

`_block_real_http`에 `_http_block_stub` 트립와이어를 추가했습니다 (`_ssrf_dns_stub`와 동일 패턴). **행위 프로브를 쓰지 않은 이유**: "실제로 요청해서 RuntimeError가 나는지" 검사하면, fixture가 없을 때 가드 자신이 막으려던 실제 외부 호출을 수행하게 됩니다.

## 3. falsifiability 실증 — 그리고 실제 결함 1건 발견

워크트리에서 fixture를 **실제로 꺼서** 8종 전부 검증했습니다 (`patched_rc != 0 && control_rc == 0`):

```
FALSIFIABLE  | patched_rc=1 control_rc=0 | module-level irm redirect
FALSIFIABLE  | patched_rc=1 control_rc=0 | _block_real_http
FALSIFIABLE  | patched_rc=1 control_rc=0 | _deterministic_dns_resolution
FALSIFIABLE  | patched_rc=1 control_rc=0 | _isolate_generated_images
FALSIFIABLE  | patched_rc=1 control_rc=0 | _isolate_dedup_state
FALSIFIABLE  | patched_rc=1 control_rc=0 | _isolate_signal_history_state
FALSIFIABLE  | patched_rc=1 control_rc=0 | _isolate_translation_cache
FALSIFIABLE  | patched_rc=1 control_rc=0 | _isolate_image_rejection_state
=== 8/8 guards falsifiable ===
```

**발견한 결함**: image_rejection 가드의 최초 버전은 "`_STATE_PATH`가 커밋된 `_state/` 아래가 아님"만 단언했는데, **모듈 레벨 리다이렉트가 이미 이를 보장**하므로 per-test fixture를 꺼도 green이었습니다. 같은 대상을 두 겹으로 보호할 때는 각 계층이 **고유하게 제공하는 것**을 단언해야 하므로, "활성 경로가 import 시점 baseline과 다름"을 추가해 8/8을 달성했습니다. (함정 6으로 문서화)

**하네스 자체의 함정도 문서화**: `tests/conftest.py`를 짧은 간격으로 반복해 덮어쓰면 `__pycache__`가 무효화되지 않아(pyc 검증은 mtime+size 기반) 결과가 실행마다 뒤집힙니다. 초기 하네스가 실제로 이 때문에 3건을 오탐했고, `python3 -B` + `PYTHONDONTWRITEBYTECODE=1` + 매 실행 전 `__pycache__` 삭제 + control 재실행으로 고정했습니다.

## 4. `pyproject.toml`

`no_state_isolation` 마커 설명이 `(dedup/signal)`이라고만 적혀 translation이 누락돼 있었습니다. 정정하고, 경로 리다이렉트 fixture만 이 마커를 존중한다는 점을 명시했습니다.

## 검증

| 항목 | 결과 |
|---|---|
| `pytest tests/ -q --no-cov` | `4913 passed, 16 skipped` (기존 4910 +3) |
| `ruff check` + `ruff format --check` | clean (261 files) |
| `component_counts.py --check` | exit 0 (드리프트 없음) |
| falsifiability 하네스 | 2회 연속 8/8 동일 |

워크트리(`/tmp/inv-falsify`)는 검증 후 제거했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)