### PR TITLE
feat: 런타임 트리-쓰기 탐지기 + 실제 오염 1건 수정 (하네스 29 → 34)

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 49 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 125 |
+| 테스트 파일 (tests/test_*.py) | 126 |
 
 <!-- component-counts:end -->

--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -60,9 +60,15 @@ CASES: dict[str, str] = {
     "_isolate_signal_history_state": "test_signal_history_redirected_off_repo_tree",
     "_isolate_translation_cache": "test_translation_cache_redirected_off_repo_tree",
     "_isolate_image_rejection_state": "test_image_rejection_state_redirected_off_repo_tree",
+    "_isolate_tvl_history_state": "test_tvl_history_redirected_off_repo_tree",
+    "_detect_real_tree_writes": "test_real_tree_writes_detected",
 }
 
-_AUTOUSE_RE = re.compile(r"@pytest\.fixture\(autouse=True\)\n(?:@[^\n]*\n)*def (\w+)\(")
+# ``autouse=True`` may sit alongside other kwargs (``scope="session"``), in any
+# order. Matching the exact single-kwarg spelling let a session-scoped autouse
+# fixture escape the drift check entirely — found 2026-08-05 when
+# ``_detect_real_tree_writes`` was added and the registry stayed silent.
+_AUTOUSE_RE = re.compile(r"@pytest\.fixture\([^)]*autouse=True[^)]*\)\n(?:@[^\n]*\n)*def (\w+)\(")
 
 
 class StaticCase(NamedTuple):
@@ -246,6 +252,31 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         '[tool.coverage.run]\nrelative_files = true\nomit = ["*/collect_*.py"]',
         "tests/test_coverage_floor_guard.py::test_pyproject_coverage_config_omits_nothing",
     ),
+    # ---------------------------------------------------------------------
+    # Part 3 (2026-08-05): 런타임 트리-쓰기 탐지기. fixture 를 끄는 케이스는
+    # CASES 에 있고, 여기서는 **탐지기 자체를 무력화**하는 변형을 검증한다.
+    # ---------------------------------------------------------------------
+    StaticCase(
+        "트리-쓰기 탐지기 무력화 (모든 경로를 안전으로 분류)",
+        "tests/_tree_write_guard.py",
+        "    if isinstance(target, int):  # file descriptor, not a path\n        return None",
+        "    return None\n    if isinstance(target, int):  # file descriptor, not a path\n        return None",
+        "tests/test_tree_write_guard.py::TestProtectedPathClassification::test_committed_tree_paths_are_protected[_state/dedup_seen.json]",
+    ),
+    StaticCase(
+        "트리-쓰기 탐지기: io.open 패치 누락 (Path.write_text 우회)",
+        "tests/_tree_write_guard.py",
+        '        for owner in (builtins, io):\n            self._patch(owner, "open", self._wrap_open)',
+        '        for owner in (builtins,):\n            self._patch(owner, "open", self._wrap_open)',
+        "tests/test_tree_write_guard.py::TestInterception::test_pathlib_write_text_is_caught",
+    ),
+    StaticCase(
+        "트리-쓰기 탐지기: 쓰기 모드 판정 무력화",
+        "tests/_tree_write_guard.py",
+        'return any(c in mode for c in "wax+")',
+        "return False",
+        "tests/test_tree_write_guard.py::TestWriteModeDetection::test_write_modes_detected[w]",
+    ),
 )
 
 
@@ -284,9 +315,13 @@ def _purge_pycache() -> None:
 
 
 def _disable_fixture(src: str, name: str) -> str:
-    """지정 fixture 의 autouse=True 를 False 로 바꾼다."""
-    pattern = re.compile(r"@pytest\.fixture\(autouse=True\)\n(def " + re.escape(name) + r"\()")
-    patched, count = pattern.subn(r"@pytest.fixture(autouse=False)\n\1", src)
+    """지정 fixture 의 autouse=True 를 False 로 바꾼다.
+
+    데코레이터에 다른 kwarg(``scope="session"`` 등)가 함께 있어도 매칭한다 —
+    ``autouse=True`` 만 치환하고 나머지 인자는 보존한다.
+    """
+    pattern = re.compile(r"@pytest\.fixture\(([^)]*)autouse=True([^)]*)\)\n(def " + re.escape(name) + r"\()")
+    patched, count = pattern.subn(r"@pytest.fixture(\1autouse=False\2)\n\3", src)
     if count != 1:
         raise RuntimeError(f"fixture {name!r} 의 autouse 데코레이터를 정확히 1개 찾지 못했다 (found={count})")
     return patched

--- a/tests/_tree_write_guard.py
+++ b/tests/_tree_write_guard.py
@@ -1,0 +1,310 @@
+"""Runtime detector for non-hermetic writes into the committed repo tree.
+
+## Why a runtime detector, when static guards already exist
+
+``test_hermetic_test_writes_guard.py`` AST-scans tests for the *shape* of a
+real-tree write (importing a production ``REPO_ROOT``). That catches the
+canonical vector, but it reasons about source text: a path assembled at runtime,
+handed in by a fixture, or reached through a production default argument is
+invisible to it. Static analysis can only see the ways it knows to look.
+
+## Why interception, not a before/after snapshot
+
+The obvious runtime design — snapshot ``assets/``/``_posts/`` before the suite
+and diff after — cannot catch the incident that motivated this guard. On
+2026-06-30 tests wrote real files under ``REPO_ROOT/assets/images/generated/``
+**and removed them in a ``finally`` block**; the leak surfaced only on abnormal
+termination. A before/after diff of a normally-terminating run is empty. The
+write has to be caught *as it happens*.
+
+So this module patches the write entry points and raises on the first write
+whose resolved target is a protected path. That also gives exact attribution —
+pytest reports the failing test, and the traceback names the offending line —
+where a snapshot only says "something, somewhere, changed".
+
+``builtins.open`` and ``io.open`` are the *same function object* but are reached
+through different module attributes: ``Path.write_text``/``Path.open`` call
+``io.open``, while ``open(...)`` and PIL's ``Image.save`` call
+``builtins.open``. Both names must be patched or half the writes slip through.
+
+## Scope and blind spots (stated, not implied)
+
+In-process writes only. A subprocess (``bundle exec jekyll build``, a collector
+launched via ``subprocess.run``) writes through its own interpreter and is not
+seen here — :func:`snapshot_tree` / :func:`diff_tree` provide the complementary
+end-of-session net for that case. C extensions that write via raw syscalls
+without going through ``os``/``io`` are likewise invisible.
+"""
+
+from __future__ import annotations
+
+import builtins
+import contextlib
+import io
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Derived from __file__, never imported from production — importing a production
+# root constant into a test module is exactly what the hermetic guard bans.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Path components that make a write allowed wherever it appears. These are build
+# and tooling artifacts that legitimately live inside the checkout.
+_EXEMPT_PARTS = frozenset(
+    {
+        "__pycache__",
+        ".git",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "node_modules",
+        ".venv",
+        "vendor",
+        ".bundle",
+        ".omc",
+        "coverage-html",
+        ".jekyll-cache",
+        ".jekyll-metadata",
+    }
+)
+
+# Repo-relative path prefixes that are allowed to be written.
+_EXEMPT_PREFIXES: tuple[str, ...] = (
+    ".coverage",  # coverage data files (.coverage, .coverage.host.pid.random)
+    "coverage.json",
+)
+
+
+class Violation(NamedTuple):
+    """A single attempted write into the protected tree."""
+
+    operation: str  # "open", "os.open", "os.remove", ...
+    path: str  # repo-relative
+
+    def __str__(self) -> str:  # pragma: no cover - formatting only
+        return f"{self.operation} -> {self.path}"
+
+
+def _relative_if_protected(target: Any, *, dir_fd: int | None = None) -> str | None:
+    """Return the repo-relative path if writing ``target`` pollutes the tree.
+
+    Returns ``None`` for anything outside the checkout (tmp dirs, /dev/null,
+    site-packages) and for the exempt build artifacts above. Non-path arguments
+    — an already-open file descriptor handed to ``open()``, for instance — are
+    not filesystem targets and are also ``None``.
+
+    ``dir_fd`` with a *relative* path resolves against that descriptor, not cwd,
+    so the usual ``abspath`` assumption is wrong and the target is unknowable
+    without the fd. This is not hypothetical: ``tempfile.TemporaryDirectory``
+    cleanup unlinks via ``os.unlink(name, dir_fd=fd)``, which made a properly
+    hermetic tmp-dir teardown look like a write to ``REPO_ROOT/<name>``.
+    """
+    if isinstance(target, int):  # file descriptor, not a path
+        return None
+    try:
+        path = Path(os.fsdecode(target))
+    except (TypeError, ValueError):
+        return None
+    if dir_fd is not None and not path.is_absolute():
+        return None
+
+    # abspath, not resolve(): resolve() follows symlinks and stats the
+    # filesystem on every call, which is far too costly on this hot path.
+    absolute = Path(os.path.abspath(path))
+    try:
+        relative = absolute.relative_to(REPO_ROOT)
+    except ValueError:
+        return None  # outside the checkout — always fine
+
+    parts = relative.parts
+    if not parts:
+        return None
+    if _EXEMPT_PARTS.intersection(parts):
+        return None
+    if parts[0].startswith(_EXEMPT_PREFIXES):
+        return None
+    return str(relative)
+
+
+def _is_write_mode(mode: str) -> bool:
+    return any(c in mode for c in "wax+")
+
+
+# O_RDONLY is 0, so a flags value is a write iff one of these bits is set.
+_WRITE_FLAGS = os.O_WRONLY | os.O_RDWR | os.O_APPEND | os.O_CREAT | os.O_TRUNC
+
+# Operations whose effect depends on whether the target already exists.
+_CREATE_OPS = frozenset({"os.mkdir", "os.makedirs"})
+_DELETE_OPS = frozenset({"os.remove", "os.unlink", "os.rmdir", "shutil.rmtree"})
+
+
+class TreeWriteGuard:
+    """Patches the write entry points and reports protected-tree writes.
+
+    ``on_violation`` decides the policy: raise to block the write and fail the
+    test, or append to a list for a report-only discovery run.
+    """
+
+    def __init__(self, on_violation: Callable[[Violation], None]) -> None:
+        self._on_violation = on_violation
+        self._originals: list[tuple[Any, str, Any]] = []
+
+    # -- patching ---------------------------------------------------------
+
+    def _patch(self, owner: Any, name: str, factory: Callable[[Any], Any]) -> None:
+        original = getattr(owner, name)
+        self._originals.append((owner, name, original))
+        wrapper = factory(original)
+        # Tripwire: lets the isolation guard confirm this patch point is live
+        # without performing a write. Mirrors ``_ssrf_dns_stub`` /
+        # ``_http_block_stub`` in conftest.
+        wrapper._tree_write_guard_stub = True
+        setattr(owner, name, wrapper)
+
+    def install(self) -> None:
+        _INSTALLED.append(self)
+        # `open` — patched on BOTH names: same object, different lookup paths.
+        for owner in (builtins, io):
+            self._patch(owner, "open", self._wrap_open)
+        self._patch(os, "open", self._wrap_os_open)
+        for name in ("remove", "unlink", "rmdir", "mkdir", "makedirs"):
+            self._patch(os, name, self._wrap_path_arg(f"os.{name}"))
+        for name in ("rename", "replace"):
+            self._patch(os, name, self._wrap_two_path_args(f"os.{name}"))
+        # shutil.copyfile/copy/move funnel through open(), but rmtree calls
+        # os.unlink/os.rmdir on a walk it performs itself — cheap to cover here
+        # and it names the whole tree rather than one leaf file.
+        self._patch(shutil, "rmtree", self._wrap_path_arg("shutil.rmtree"))
+
+    def uninstall(self) -> None:
+        for owner, name, original in reversed(self._originals):
+            setattr(owner, name, original)
+        self._originals.clear()
+        if self in _INSTALLED:
+            _INSTALLED.remove(self)
+
+    def __enter__(self) -> TreeWriteGuard:
+        self.install()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.uninstall()
+
+    # -- wrappers ---------------------------------------------------------
+
+    def _report(self, operation: str, target: Any, *, dir_fd: int | None = None) -> None:
+        relative = _relative_if_protected(target, dir_fd=dir_fd)
+        if relative is None:
+            return
+        # Only calls that actually change the tree count. Creating a directory
+        # that already exists, or deleting a path that does not, is a no-op —
+        # `post_generator.os.makedirs(POSTS_DIR, exist_ok=True)` reaches the real
+        # `_posts/` on every collector test but leaves it untouched. Reporting
+        # those would bury the writes that do land under constant noise.
+        exists = (REPO_ROOT / relative).exists()
+        if operation in _CREATE_OPS and exists:
+            return
+        if operation in _DELETE_OPS and not exists:
+            return
+        self._on_violation(Violation(operation, relative))
+
+    def _wrap_open(self, original: Any) -> Any:
+        def guarded(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+            if _is_write_mode(mode):
+                self._report("open", file)
+            return original(file, mode, *args, **kwargs)
+
+        return guarded
+
+    def _wrap_os_open(self, original: Any) -> Any:
+        def guarded(path: Any, flags: int, *args: Any, **kwargs: Any) -> Any:
+            if flags & _WRITE_FLAGS:
+                self._report("os.open", path, dir_fd=kwargs.get("dir_fd"))
+            return original(path, flags, *args, **kwargs)
+
+        return guarded
+
+    def _wrap_path_arg(self, operation: str) -> Callable[[Any], Any]:
+        def factory(original: Any) -> Any:
+            def guarded(path: Any, *args: Any, **kwargs: Any) -> Any:
+                self._report(operation, path, dir_fd=kwargs.get("dir_fd"))
+                return original(path, *args, **kwargs)
+
+            return guarded
+
+        return factory
+
+    def _wrap_two_path_args(self, operation: str) -> Callable[[Any], Any]:
+        def factory(original: Any) -> Any:
+            def guarded(src: Any, dst: Any, *args: Any, **kwargs: Any) -> Any:
+                self._report(operation, src, dir_fd=kwargs.get("src_dir_fd"))
+                self._report(operation, dst, dir_fd=kwargs.get("dst_dir_fd"))
+                return original(src, dst, *args, **kwargs)
+
+            return guarded
+
+        return factory
+
+
+# Guards currently patched in, outermost first. Wrappers chain — an inner guard
+# calls what it replaced, which is the outer guard's wrapper — so a second guard
+# installed on top of the session one still trips the session policy.
+_INSTALLED: list[TreeWriteGuard] = []
+
+
+@contextlib.contextmanager
+def suspended() -> Iterator[None]:
+    """Lift every installed guard for the block, then reinstall them.
+
+    Test-infrastructure only, for exercising a guard instance in isolation
+    (``tests/test_tree_write_guard.py``). Production tests must never reach for
+    this to "allow" a write — redirect the module's path constant instead.
+    """
+    lifted = list(_INSTALLED)
+    for guard in reversed(lifted):
+        guard.uninstall()
+    try:
+        yield
+    finally:
+        for guard in lifted:
+            guard.install()
+
+
+# ---------------------------------------------------------------------------
+# Complementary net: catches out-of-process writes the interceptor cannot see.
+# ---------------------------------------------------------------------------
+
+# Trees worth snapshotting: committed content a stray write would dirty. Kept
+# narrow because this walks the filesystem.
+_SNAPSHOT_DIRS: tuple[str, ...] = ("_posts", "_state", "assets/images/generated")
+
+
+def snapshot_tree() -> dict[str, int]:
+    """Map repo-relative path -> size for the snapshotted content dirs.
+
+    Size rather than a hash: this runs on a tree with thousands of images, and
+    the goal is detecting *appearance/disappearance/growth*, not byte-level
+    equality. Hashing every file would cost more than the guard is worth.
+    """
+    snapshot: dict[str, int] = {}
+    for relative_dir in _SNAPSHOT_DIRS:
+        root = REPO_ROOT / relative_dir
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and not _EXEMPT_PARTS.intersection(path.parts):
+                snapshot[str(path.relative_to(REPO_ROOT))] = path.stat().st_size
+    return snapshot
+
+
+def diff_tree(before: dict[str, int], after: dict[str, int]) -> list[str]:
+    """Human-readable added/removed/modified entries between two snapshots."""
+    changes = [f"added: {p}" for p in sorted(set(after) - set(before))]
+    changes += [f"removed: {p}" for p in sorted(set(before) - set(after))]
+    changes += [f"modified: {p}" for p in sorted(set(before) & set(after)) if before[p] != after[p]]
+    return changes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ TOOLS_DIR = os.path.join(SCRIPTS_DIR, "tools")
 if TOOLS_DIR not in sys.path:
     sys.path.insert(0, TOOLS_DIR)
 
+# Add tests/ to path for the leading-underscore test *helper* modules that are
+# not themselves collected (``_tree_write_guard``).
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if TESTS_DIR not in sys.path:
+    sys.path.insert(0, TESTS_DIR)
+
 
 # ---------------------------------------------------------------------------
 # Module-level: redirect image_rejection_metrics state to a tmp dir BEFORE any
@@ -333,6 +339,64 @@ def _isolate_translation_cache(request, tmp_path, monkeypatch):
             monkeypatch.setattr(translator_scripts, "_cache_dirty", False)
     except ImportError:
         pass
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tvl_history_state(request, tmp_path, monkeypatch):
+    """Redirect ``collect_defi_llama`` TVL-history writes to a per-test tmp file.
+
+    ``build_post_content()`` calls ``_check_tvl_staleness()``, which appends to a
+    ``TimeSeriesStore`` bound to the module global ``_TVL_HISTORY_PATH``. That
+    write happens on the *content-building* path, so a test needs no collector,
+    no network and no fixtures to trigger it — ``test_build_post_content_
+    contains_key_sections`` takes no arguments at all and still rewrote the
+    committed ``_state/defi_tvl_history.json`` on every run.
+
+    Found by ``_detect_real_tree_writes`` below, not by any static guard: the
+    path is correctly ``__file__``-anchored and the test imports no production
+    root, so every source-shape check passes. Only watching the actual write
+    surfaced it.
+
+    Opt-out: ``no_state_isolation``, consistent with the other ``_state``
+    redirects.
+    """
+    if request.node.get_closest_marker("no_state_isolation"):
+        return
+    try:
+        import collect_defi_llama as defi
+    except ImportError:
+        return
+    monkeypatch.setattr(defi, "_TVL_HISTORY_PATH", str(tmp_path / "_state" / "defi_tvl_history.json"))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _detect_real_tree_writes():
+    """Fail the moment a test writes into the committed repo tree.
+
+    The static guards check what tests *look* like; this checks what they *do*.
+    See ``tests/_tree_write_guard.py`` for why interception beats a before/after
+    snapshot (writes cleaned up in ``finally`` leave no diff) and for the stated
+    blind spots.
+
+    Session-scoped so the patch cost is paid once, not 4900 times. Attribution
+    is unaffected: the exception is raised inside whichever test performs the
+    write, so pytest reports that test and the traceback names the line.
+    """
+    from _tree_write_guard import TreeWriteGuard, Violation
+
+    def _fail(violation: Violation) -> None:
+        raise AssertionError(
+            f"테스트가 커밋된 레포 트리에 썼습니다: {violation}\n"
+            "실제 트리 쓰기는 워킹 트리를 더럽히고, 파일시스템 상태에 의존하는 "
+            "다른 테스트를 로컬 green / CI red 로 갈라놓습니다.\n"
+            "해당 모듈의 경로 상수를 tmp 로 리다이렉트하세요 (conftest 의 "
+            "_isolate_* fixture 패턴 참고).\n"
+            "이 경로가 정말 써도 되는 산출물이면 _tree_write_guard._EXEMPT_PARTS / "
+            "_EXEMPT_PREFIXES 에 근거와 함께 추가하세요."
+        )
+
+    with TreeWriteGuard(_fail):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_suite_isolation_guard.py
+++ b/tests/test_suite_isolation_guard.py
@@ -8,6 +8,8 @@ repo tree again.
 import os
 from pathlib import Path
 
+import pytest
+
 import common.dedup as dedup
 import common.image_generator as ig
 import common.signal_tracker as st
@@ -273,3 +275,65 @@ def test_image_rejection_atexit_baseline_off_repo_tree():
         f"the atexit restore target ({baseline}) is inside the committed "
         "_state tree; per-test isolation cannot prevent shutdown pollution."
     )
+
+
+def test_tvl_history_redirected_off_repo_tree():
+    """``_isolate_tvl_history_state`` must redirect TVL-history writes off the tree.
+
+    ``collect_defi_llama.build_post_content()`` calls ``_check_tvl_staleness()``,
+    which appends to a ``TimeSeriesStore`` bound to the module global
+    ``_TVL_HISTORY_PATH``. Because the write sits on the content-building path, a
+    test needs no collector, no network and no fixtures to trigger it — which is
+    exactly how ``test_build_post_content_contains_key_sections`` rewrote the
+    committed ``_state/defi_tvl_history.json`` on every run before the fixture
+    existed.
+
+    No static guard could see it: the path is properly ``__file__``-anchored and
+    the test imports no production root. Only the runtime write detector found
+    it, and only this redirect keeps it off the tree.
+    """
+    import collect_defi_llama as defi
+
+    active = os.path.abspath(defi._TVL_HISTORY_PATH)
+
+    assert not active.startswith(_REPO_STATE + os.sep), (
+        f"collect_defi_llama._TVL_HISTORY_PATH ({active}) points inside the "
+        "committed _state tree during tests — the _isolate_tvl_history_state "
+        "conftest fixture is not active. build_post_content() tests will "
+        "rewrite the committed TVL history."
+    )
+
+
+def test_real_tree_writes_detected():
+    """``_detect_real_tree_writes`` must have every write entry point patched.
+
+    Two layers, because either alone can pass while the guard is useless:
+
+    1. *Tripwire* — each patch point carries ``_tree_write_guard_stub``.
+       ``builtins.open`` and ``io.open`` are the same function object reached
+       through different module attributes (``Path.write_text`` calls ``io.open``,
+       ``open()`` and PIL call ``builtins.open``), so both names are asserted
+       separately; patching one and missing the other silently halves coverage.
+    2. *Behaviour* — an actual write into the committed tree must be refused.
+       A live tripwire on a detector whose path logic no longer fires would
+       still pass layer 1.
+    """
+    import builtins
+    import io
+
+    for owner, name in ((builtins, "open"), (io, "open"), (os, "open"), (os, "replace"), (os, "remove")):
+        target = getattr(owner, name)
+        assert getattr(target, "_tree_write_guard_stub", False), (
+            f"{owner.__name__}.{name} is not patched — the _detect_real_tree_writes "
+            "conftest fixture is not active. Tests can write into the committed tree undetected."
+        )
+
+    # The probe is only ever created if the detector is inert; when it is live
+    # the write is refused before the file exists, so the cleanup is a no-op.
+    probe = _REPO_ROOT / "_state" / "__tree_write_guard_probe.tmp"
+    try:
+        with pytest.raises(AssertionError, match="커밋된 레포 트리에 썼습니다"), open(probe, "w", encoding="utf-8"):
+            pass
+    finally:
+        if probe.exists():
+            probe.unlink()

--- a/tests/test_tree_write_guard.py
+++ b/tests/test_tree_write_guard.py
@@ -29,6 +29,7 @@ from _tree_write_guard import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 
@@ -36,18 +37,35 @@ class _Blocked(Exception):
     """Sentinel: the guard refused a write. Never escapes ``_collect``."""
 
 
-def _fingerprint(path: Path) -> bytes | None:
-    """Contents of ``path``, or ``None`` if absent.
+def _remove(path: Path) -> None:
+    """Delete ``path`` if present, with the installed guards lifted.
 
-    Compared before/after so the assertion is "the guard changed nothing" rather
-    than "the file does not exist". The weaker form couples the test to whatever
-    the working tree happened to contain beforehand, and would also pass if the
-    guard let a write through to an already-existing file.
+    ``Path.unlink`` goes through the patched ``os.unlink``; deleting an existing
+    file under ``_state/`` is itself a protected-tree mutation, so the session
+    guard would refuse the cleanup. Suspending is required, not cosmetic.
     """
+    with suspended():
+        path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def probe_path(request: pytest.FixtureRequest) -> Iterator[Path]:
+    """An absent path inside the protected tree, guaranteed clean either side.
+
+    The tests below deliberately aim a write at the committed tree. When the
+    detector works the write never lands — but these same tests are run by the
+    falsifiability harness with the detector *broken*, and then it does. CI
+    caught exactly that: the ``io.open`` mutation let ``Path.write_text``
+    through and left ``_state/__unit_probe_pathlib.json`` behind, failing the
+    "working tree restored" check. A test that proves writes are blocked must
+    clean up after the case where they are not.
+    """
+    target = REPO_ROOT / "_state" / f"__unit_probe_{request.node.name}.json"
+    _remove(target)
     try:
-        return path.read_bytes()
-    except OSError:
-        return None
+        yield target
+    finally:
+        _remove(target)
 
 
 class TestProtectedPathClassification:
@@ -151,20 +169,18 @@ class TestInterception:
             action()
         return found
 
-    def test_builtin_open_write_into_tree_is_caught(self) -> None:
-        target = REPO_ROOT / "_state" / "__unit_probe_builtin.json"
-        before = _fingerprint(target)
-        found = self._collect(lambda: self._swallow(lambda: open(target, "w")))  # noqa: SIM115 — the guard must refuse it
-        assert [v.path for v in found] == ["_state/__unit_probe_builtin.json"]
-        assert _fingerprint(target) == before, "the guard must refuse the write, not observe it after the fact"
+    def test_builtin_open_write_into_tree_is_caught(self, probe_path: Path) -> None:
+        relative = str(probe_path.relative_to(REPO_ROOT))
+        found = self._collect(lambda: self._swallow(lambda: open(probe_path, "w")))  # noqa: SIM115 — must be refused
+        assert [v.path for v in found] == [relative]
+        assert not probe_path.exists(), "the guard must refuse the write, not observe it after the fact"
 
-    def test_pathlib_write_text_is_caught(self) -> None:
+    def test_pathlib_write_text_is_caught(self, probe_path: Path) -> None:
         """``Path.write_text`` goes through ``io.open``, not ``builtins.open``."""
-        target = REPO_ROOT / "_state" / "__unit_probe_pathlib.json"
-        before = _fingerprint(target)
-        found = self._collect(lambda: self._swallow(lambda: target.write_text("x", encoding="utf-8")))
-        assert [v.path for v in found] == ["_state/__unit_probe_pathlib.json"]
-        assert _fingerprint(target) == before, "io.open path is unguarded — Path.write_text slipped through"
+        relative = str(probe_path.relative_to(REPO_ROOT))
+        found = self._collect(lambda: self._swallow(lambda: probe_path.write_text("x", encoding="utf-8")))
+        assert [v.path for v in found] == [relative]
+        assert not probe_path.exists(), "io.open path is unguarded — Path.write_text slipped through"
 
     def test_reads_are_not_caught(self) -> None:
         found = self._collect(lambda: self._swallow(lambda: open(REPO_ROOT / "pyproject.toml").close()))

--- a/tests/test_tree_write_guard.py
+++ b/tests/test_tree_write_guard.py
@@ -1,0 +1,222 @@
+"""Unit tests for the runtime real-tree write detector.
+
+``test_suite_isolation_guard.test_real_tree_writes_detected`` proves the
+detector is *installed*; these prove it is *correct*. A detector that classifies
+every path as safe would pass the installation check and catch nothing, so the
+path-classification rules are pinned here in both directions — what must be
+flagged, and what must be spared.
+
+The false-negative direction matters as much as the false-positive one: an
+over-eager detector that flagged tmp dirs or ``__pycache__`` would be turned off
+within a day, which is the same outcome as having no detector.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+from _tree_write_guard import (
+    REPO_ROOT,
+    TreeWriteGuard,
+    Violation,
+    _is_write_mode,
+    _relative_if_protected,
+    diff_tree,
+    suspended,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _Blocked(Exception):
+    """Sentinel: the guard refused a write. Never escapes ``_collect``."""
+
+
+def _fingerprint(path: Path) -> bytes | None:
+    """Contents of ``path``, or ``None`` if absent.
+
+    Compared before/after so the assertion is "the guard changed nothing" rather
+    than "the file does not exist". The weaker form couples the test to whatever
+    the working tree happened to contain beforehand, and would also pass if the
+    guard let a write through to an already-existing file.
+    """
+    try:
+        return path.read_bytes()
+    except OSError:
+        return None
+
+
+class TestProtectedPathClassification:
+    """``_relative_if_protected`` — the rule that decides what counts."""
+
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            "_posts/2026-08-05-x.md",
+            "_state/dedup_seen.json",
+            "assets/images/generated/x.png",
+            "_data/nav.yml",
+            "_layouts/post.html",
+            "scripts/common/dedup.py",
+            "docs/test-isolation.md",
+        ],
+    )
+    def test_committed_tree_paths_are_protected(self, relative: str) -> None:
+        assert _relative_if_protected(str(REPO_ROOT / relative)) == relative
+
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            "tests/__pycache__/test_x.cpython-313.pyc",
+            "scripts/common/__pycache__/dedup.cpython-313.pyc",
+            ".git/index",
+            ".pytest_cache/v/cache/lastfailed",
+            "node_modules/foo/index.js",
+            ".omc/state/session.json",
+            "coverage-html/index.html",
+            ".coverage",
+            ".coverage.host.12345.987654",
+            "coverage.json",
+        ],
+    )
+    def test_build_artifacts_are_exempt(self, relative: str) -> None:
+        assert _relative_if_protected(str(REPO_ROOT / relative)) is None
+
+    def test_paths_outside_the_checkout_are_ignored(self, tmp_path: Path) -> None:
+        assert _relative_if_protected(str(tmp_path / "anything.json")) is None
+        assert _relative_if_protected("/dev/null") is None
+
+    def test_accepts_path_objects_and_bytes(self) -> None:
+        target = REPO_ROOT / "_state" / "x.json"
+        assert _relative_if_protected(target) == "_state/x.json"
+        assert _relative_if_protected(os.fsencode(str(target))) == "_state/x.json"
+
+    def test_file_descriptors_are_not_paths(self) -> None:
+        """``open(fd, "w")`` passes an int — a descriptor, not a filesystem target."""
+        assert _relative_if_protected(3) is None
+
+    def test_relative_path_with_dir_fd_is_ignored(self) -> None:
+        """``dir_fd`` resolves the name against a descriptor, not cwd.
+
+        ``tempfile.TemporaryDirectory`` teardown calls
+        ``os.unlink(name, dir_fd=fd)``. Treating that bare name as cwd-relative
+        reported a correctly hermetic tmp cleanup as a write to
+        ``REPO_ROOT/<name>`` — 26 of the 29 findings in the first discovery run
+        were this one bug.
+        """
+        assert _relative_if_protected("_state", dir_fd=7) is None
+        assert _relative_if_protected("cache.json", dir_fd=7) is None
+        # An absolute path is unambiguous even when dir_fd is supplied.
+        assert _relative_if_protected(str(REPO_ROOT / "_state" / "x.json"), dir_fd=7) == "_state/x.json"
+
+
+class TestWriteModeDetection:
+    @pytest.mark.parametrize("mode", ["w", "wb", "a", "ab", "x", "r+", "rb+", "w+b"])
+    def test_write_modes_detected(self, mode: str) -> None:
+        assert _is_write_mode(mode)
+
+    @pytest.mark.parametrize("mode", ["r", "rb", "rt"])
+    def test_read_modes_ignored(self, mode: str) -> None:
+        assert not _is_write_mode(mode)
+
+
+class TestInterception:
+    """End-to-end: the patched entry points actually observe writes."""
+
+    def _collect(self, action) -> list[Violation]:
+        """Run ``action`` under a fresh guard that blocks on the first violation.
+
+        Two details this encodes:
+
+        * The session guard is *suspended*. Wrappers chain — a guard installed on
+          top of the session one records the call and then hands it to what it
+          replaced, i.e. the session guard's wrapper, which raises. Suspending
+          isolates this instance's behaviour.
+        * The callback raises rather than merely recording. A record-and-continue
+          callback lets the write through, so the "detected" assertion would pass
+          *and* leave a real file in ``_state/`` — the very pollution under test.
+          Blocking keeps these tests hermetic, which is the point.
+        """
+        found: list[Violation] = []
+
+        def block(violation: Violation) -> None:
+            found.append(violation)
+            raise _Blocked
+
+        with suspended(), TreeWriteGuard(block), contextlib.suppress(_Blocked):
+            action()
+        return found
+
+    def test_builtin_open_write_into_tree_is_caught(self) -> None:
+        target = REPO_ROOT / "_state" / "__unit_probe_builtin.json"
+        before = _fingerprint(target)
+        found = self._collect(lambda: self._swallow(lambda: open(target, "w")))  # noqa: SIM115 — the guard must refuse it
+        assert [v.path for v in found] == ["_state/__unit_probe_builtin.json"]
+        assert _fingerprint(target) == before, "the guard must refuse the write, not observe it after the fact"
+
+    def test_pathlib_write_text_is_caught(self) -> None:
+        """``Path.write_text`` goes through ``io.open``, not ``builtins.open``."""
+        target = REPO_ROOT / "_state" / "__unit_probe_pathlib.json"
+        before = _fingerprint(target)
+        found = self._collect(lambda: self._swallow(lambda: target.write_text("x", encoding="utf-8")))
+        assert [v.path for v in found] == ["_state/__unit_probe_pathlib.json"]
+        assert _fingerprint(target) == before, "io.open path is unguarded — Path.write_text slipped through"
+
+    def test_reads_are_not_caught(self) -> None:
+        found = self._collect(lambda: self._swallow(lambda: open(REPO_ROOT / "pyproject.toml").close()))
+        assert found == []
+
+    def test_tmp_writes_are_not_caught(self, tmp_path: Path) -> None:
+        def write() -> None:
+            (tmp_path / "ok.json").write_text("{}", encoding="utf-8")
+
+        assert self._collect(write) == []
+
+    def test_creating_an_existing_directory_is_not_a_change(self) -> None:
+        """``post_generator`` calls ``os.makedirs(POSTS_DIR, exist_ok=True)`` on
+        every collector test; the real ``_posts/`` already exists, so nothing
+        changes and reporting it would be pure noise."""
+        found = self._collect(lambda: os.makedirs(REPO_ROOT / "_posts", exist_ok=True))
+        assert found == []
+
+    def test_deleting_a_missing_path_is_not_a_change(self) -> None:
+        found = self._collect(lambda: self._swallow(lambda: os.remove(REPO_ROOT / "_state" / "__absent.json")))
+        assert found == []
+
+    def test_uninstall_restores_every_entry_point(self) -> None:
+        import builtins
+        import io
+
+        before = [builtins.open, io.open, os.open, os.replace, os.remove]
+        with TreeWriteGuard(lambda _v: None):
+            assert getattr(builtins.open, "_tree_write_guard_stub", False)
+            assert getattr(io.open, "_tree_write_guard_stub", False)
+        after = [builtins.open, io.open, os.open, os.replace, os.remove]
+        assert before == after, "guard did not restore the original write entry points"
+
+    @staticmethod
+    def _swallow(action) -> None:
+        """Run ``action`` ignoring OS errors — we assert on detection, not IO."""
+        try:
+            result = action()
+        except OSError:
+            return
+        close = getattr(result, "close", None)
+        if close is not None:
+            close()
+
+
+class TestSnapshotDiff:
+    """The complementary out-of-process net."""
+
+    def test_reports_added_removed_and_modified(self) -> None:
+        before = {"a": 1, "b": 2, "c": 3}
+        after = {"b": 2, "c": 99, "d": 4}
+        assert diff_tree(before, after) == ["added: d", "removed: a", "modified: c"]
+
+    def test_identical_snapshots_are_clean(self) -> None:
+        assert diff_tree({"a": 1}, {"a": 1}) == []


### PR DESCRIPTION
## 배경

정적 가드(`test_hermetic_test_writes_guard.py`)는 테스트가 **어떻게 생겼는지**를 본다 — production `REPO_ROOT` 를 import 하는 형태. 하지만 런타임에 조립된 경로, fixture 가 넘겨준 경로, production 기본 인자를 타고 나가는 쓰기는 소스 형태로 보이지 않는다. 실제 쓰기를 관찰하는 층을 추가했다.

## 스냅샷이 아니라 가로채기인 이유

원래 제안은 `assets/`/`_posts/` 전후 스냅샷이었으나, 그 설계는 **이 가드가 막으려는 사고를 원리적으로 못 잡는다.**

2026-06-30 사고는 테스트가 `REPO_ROOT/assets/images/generated/` 에 실제 파일을 쓰고 **`finally` 에서 지웠다.** 유출은 비정상 종료에서만 드러났다. 정상 종료한 실행의 전후 diff 는 비어 있다.

그래서 쓰기 진입점을 패치하고 보호 경로에 대한 첫 쓰기에서 즉시 raise 한다. 귀속도 정확해진다 — pytest 가 실패한 테스트를 지목하고 트레이스백이 문제의 줄을 가리킨다. 스냅샷은 "어딘가 뭔가 바뀌었다"까지만 말한다.

`builtins.open` 과 `io.open` 은 **같은 함수 객체지만 조회 경로가 다르다**:

```
$ python3 -c "import io,builtins; print(builtins.open is io.open)"
True
# 그러나 pathlib.Path.open() 은 io.open(self, ...) 을 호출하고,
# open(...)/PIL Image.save 는 builtins.open 을 호출한다
```

한쪽만 패치하면 쓰기의 절반이 그대로 빠져나간다. 이 대칭성은 유닛 테스트로 고정했다.

## 발굴 결과 — 실제 오염 1건

report-only 모드로 전체 스위트를 돌려 29건을 받았고, 탐지기 정제 후 **3건(= 위반 1건)** 이 남았다.

```
tests/test_collect_defi_llama.py::test_build_post_content_contains_key_sections
    open           _state/defi_tvl_history.tmp
    os.replace     _state/defi_tvl_history.json
    os.replace     _state/defi_tvl_history.tmp
```

`build_post_content()` → `_check_tvl_staleness()` → `TimeSeriesStore(_TVL_HISTORY_PATH).append()` 가 커밋된 `_state/defi_tvl_history.json` 을 매 실행 다시 썼다. 해당 테스트는 **fixture 를 하나도 받지 않는다** — 수집기도, 네트워크도, tmp_path 도 없이 트리를 오염시켰다.

모든 정적 검사를 통과하는 이유: 경로는 정상적으로 `__file__` 앵커였고(`test_module_level_state_paths_anchored_to_repo_root` green), 테스트는 production 루트를 import 하지 않는다(hermetic 가드 green). 실제 쓰기를 봐야만 보이는 부류다. `_isolate_tvl_history_state` 로 리다이렉트했다.

### 나머지 26건은 탐지기 자신의 버그였다

`tempfile.TemporaryDirectory` 정리는 `os.unlink(name, dir_fd=fd)` 를 쓴다. **`dir_fd` 가 주어지면 상대경로는 cwd 가 아니라 그 디스크립터 기준**이므로 `abspath` 가정이 깨진다. 정상 격리된 tmp 정리가 `REPO_ROOT/<name>` 쓰기로 보였다.

추가로, 이미 존재하는 디렉토리 생성과 없는 경로 삭제는 아무것도 바꾸지 않으므로 보고하지 않는다 — `post_generator` 의 `os.makedirs(POSTS_DIR, exist_ok=True)` 는 수집기 테스트마다 실제 `_posts/` 에 닿지만 트리를 건드리지 않는다. 이 노이즈를 남겨두면 진짜 쓰기가 묻힌다.

## 하네스 드리프트 체크의 갭

새 세션 fixture 를 추가했는데 레지스트리가 **침묵**해서 발견했다. `_AUTOUSE_RE` 가 `@pytest.fixture(autouse=True)` 정확 일치만 매칭해 `@pytest.fixture(scope="session", autouse=True)` 가 드리프트 검사를 통째로 빠져나갔다. kwarg 순서/개수와 무관하게 매칭하도록 고치고 `_disable_fixture` 의 치환도 맞췄다(다른 kwarg 는 보존).

## 범위와 사각 (명시)

**in-process 쓰기만** 본다. 서브프로세스(`bundle exec jekyll build`, `subprocess.run` 으로 띄운 수집기)는 자기 인터프리터로 쓰므로 보이지 않고, raw syscall 을 쓰는 C 확장도 마찬가지다. 그 경우를 위해 `snapshot_tree()`/`diff_tree()` 를 보조망으로 뒀다.

## 검증

**하네스 — 34/34 falsifiable** (29 → 34: fixture 2 + 탐지기 3)

```
$ PYTHONPATH=scripts python3 scripts/tools/guard_falsifiability.py
...
FALSIFIABLE | patched_rc=1 control_rc=0 | _isolate_tvl_history_state | test_tvl_history_redirected_off_repo_tree
FALSIFIABLE | patched_rc=1 control_rc=0 | _detect_real_tree_writes   | test_real_tree_writes_detected
FALSIFIABLE | patched_rc=1 control_rc=0 | 트리-쓰기 탐지기 무력화 (모든 경로를 안전으로 분류)
FALSIFIABLE | patched_rc=1 control_rc=0 | 트리-쓰기 탐지기: io.open 패치 누락 (Path.write_text 우회)
FALSIFIABLE | patched_rc=1 control_rc=0 | 트리-쓰기 탐지기: 쓰기 모드 판정 무력화

34/34 guards falsifiable
```

**red 의 원인이 가드 단언인지 개별 확인** (`rc != 0` 만으로는 부족 — PR #1075 에서 확립한 규약)

```
[assert] fixture off: _isolate_tvl_history_state
  E  AssertionError: collect_defi_llama._TVL_HISTORY_PATH (/.../_state/defi_tvl_history.json) points inside...
[assert] fixture off: _detect_real_tree_writes
  E  AssertionError: builtins.open is not patched — the _detect_real_tree_writes conftest fixture is not active.
[assert] 트리-쓰기 탐지기 무력화
  E  AssertionError: assert None == '_state/dedup_seen.json'
[assert] io.open 패치 누락
  E  AssertionError: assert [] == ['_state/__unit_probe_pathlib.json']
[assert] 쓰기 모드 판정 무력화
  E  AssertionError: assert False +  where False = _is_write_mode('w')
```

**기타**

```
$ PYTHONPATH=scripts python3 -m pytest tests/ -q
4985 passed, 16 skipped in 212.65s
Required test coverage of 70% reached. Total coverage: 72.63%

$ python3 -m ruff check scripts/ tests/ && python3 -m ruff format --check scripts/ tests/
All checks passed!  /  265 files already formatted

$ python3 -m basedpyright
0 errors, 0 warnings, 0 notes
```

가드를 켠 상태로 전체 스위트가 green 이고, 실행 후 `git status` 에 오염이 없다. `docs/component-counts.md` 는 테스트 파일 추가에 맞춰 재생성했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)