### PR TITLE
feat: 가드 우회 경로 10건 차단 + falsifiability 하네스 Part 2 (19 → 29)

### DIFF
--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -15,6 +15,12 @@ vacuous(무엇을 꺼도 green) 한지 알 수 없다.
 CASES 에 없는 fixture 가 있으면 실패한다. 새 격리 fixture 를 가드 없이
 추가하는 것을 차단한다.
 
+Part 2 (2026-08-05): 가드 자체의 **우회 경로**를 감사해 10건을 STATIC_CASES 에
+편입했다 — cwd 프리픽스/f-string 형태의 `_state` 루팅, 모듈 레벨 writer 표
+드리프트, `getattr`/`import_module` 를 통한 production 루트 취득, 그리고
+`--fail-under` 숫자는 그대로 둔 채 게이트를 무력화하는 4가지 커버리지 편집
+(측정 범위 축소 x2, `--omit`, `continue-on-error`).
+
 사용법:
     python scripts/tools/guard_falsifiability.py            # 표 출력
     python scripts/tools/guard_falsifiability.py --json     # JSON 출력
@@ -80,18 +86,24 @@ class StaticCase(NamedTuple):
 # 19행 `sys.path.insert` 가 바뀌고 정작 24행 `HISTORY_PATH` 는 그대로여서 가드가
 # 정당하게 green 이었다 — 가드가 아니라 mutation 이 틀린 것이었다. 첫 일치를 조용히
 # 바꾸는 대신 AMBIGUOUS-ANCHOR 로 실패시킨다.
+#
+# 두 번째 규약(2026-08-05 갭 감사): **주입 코드는 대상 파일에서 실행 가능해야 한다.**
+# 초기 form A 케이스는 `dedup.py` 에 `Path("_state/probe.json")` 을 주입했는데 그
+# 모듈은 `pathlib` 을 import 하지 않아 autouse fixture 의 dedup import 가 NameError
+# 로 죽었다 — 테스트 본문은 실행조차 되지 않았는데 rc!=0 이라 FALSIFIABLE 로 보였다.
+# 주입은 대상 모듈에 이미 있는 이름만 쓸 것(또는 import 불필요한 리터럴).
 STATIC_CASES: tuple[StaticCase, ...] = (
     StaticCase(
-        "AST 스캔: 스크립트에 cwd-상대 _state 주입",
+        "AST 스캔: 스크립트에 cwd-상대 _state 주입 (form A)",
         "scripts/common/dedup.py",
         None,
-        '\n_FALSIFIABILITY_PROBE = Path("_state/probe.json")\n',
+        '\n_FALSIFIABILITY_PROBE = "_state/probe.json"\n',
         "tests/test_state_path_anchoring.py::test_no_cwd_relative_state_paths_in_scripts",
     ),
     StaticCase(
         "_state 탐지기 무력화 (_is_slash_rooted)",
         "tests/test_state_path_anchoring.py",
-        'return value.startswith(_BARE_ROOT + "/") or value.startswith(_BARE_ROOT + "\\\\")',
+        'return bare.startswith(_BARE_ROOT + "/") or bare.startswith(_BARE_ROOT + "\\\\")',
         "return False",
         "tests/test_state_path_anchoring.py::test_guard_detects_known_antipatterns",
     ),
@@ -157,6 +169,82 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         "--fail-under=70",
         "--fail-under=40",
         "tests/test_coverage_floor_guard.py::test_workflow_global_coverage_floor_enforced",
+    ),
+    # ---------------------------------------------------------------------
+    # Part 2 (2026-08-05): 갭 감사에서 나온 10건. 각 케이스는 "가드가 통과한다"가
+    # 아니라 "이 우회를 실제로 주입하면 red 가 된다"를 증명한다.
+    # ---------------------------------------------------------------------
+    StaticCase(
+        "cwd 프리픽스 우회 주입 (form C1: ./_state/)",
+        "scripts/common/dedup.py",
+        None,
+        '\n_FALSIFIABILITY_PROBE = "./_state/probe.json"\n',
+        "tests/test_state_path_anchoring.py::test_no_cwd_relative_state_paths_in_scripts",
+    ),
+    StaticCase(
+        'f-string 우회 주입 (form C2: f"_state/{...}")',
+        "scripts/common/dedup.py",
+        None,
+        '\n_FALSIFIABILITY_PROBE = f"_state/{__name__}.json"\n',
+        "tests/test_state_path_anchoring.py::test_no_cwd_relative_state_paths_in_scripts",
+    ),
+    StaticCase(
+        "미등록 모듈 레벨 _state writer 추가 (드리프트)",
+        "scripts/check_description_quality.py",
+        None,
+        '\n_FALSIFIABILITY_PROBE = Path(__file__).resolve().parent.parent / "_state" / "probe.json"\n',
+        "tests/test_state_path_anchoring.py::test_module_level_writers_table_has_no_drift",
+    ),
+    StaticCase(
+        "테스트가 getattr 로 production REPO_ROOT 취득",
+        "tests/test_encoding_guard.py",
+        None,
+        "\nimport common.image_generator as _fp_ig  # noqa: E402\n\n"
+        '_FALSIFIABILITY_PROBE = getattr(_fp_ig, "REPO_ROOT")\n',
+        "tests/test_hermetic_test_writes_guard.py::test_no_test_imports_production_repo_root",
+    ),
+    StaticCase(
+        "테스트가 import_module 체인으로 production REPO_ROOT 취득",
+        "tests/test_encoding_guard.py",
+        None,
+        "\nimport importlib as _fp_il  # noqa: E402\n\n"
+        '_FALSIFIABILITY_PROBE = _fp_il.import_module("common.image_generator").REPO_ROOT\n',
+        "tests/test_hermetic_test_writes_guard.py::test_no_test_imports_production_repo_root",
+    ),
+    StaticCase(
+        "커버리지 측정 범위 축소 (pyproject --cov)",
+        "pyproject.toml",
+        '"--cov=scripts --cov-fail-under=70"',
+        '"--cov=scripts/common/summary_sections.py --cov-fail-under=70"',
+        "tests/test_coverage_floor_guard.py::test_pyproject_coverage_scope_not_narrowed",
+    ),
+    StaticCase(
+        "커버리지 측정 범위 축소 (워크플로우 --cov)",
+        ".github/workflows/code-quality.yml",
+        "--cov=scripts/common --cov-report=",
+        "--cov=scripts/common/summary_sections.py --cov-report=",
+        "tests/test_coverage_floor_guard.py::test_workflow_coverage_scope_not_narrowed",
+    ),
+    StaticCase(
+        "커버리지 게이트 비차단화 (continue-on-error)",
+        ".github/workflows/code-quality.yml",
+        "      - name: Generate coverage report\n        run: |",
+        "      - name: Generate coverage report\n        continue-on-error: true\n        run: |",
+        "tests/test_coverage_floor_guard.py::test_workflow_coverage_gate_steps_are_blocking",
+    ),
+    StaticCase(
+        "커버리지 게이트에서 모듈 제외 (--omit)",
+        ".github/workflows/code-quality.yml",
+        "python3 -m coverage report --fail-under=70",
+        'python3 -m coverage report --fail-under=70 --omit="*/collect_*.py"',
+        "tests/test_coverage_floor_guard.py::test_workflow_coverage_gate_omits_nothing",
+    ),
+    StaticCase(
+        "커버리지 설정에서 모듈 제외 ([tool.coverage.run] omit)",
+        "pyproject.toml",
+        "[tool.coverage.run]\nrelative_files = true",
+        '[tool.coverage.run]\nrelative_files = true\nomit = ["*/collect_*.py"]',
+        "tests/test_coverage_floor_guard.py::test_pyproject_coverage_config_omits_nothing",
     ),
 )
 

--- a/tests/test_coverage_floor_guard.py
+++ b/tests/test_coverage_floor_guard.py
@@ -23,13 +23,26 @@ The workflow gate that scopes coverage to ``summary_sections.py`` (a stricter
 95% per-module floor) is intentionally excluded here — it is guarded separately
 by ``test_summary_sections_coverage_floor.py``.
 
-Text/regex scan only (no YAML parser, no import of the measured source) so the
-guard cannot perturb the coverage gate it protects.
+## A floor number is not a gate
+
+A number alone proves nothing: four edits leave ``--fail-under=70`` untouched
+while making the gate meaningless, so each is asserted separately below.
+
+* **Measurement scope** — narrowing ``--cov=scripts`` to a single well-tested
+  module keeps the floor at 70 while measuring almost nothing.
+* **Omission** — ``coverage report --omit=...``, or an ``omit`` key under
+  ``[tool.coverage.run]`` / ``[tool.coverage.report]``, silently drops the
+  weakest modules out of the denominator.
+* **continue-on-error** — a red gate that does not fail the job is not a gate.
+
+Config parsing only (``tomllib`` for TOML, text scan for YAML; no import of the
+measured source) so the guard cannot perturb the coverage gate it protects.
 """
 
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -39,8 +52,48 @@ _WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "code-quality.yml"
 # The global scripts coverage floor both gates must enforce.
 _MIN_FLOOR = 70
 
+# The measurement scope the floor is meaningful against. `--cov=scripts` in
+# pyproject addopts applies to every pytest run; the CI step additionally names
+# `scripts/common`. Anything narrower measures a hand-picked subset.
+_REQUIRED_COV_SCOPE = "scripts"
+_ALLOWED_COV_SCOPES = frozenset({"scripts", "scripts/common"})
+
+# `--cov=X` only — `--cov-fail-under=N` has a `-`, not `=`, after `--cov`.
+_COV_SCOPE_RE = re.compile(r"--cov=(\S+)")
 _COV_FAIL_UNDER_RE = re.compile(r"--cov-fail-under=(\d+)")
 _FAIL_UNDER_RE = re.compile(r"--fail-under=(\d+)")
+_CONTINUE_ON_ERROR_RE = re.compile(r"continue-on-error:\s*(\S+)")
+_STEP_START_RE = re.compile(r"^ *- name: ", re.M)
+
+
+def _pyproject() -> dict:
+    """Parsed pyproject.toml (parsing config is not importing measured source)."""
+    return tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _pytest_addopts() -> str:
+    return _pyproject()["tool"]["pytest"]["ini_options"]["addopts"]
+
+
+def _workflow_steps() -> list[str]:
+    """The workflow split into per-step text blocks (`- name:` delimited)."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    starts = [m.start() for m in _STEP_START_RE.finditer(text)]
+    return [text[s:e] for s, e in zip(starts, [*starts[1:], len(text)], strict=True)]
+
+
+def _global_coverage_report_lines() -> list[str]:
+    """`coverage report --fail-under=N` lines that are NOT the per-module gate.
+
+    The ``--include="*/summary_sections.py"`` line is a separate 95% gate owned
+    by ``test_summary_sections_coverage_floor.py``.
+    """
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    return [
+        line
+        for line in text.splitlines()
+        if "coverage report" in line and "--fail-under=" in line and "--include=" not in line
+    ]
 
 
 def test_config_files_exist() -> None:
@@ -72,13 +125,7 @@ def test_workflow_global_coverage_floor_enforced() -> None:
     Only the *global* ``coverage report --fail-under=N`` line counts — the
     ``--include="*/summary_sections.py"`` line is a separate per-module gate.
     """
-    text = _WORKFLOW.read_text(encoding="utf-8")
-
-    global_lines = [
-        line
-        for line in text.splitlines()
-        if "coverage report" in line and "--fail-under=" in line and "--include=" not in line
-    ]
+    global_lines = _global_coverage_report_lines()
     assert global_lines, (
         "code-quality.yml no longer runs a global "
         "`coverage report --fail-under=N` step (without --include). The global "
@@ -92,4 +139,99 @@ def test_workflow_global_coverage_floor_enforced() -> None:
         f"code-quality.yml global coverage floor lowered to {min(floors)} "
         f"(< {_MIN_FLOOR}). If intentional, update _MIN_FLOOR in this guard "
         f"and both --fail-under values (pyproject + code-quality.yml) together."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate *validity*: the four edits that keep `--fail-under=70` intact while
+# making it prove nothing. A floor is only as strong as what it measures.
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_coverage_scope_not_narrowed() -> None:
+    """pytest addopts must measure the whole ``scripts`` tree.
+
+    Narrowing to ``--cov=scripts/common/summary_sections.py`` leaves the floor
+    reading 70 while measuring one already-well-tested module — every other
+    script could lose its tests and the gate would stay green.
+    """
+    addopts = _pytest_addopts()
+    scopes = _COV_SCOPE_RE.findall(addopts)
+    assert scopes, f"pyproject addopts no longer sets `--cov=...`; the floor measures nothing. Got: {addopts!r}"
+    assert _REQUIRED_COV_SCOPE in scopes, (
+        f"pyproject coverage scope narrowed to {scopes} — must include "
+        f"`--cov={_REQUIRED_COV_SCOPE}` so the floor covers the whole tree."
+    )
+
+
+def test_workflow_coverage_scope_not_narrowed() -> None:
+    """The CI test step must not measure a subset narrower than ``scripts/common``."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    scopes = set(_COV_SCOPE_RE.findall(text))
+    assert scopes, "code-quality.yml no longer passes `--cov=...` to pytest; CI measures nothing."
+
+    narrowed = sorted(s for s in scopes if s not in _ALLOWED_COV_SCOPES)
+    assert not narrowed, (
+        f"code-quality.yml measures narrowed coverage scope(s) {narrowed}. "
+        f"Allowed: {sorted(_ALLOWED_COV_SCOPES)}. A narrower scope inflates the "
+        f"percentage without changing the floor."
+    )
+
+
+def test_workflow_coverage_gate_steps_are_blocking() -> None:
+    """The coverage gate steps must fail the job — no ``continue-on-error``.
+
+    Checked at both step and job level: either one turns a red gate into an
+    annotation. ``continue-on-error: false`` is explicit and allowed.
+    """
+    gate_steps = [s for s in _workflow_steps() if "coverage report" in s and "--fail-under=" in s]
+    assert gate_steps, "no `coverage report --fail-under=N` step found in code-quality.yml — the gate is gone."
+
+    soft: list[str] = []
+    for step in gate_steps:
+        match = _CONTINUE_ON_ERROR_RE.search(step)
+        if match and match.group(1).lower() != "false":
+            soft.append(f"{step.splitlines()[0].strip()} -> continue-on-error: {match.group(1)}")
+
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    job_header = text.split("steps:", 1)[0]
+    job_match = _CONTINUE_ON_ERROR_RE.search(job_header)
+    if job_match and job_match.group(1).lower() != "false":
+        soft.append(f"job-level -> continue-on-error: {job_match.group(1)}")
+
+    assert not soft, "coverage gate is non-blocking (failures would not fail the job):\n" + "\n".join(
+        f"  - {s}" for s in soft
+    )
+
+
+def test_workflow_coverage_gate_omits_nothing() -> None:
+    """The global ``coverage report`` gate must not ``--omit`` modules.
+
+    ``--omit="*/collect_*.py"`` drops the weakest files out of the denominator;
+    the reported percentage climbs and the floor never notices.
+    """
+    offenders = [line.strip() for line in _global_coverage_report_lines() if "--omit" in line]
+    assert not offenders, (
+        "global coverage gate omits modules from measurement:\n"
+        + "\n".join(f"  - {line}" for line in offenders)
+        + "\n\nOmitting files inflates the percentage without changing --fail-under."
+    )
+
+
+def test_pyproject_coverage_config_omits_nothing() -> None:
+    """``[tool.coverage.*]`` must not omit/narrow what is measured.
+
+    ``--cov-config=pyproject.toml`` means an ``omit`` key here silently applies
+    to *both* gates at once — the quietest way to lift the number.
+    """
+    coverage_cfg = _pyproject().get("tool", {}).get("coverage", {})
+    offenders = [
+        f"[tool.coverage.{section}] {key} = {coverage_cfg[section][key]!r}"
+        for section in ("run", "report")
+        for key in ("omit", "include")
+        if key in coverage_cfg.get(section, {})
+    ]
+    assert not offenders, (
+        "coverage config narrows what is measured, inflating the percentage the "
+        "floor is checked against:\n" + "\n".join(f"  - {o}" for o in offenders)
     )

--- a/tests/test_hermetic_test_writes_guard.py
+++ b/tests/test_hermetic_test_writes_guard.py
@@ -31,7 +31,7 @@ flagged. This guard AST-scans (ignoring comments/strings), so the docstrings and
 
 ## Scope
 
-This guard flags two shapes of production real-tree-root access in tests:
+This guard flags four shapes of production real-tree-root access in tests:
 
   1. Direct import — ``from <prod> import REPO_ROOT`` (incl. ``... as RR``).
      The canonical vector the 2026-06-30 incident used.
@@ -41,6 +41,14 @@ This guard flags two shapes of production real-tree-root access in tests:
        - ``from common import post_generator; post_generator.REPO_ROOT``
        - ``import common.post_generator; common.post_generator.REPO_ROOT``
      These leak the *real* repo root into the test just as surely as form 1.
+  3. Dynamic attribute access — ``getattr(pg, "REPO_ROOT")``. The name lives in
+     a *string*, so forms 1-2 (which match an ``Attribute`` node or an import
+     alias) never see it, yet the value returned is the same real repo root.
+  4. Inline-import attribute access —
+     ``importlib.import_module("common.post_generator").REPO_ROOT``. The
+     attribute base is a ``Call``, not a ``Name``/dotted chain, so the form-2
+     scan bails out. Combined with form 3 this also covers
+     ``getattr(import_module("common.post_generator"), "REPO_ROOT")``.
 
 Intentionally NOT flagged — the legitimate redirect: the object-form
 ``monkeypatch.setattr(pg, "REPO_ROOT", str(tmp_path))`` (or the string-target
@@ -48,7 +56,9 @@ Intentionally NOT flagged — the legitimate redirect: the object-form
 produces a ``mod.REPO_ROOT`` *attribute-read* node — the module is passed as an
 argument and the name is a string literal — so the AST attribute scan never
 sees them. That asymmetry (read-attribute is banned, setattr object/string form
-is allowed) is what makes closing the alias gap safe.
+is allowed) is what makes closing the alias gap safe. Form 3 preserves it by
+matching only ``getattr`` — ``setattr(pg, "REPO_ROOT", ...)`` writes the
+redirect rather than leaking the root, and stays allowed.
 
 Attribute access to *non-root* module attributes (``dedup.STATE_DIR``,
 ``signal_tracker._HISTORY_FILE``, ``image_generator.IMAGES_DIR``) is untouched —
@@ -99,6 +109,37 @@ def _dotted_name(node: ast.expr) -> str | None:
     return None
 
 
+def _call_name(call: ast.Call) -> str:
+    """Bare callee name for ``f(...)`` / ``a.b.f(...)``, else ``""``."""
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _first_arg_str(call: ast.Call) -> str | None:
+    if call.args and isinstance(call.args[0], ast.Constant) and isinstance(call.args[0].value, str):
+        return call.args[0].value
+    return None
+
+
+def _is_prod_module_expr(expr: ast.expr, aliases: set[str]) -> bool:
+    """True if ``expr`` evaluates to a production module object.
+
+    Covers the three ways a test can name one: a local alias bound by an import
+    (``pg``), a dotted no-alias chain (``common.post_generator``), and an inline
+    ``importlib.import_module("common.post_generator")`` call (form 4).
+    """
+    if isinstance(expr, ast.Name) and expr.id in aliases:
+        return True
+    if isinstance(expr, ast.Call) and _call_name(expr) == "import_module":
+        return _is_production_module(_first_arg_str(expr))
+    dotted = _dotted_name(expr)
+    return dotted is not None and _is_production_module(dotted)
+
+
 def _collect_prod_module_aliases(tree: ast.AST) -> set[str]:
     """Local names bound to a *production module* (for alias-attribute detection).
 
@@ -136,17 +177,24 @@ def _scan_tree(tree: ast.AST, label: str) -> list[str]:
         if isinstance(node, ast.ImportFrom) and _is_production_module(node.module):
             if any(alias.name in _BANNED_NAMES for alias in node.names):
                 offenders.append(f"{label}:{node.lineno}")
-        # Form 2 — module-alias attribute *read* ``<mod>.REPO_ROOT``. The
+        # Forms 2 and 4 — attribute *read* ``<prod-module-expr>.REPO_ROOT``,
+        # where the base is an alias (2a), a dotted no-alias chain (2b), or an
+        # inline ``import_module(...)`` call (4). The
         # ``monkeypatch.setattr(mod, "REPO_ROOT", ...)`` object form has no such
         # attribute node (module is an arg, name is a string), so it is not hit.
         elif isinstance(node, ast.Attribute) and node.attr in _BANNED_NAMES:
-            base = node.value
-            if isinstance(base, ast.Name) and base.id in aliases:
-                offenders.append(f"{label}:{node.lineno}")  # 2a: aliased module
-            else:
-                dotted = _dotted_name(base)  # 2b: dotted no-alias (common.post_generator.*)
-                if dotted is not None and _is_production_module(dotted):
-                    offenders.append(f"{label}:{node.lineno}")
+            if _is_prod_module_expr(node.value, aliases):
+                offenders.append(f"{label}:{node.lineno}")
+        # Form 3 — dynamic read ``getattr(<prod-module-expr>, "REPO_ROOT")``.
+        # Matched on ``getattr`` only: ``setattr`` is the sanctioned redirect.
+        elif isinstance(node, ast.Call) and _call_name(node) == "getattr" and len(node.args) >= 2:
+            attr = node.args[1]
+            if (
+                isinstance(attr, ast.Constant)
+                and attr.value in _BANNED_NAMES
+                and _is_prod_module_expr(node.args[0], aliases)
+            ):
+                offenders.append(f"{label}:{node.lineno}")
     return offenders
 
 
@@ -205,6 +253,14 @@ def test_detector_flags_all_banned_forms():
         "from scripts.common import post_generator\nx = post_generator.REPO_ROOT\n",
         # Form 2b — dotted no-alias chain.
         "import common.post_generator\nx = common.post_generator.REPO_ROOT\n",
+        # Form 3 — dynamic getattr with the name in a string.
+        'import common.post_generator as pg\nx = getattr(pg, "REPO_ROOT")\n',
+        'from common import post_generator\nx = getattr(post_generator, "POSTS_DIR")\n',
+        'import common.post_generator\nx = getattr(common.post_generator, "SITE_DIR")\n',
+        'x = getattr(import_module("common.post_generator"), "REPO_ROOT")\n',
+        # Form 4 — attribute read straight off an inline import_module call.
+        'x = importlib.import_module("common.post_generator").REPO_ROOT\n',
+        'x = import_module("scripts.common.post_generator").POSTS_DIR\n',
     )
     for snippet in bad:
         assert _offenders_in(snippet), f"detector missed: {snippet!r}"
@@ -225,6 +281,13 @@ def test_detector_spares_legitimate_forms():
         "_REPO_ROOT = Path(__file__).resolve().parent.parent\nx = _REPO_ROOT / '_state'\n",
         # Banned name as an attribute on a NON-production module.
         "import os\nx = os.REPO_ROOT\n",
+        # setattr is the redirect, not a leak — form 3 must not swallow it.
+        'import common.post_generator as pg\nsetattr(pg, "REPO_ROOT", str(tmp_path))\n',
+        # getattr of a NON-banned attribute, and off a non-production module.
+        'import common.dedup as dedup\nx = getattr(dedup, "STATE_DIR")\n',
+        'import os\nx = getattr(os, "REPO_ROOT")\n',
+        # Inline import of a non-production module.
+        'x = importlib.import_module("json").REPO_ROOT\n',
     )
     for snippet in good:
         assert not _offenders_in(snippet), f"detector false-positive: {snippet!r}"

--- a/tests/test_state_path_anchoring.py
+++ b/tests/test_state_path_anchoring.py
@@ -12,12 +12,20 @@ The fix everywhere is to compose the path from a ``__file__`` anchor
 non-first ``os.path.join`` arg) — never as the leading element of a path.
 
 This guard AST-scans every script (AST ignores comments/strings-in-comments) and
-fails on two forms:
+fails on three forms:
   A. any string literal that starts with ``_state/`` or ``_state\\`` — these are
      bare-relative regardless of how they are used; and
   B. an exact ``"_state"`` literal handed to ``Path(...)`` or ``*.join(...)`` as
      the first argument — the no-slash single-component bare-root that form A
-     cannot see (slash-rooted forms in any context are already caught by A).
+     cannot see (slash-rooted forms in any context are already caught by A); and
+  C. the two shapes that wear a disguise A/B cannot see through:
+     C1. an explicit-cwd prefix — ``"./_state/foo.json"`` resolves against cwd
+         exactly like ``"_state/foo.json"`` but does not *start with* the bare
+         root, so form A's ``startswith`` misses it. Both A and B therefore
+         strip leading ``./`` / ``.\\`` before testing.
+     C2. an f-string rooted at the bare root — ``Path(f"_state/{name}.json")``
+         is an ``ast.JoinedStr``, not an ``ast.Constant``, so neither A nor B
+         ever sees it. Its leading literal chunk is tested with the same rules.
 """
 
 from __future__ import annotations
@@ -34,9 +42,38 @@ def _py_files() -> list[Path]:
     return [p for p in SCRIPTS_DIR.rglob("*.py") if "__pycache__" not in p.parts]
 
 
+# Form C1: an explicit-cwd prefix is semantically identical to no prefix at all
+# (``./_state/x`` == ``_state/x``), so it must be stripped before the root tests.
+_CWD_PREFIXES = ("./", ".\\")
+
+
+def _strip_cwd_prefix(value: str) -> str:
+    """Drop leading explicit-cwd markers (``./``, ``.\\``), however many."""
+    while value.startswith(_CWD_PREFIXES):
+        value = value[2:]
+    return value
+
+
 def _is_slash_rooted(value: str) -> bool:
     """Form A: a literal that *starts a path* with the _state segment."""
-    return value.startswith(_BARE_ROOT + "/") or value.startswith(_BARE_ROOT + "\\")
+    bare = _strip_cwd_prefix(value)
+    return bare.startswith(_BARE_ROOT + "/") or bare.startswith(_BARE_ROOT + "\\")
+
+
+def _is_bare_root(value: str) -> bool:
+    """Form B: the exact single-component bare root (cwd prefix tolerated)."""
+    return _strip_cwd_prefix(value) == _BARE_ROOT
+
+
+def _fstring_prefix(node: ast.JoinedStr) -> str | None:
+    """Form C2: the leading *literal* chunk of an f-string, if it has one.
+
+    ``f"_state/{name}"`` -> ``"_state/"``; ``f"{root}/_state/x"`` -> None
+    (an interpolation leads, so the path is anchored at whatever ``root`` is).
+    """
+    if node.values and isinstance(node.values[0], ast.Constant) and isinstance(node.values[0].value, str):
+        return node.values[0].value
+    return None
 
 
 def _call_name(call: ast.Call) -> str:
@@ -59,13 +96,20 @@ def _collect_offenders(source: str, label: str) -> list[str]:
     offenders: list[str] = []
     tree = ast.parse(source, filename=label)
     for node in ast.walk(tree):
-        # Form A — any string literal that roots a path at _state/.
+        # Form A (+C1) — any string literal that roots a path at _state/.
         if isinstance(node, ast.Constant) and isinstance(node.value, str) and _is_slash_rooted(node.value):
             offenders.append(f"{label}:{node.lineno} -> literal {node.value!r}")
-        # Form B — leading "_state" as the first arg to Path(...) / *.join(...).
+        # Form C2 — f-string whose leading literal chunk roots the path at _state.
+        # An f-string with no interpolation compiles to a Constant, so a bare
+        # ``_state`` prefix here is always followed by an interpolated segment.
+        elif isinstance(node, ast.JoinedStr):
+            prefix = _fstring_prefix(node)
+            if prefix is not None and (_is_slash_rooted(prefix) or _is_bare_root(prefix)):
+                offenders.append(f"{label}:{node.lineno} -> f-string rooted at {prefix!r}")
+        # Form B (+C1) — leading "_state" as the first arg to Path(...) / *.join(...).
         elif isinstance(node, ast.Call) and _call_name(node) in {"Path", "join"}:
             first = _first_arg_str(node)
-            if first is not None and first == _BARE_ROOT:
+            if first is not None and _is_bare_root(first):
                 offenders.append(f"{label}:{node.lineno} -> {_call_name(node)}({first!r}) leading bare-root")
     return offenders
 
@@ -91,6 +135,16 @@ def test_guard_detects_known_antipatterns() -> None:
         'x = os.path.join("_state", "foo.json")',
         'parser.add_argument("--f", default="_state/foo.txt")',
         "p = Path('_state') / 'foo.json'",
+        # Form C1 — explicit-cwd prefix resolves against cwd just the same.
+        'x = Path("./_state/foo.json")',
+        'x = open("./_state/foo.json")',
+        'x = Path("./_state")',
+        'x = os.path.join("./_state", "foo.json")',
+        # Form C2 — f-string rooted at the bare root (invisible to A and B).
+        'x = Path(f"_state/{name}.json")',
+        'x = Path(f"./_state/{name}.json")',
+        'x = open(f"_state/{name}.json")',
+        'x = Path(f"_state{sep}foo.json")',
     )
     for snippet in bad:
         assert _collect_offenders(snippet, "<bad>"), f"detector missed: {snippet}"
@@ -101,6 +155,10 @@ def test_guard_detects_known_antipatterns() -> None:
         'x = os.path.join(REPO_ROOT, "_state", "foo.json")',
         'x = Path(__file__).resolve().parent.parent / "_state"',
         'name = "_state"  # bare component used elsewhere, anchored at call site',
+        # Anchored f-strings: an interpolation leads, so the root is whatever
+        # the anchored variable holds — not cwd.
+        'x = Path(f"{_REPO_ROOT}/_state/{name}.json")',
+        'x = f"{REPO_ROOT}/_state"',
     )
     for snippet in good:
         assert not _collect_offenders(snippet, "<good>"), f"detector false-positive: {snippet}"
@@ -212,6 +270,84 @@ def test_module_level_state_paths_anchored_to_repo_root(rel_path: str, root_var:
         assert name in assigns, f"{rel_path}: module-level state variable {name!r} is missing"
         rhs = ast.unparse(assigns[name])
         assert root_var in rhs, f"{rel_path}: {name} must reference {root_var!r} (got: {rhs!r})"
+
+
+# Module-level _state writers verified by a *dedicated* test rather than by the
+# `_MODULE_LEVEL_WRITERS` table above. Listed here so the drift check below
+# counts them as covered.
+_DEDICATED_ANCHOR_TESTS: frozenset[str] = frozenset(
+    {
+        "common/image_rejection_metrics.py",  # test_image_rejection_metrics_anchors_state_to_repo_root
+        "fix_defi_tvl_history.py",  # test_fix_defi_tvl_history_state_path_uses_file_anchor
+    }
+)
+
+
+def _builds_state_path(expr: ast.expr) -> bool:
+    """True if ``expr`` composes a filesystem path containing a ``_state`` segment.
+
+    Two conditions must both hold, which is what keeps the scan from firing on
+    prose: (1) a string constant that *is* the bare root or roots a path at it,
+    and (2) an actual path-construction node — a ``Path()``/``join()``/
+    ``abspath()`` call or a ``/`` operator. A module that merely mentions
+    ``_state`` inside a message or a table of test fixtures satisfies neither.
+    """
+    if not any(
+        isinstance(n, ast.Constant)
+        and isinstance(n.value, str)
+        and (_is_bare_root(n.value) or _is_slash_rooted(n.value))
+        for n in ast.walk(expr)
+    ):
+        return False
+    for node in ast.walk(expr):
+        if isinstance(node, ast.Call) and _call_name(node) in {"Path", "join", "abspath"}:
+            return True
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            return True
+    return False
+
+
+def _discover_module_level_state_writers() -> set[str]:
+    """Every script that assigns a ``_state`` path at module scope."""
+    writers: set[str] = set()
+    for path in _py_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            value = node.value if isinstance(node, (ast.Assign, ast.AnnAssign)) else None
+            if value is not None and _builds_state_path(value):
+                writers.add(str(path.relative_to(SCRIPTS_DIR)))
+    return writers
+
+
+def test_module_level_writers_table_has_no_drift() -> None:
+    """Every module-level ``_state`` writer must be covered by an anchor test.
+
+    ``_MODULE_LEVEL_WRITERS`` is hand-maintained, so a newly added writer is
+    silently unguarded — the parametrized test above simply never runs for it
+    and the suite stays green. This closes that hole by discovering writers from
+    the source tree and requiring each one to be registered.
+
+    Adding a new module-level ``_state`` writer? Append ``(rel_path, root_var,
+    state_vars)`` to ``_MODULE_LEVEL_WRITERS`` (or write a dedicated test and
+    list the file in ``_DEDICATED_ANCHOR_TESTS``).
+    """
+    discovered = _discover_module_level_state_writers()
+    assert discovered, "no module-level _state writers discovered — the scan is broken (vacuous)"
+
+    covered = {rel for rel, _, _ in _MODULE_LEVEL_WRITERS} | _DEDICATED_ANCHOR_TESTS
+    unregistered = sorted(discovered - covered)
+    assert not unregistered, (
+        "module-level _state writer(s) not covered by any repo-root anchor test:\n"
+        + "\n".join(f"  - {p}" for p in unregistered)
+        + "\n\nRegister each in _MODULE_LEVEL_WRITERS in this file so its __file__ anchor is verified."
+    )
+
+
+def test_module_level_writers_table_entries_still_exist() -> None:
+    """Canary: a renamed/deleted entry must fail loudly, not skip silently."""
+    missing = [rel for rel, _, _ in _MODULE_LEVEL_WRITERS if not (SCRIPTS_DIR / rel).is_file()]
+    missing += [rel for rel in sorted(_DEDICATED_ANCHOR_TESTS) if not (SCRIPTS_DIR / rel).is_file()]
+    assert not missing, f"registered _state writer(s) no longer exist: {missing}"
 
 
 def test_fix_defi_tvl_history_state_path_uses_file_anchor() -> None:


### PR DESCRIPTION
## 배경

PR #1073/#1074 로 가드 19종의 falsifiability 를 실증했지만, 검증한 것은 "등록된 mutation 이 red 를 만드는가"였다. 이번엔 반대 방향 — **가드를 통과하면서 위반할 수 있는 경로가 남아있는가**를 감사해 10건을 찾아 막았다.

## 갭 10건

### `_state` 경로 탐지기 (`tests/test_state_path_anchoring.py`)

| # | 우회 경로 | 왜 통과했나 |
|---|-----------|-------------|
| 1 | `"./_state/foo.json"` (form C1) | form A 는 `startswith("_state/")` — `./` 프리픽스가 붙으면 못 본다. cwd 상대 해석은 동일하다 |
| 2 | `Path(f"_state/{name}.json")` (form C2) | f-string 은 `ast.JoinedStr` 이라 `ast.Constant` 를 보는 form A/B 양쪽 모두 통과 |
| 3 | 미등록 모듈 레벨 `_state` writer | `_MODULE_LEVEL_WRITERS` 가 수기 표 → 새 writer 는 파라미터화 테스트가 아예 돌지 않고 green |

3번은 소스에서 writer 를 전수 발견해 미등록 시 실패시킨다. 오탐 방지로 두 조건을 모두 요구한다: `_state` 문자열 상수 **그리고** 실제 경로 생성 노드(`Path()`/`join()`/`/`). 하네스 자신처럼 `_state` 를 문자열 표에 담고만 있는 파일은 걸리지 않는다.

### hermetic 탐지기 (`tests/test_hermetic_test_writes_guard.py`)

| # | 우회 경로 | 왜 통과했나 |
|---|-----------|-------------|
| 4 | `getattr(pg, "REPO_ROOT")` | 이름이 문자열에 있어 Attribute 스캔에 안 걸린다 |
| 5 | `import_module("common.x").REPO_ROOT` | base 가 `Call` 이라 dotted-chain 검사가 `None` 으로 빠진다 |

정당한 리다이렉트인 `setattr(pg, "REPO_ROOT", ...)` 는 계속 허용된다 — form 3 은 `getattr` 만 매칭한다.

### 커버리지 게이트 무결성 (`tests/test_coverage_floor_guard.py`)

숫자 `70` 은 그대로 두고 게이트만 무력화하는 4가지 편집이 전부 무가드였다.

| # | 우회 경로 | 효과 |
|---|-----------|------|
| 6 | `--cov=scripts` → 단일 모듈 | 하한 70 유지, 측정 대상은 거의 없음 |
| 7 | 워크플로우 `--cov` 축소 | 동일 |
| 8 | 게이트 스텝 `continue-on-error: true` | red 가 job 을 실패시키지 않음 |
| 9 | `coverage report --omit=...` | 약한 모듈을 분모에서 제거 |
| 10 | `[tool.coverage.run] omit` | `--cov-config=pyproject.toml` 이라 **두 게이트 모두**에 조용히 적용 |

## 하네스 Part 2 + 기존 케이스 결함 수정

10건을 `STATIC_CASES` 에 편입 (19 → 29).

감사 중 **기존 form A 케이스의 허위 FALSIFIABLE 판정**을 발견했다. `dedup.py` 에 `Path("_state/probe.json")` 을 주입했는데 그 모듈은 `pathlib` 을 import 하지 않아, autouse fixture 의 dedup import 가 `NameError` 로 죽었다:

```
tests/conftest.py:29: in <module>
    import common.image_rejection_metrics as _irm_a
scripts/common/dedup.py:254: in <module>
    _FALSIFIABILITY_PROBE = Path("_state/probe.json")
E   NameError: name 'Path' is not defined
```

테스트 본문은 실행되지도 않았는데 `rc != 0` 이라 FALSIFIABLE 로 보였다. import 불필요한 리터럴로 교체하고, "주입 코드는 대상 파일에서 실행 가능해야 한다"를 앵커 유일성에 이은 두 번째 규약으로 문서화했다.

## 검증

**하네스 전체 — 29/29 falsifiable**

```
$ PYTHONPATH=scripts python3 scripts/tools/guard_falsifiability.py
...
FALSIFIABLE | patched_rc=1 control_rc=0 | cwd 프리픽스 우회 주입 (form C1: ./_state/)
FALSIFIABLE | patched_rc=1 control_rc=0 | f-string 우회 주입 (form C2: f"_state/{...}")
FALSIFIABLE | patched_rc=1 control_rc=0 | 미등록 모듈 레벨 _state writer 추가 (드리프트)
FALSIFIABLE | patched_rc=1 control_rc=0 | 테스트가 getattr 로 production REPO_ROOT 취득
FALSIFIABLE | patched_rc=1 control_rc=0 | 테스트가 import_module 체인으로 production REPO_ROOT 취득
FALSIFIABLE | patched_rc=1 control_rc=0 | 커버리지 측정 범위 축소 (pyproject --cov)
FALSIFIABLE | patched_rc=1 control_rc=0 | 커버리지 측정 범위 축소 (워크플로우 --cov)
FALSIFIABLE | patched_rc=1 control_rc=0 | 커버리지 게이트 비차단화 (continue-on-error)
FALSIFIABLE | patched_rc=1 control_rc=0 | 커버리지 게이트에서 모듈 제외 (--omit)
FALSIFIABLE | patched_rc=1 control_rc=0 | 커버리지 설정에서 모듈 제외 ([tool.coverage.run] omit)

29/29 guards falsifiable
```

**red 의 원인이 가드 단언인지 개별 확인** (form A 결함의 교훈 — `rc != 0` 만으로는 부족)

신규 10건 각각에 mutation 을 적용해 실패 메시지를 확인했고, 전부 무관한 에러가 아닌 자기 가드의 단언이었다:

```
AssertionError: cwd-relative _state path(s) found. ...
  scripts/common/dedup.py:254 -> f-string rooted at '_state/'

AssertionError: module-level _state writer(s) not covered by any repo-root anchor test:
  - check_description_quality.py

AssertionError: coverage gate is non-blocking (failures would not fail the job):
  - - name: Generate coverage report -> continue-on-error: true

AssertionError: coverage config narrows what is measured, ...
  - [tool.coverage.run] omit = ['*/collect_*.py']
```

**기타**

```
$ PYTHONPATH=scripts python3 -m pytest tests/ -q
4943 passed, 16 skipped, 11 warnings in 194.10s
Required test coverage of 70% reached. Total coverage: 72.63%

$ python3 -m ruff check scripts/ tests/ && python3 -m ruff format --check scripts/ tests/
All checks passed!  /  263 files already formatted

$ python3 -m basedpyright
0 errors, 0 warnings, 0 notes
```

기존 코드에 신규 탐지 위반 0건 (프리스캔 확인) — 프로덕션 코드 변경 없이 가드만 강화했다. `component_counts.py` 드리프트도 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)