### PR TITLE
feat: 서브프로세스 트리 쓰기 세션 스냅샷 연결 (하네스 34 → 37)

### DIFF
--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -21,6 +21,11 @@ Part 2 (2026-08-05): 가드 자체의 **우회 경로**를 감사해 10건을 ST
 `--fail-under` 숫자는 그대로 둔 채 게이트를 무력화하는 4가지 커버리지 편집
 (측정 범위 축소 x2, `--omit`, `continue-on-error`).
 
+Part 3 (2026-08-05): 런타임 트리-쓰기 탐지기(`tests/_tree_write_guard.py`).
+in-process 가로채기 3건과 서브프로세스용 세션 스냅샷 3건. 스냅샷 층은 세션
+teardown 에서만 발현해 배선을 끊어도 스위트가 조용하므로, baseline 등록
+tripwire · 비교 로직 · 스냅샷 범위를 각각 별도 케이스로 falsify 한다.
+
 사용법:
     python scripts/tools/guard_falsifiability.py            # 표 출력
     python scripts/tools/guard_falsifiability.py --json     # JSON 출력
@@ -276,6 +281,29 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         'return any(c in mode for c in "wax+")',
         "return False",
         "tests/test_tree_write_guard.py::TestWriteModeDetection::test_write_modes_detected[w]",
+    ),
+    # 서브프로세스용 세션 스냅샷 층. 이 층은 세션 teardown 에서만 발현하므로
+    # 배선을 끊어도 스위트 어디서도 red 가 나지 않는다 — 그 침묵을 막는 케이스들.
+    StaticCase(
+        "세션 baseline 미등록 (tripwire 무력화)",
+        "tests/_tree_write_guard.py",
+        "    global _SESSION_BASELINE\n    _SESSION_BASELINE = snapshot_tree()\n    return _SESSION_BASELINE",
+        "    return snapshot_tree()",
+        "tests/test_suite_isolation_guard.py::test_real_tree_writes_detected",
+    ),
+    StaticCase(
+        "세션 스냅샷 비교 무력화 (변화를 무시)",
+        "tests/_tree_write_guard.py",
+        "    changes = diff_tree(baseline, snapshot_tree())\n    if not changes:\n        return",
+        "    changes = diff_tree(baseline, snapshot_tree())\n    if changes or not changes:\n        return",
+        "tests/test_tree_write_guard.py::TestOutOfProcessNet::test_added_file_is_reported",
+    ),
+    StaticCase(
+        "세션 스냅샷 범위 붕괴 (빈 스냅샷)",
+        "tests/_tree_write_guard.py",
+        '_SNAPSHOT_DIRS: tuple[str, ...] = ("_posts", "_state", "assets/images/generated")',
+        "_SNAPSHOT_DIRS: tuple[str, ...] = ()",
+        "tests/test_tree_write_guard.py::TestOutOfProcessNet::test_snapshot_covers_the_content_dirs",
     ),
 )
 

--- a/tests/_tree_write_guard.py
+++ b/tests/_tree_write_guard.py
@@ -308,3 +308,45 @@ def diff_tree(before: dict[str, int], after: dict[str, int]) -> list[str]:
     changes += [f"removed: {p}" for p in sorted(set(before) - set(after))]
     changes += [f"modified: {p}" for p in sorted(set(before) & set(after)) if before[p] != after[p]]
     return changes
+
+
+# Baseline captured once per session. Exposed so a guard test can confirm the
+# snapshot half of ``_detect_real_tree_writes`` actually ran — the interceptor
+# tripwires say nothing about it, and an unwired snapshot is a silent no-op.
+_SESSION_BASELINE: dict[str, int] | None = None
+
+
+def capture_session_baseline() -> dict[str, int]:
+    """Snapshot the content dirs and record it as this session's baseline."""
+    global _SESSION_BASELINE
+    _SESSION_BASELINE = snapshot_tree()
+    return _SESSION_BASELINE
+
+
+def session_baseline() -> dict[str, int] | None:
+    """This session's baseline, or ``None`` if it was never captured."""
+    return _SESSION_BASELINE
+
+
+def assert_no_out_of_process_writes(baseline: dict[str, int]) -> None:
+    """Raise if the content dirs changed since ``baseline`` was taken.
+
+    The net for writes the interceptor structurally cannot see: a subprocess
+    writes through its own interpreter, where our patches do not exist.
+
+    Attribution is coarse by nature — this compares the whole session against
+    its start, so it names the files but not the test. The message says as much
+    rather than implying precision it does not have.
+    """
+    changes = diff_tree(baseline, snapshot_tree())
+    if not changes:
+        return
+    raise AssertionError(
+        "테스트 세션이 커밋된 트리를 변경했습니다 (in-process 가로채기가 놓친 쓰기 — "
+        "서브프로세스나 raw syscall 경로):\n"
+        + "\n".join(f"  - {c}" for c in changes)
+        + "\n\n세션 단위 비교이므로 어느 테스트인지는 알 수 없습니다. "
+        "subprocess 를 쓰는 테스트부터 좁히세요 (대상 경로를 tmp 로 넘기거나 "
+        "자식 프로세스 환경에서 경로 상수를 리다이렉트).\n"
+        "이 변경이 정말 의도된 산출물이면 _SNAPSHOT_DIRS / _EXEMPT_PARTS 를 근거와 함께 갱신하세요."
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -381,8 +381,28 @@ def _detect_real_tree_writes():
     Session-scoped so the patch cost is paid once, not 4900 times. Attribution
     is unaffected: the exception is raised inside whichever test performs the
     write, so pytest reports that test and the traceback names the line.
+
+    Two layers, because the first one structurally cannot see everything:
+
+    1. *Interception* — patches the write entry points; blocks the write, names
+       the test and the line. In-process only.
+    2. *Session snapshot* — compares the content dirs against a baseline taken
+       at session start. Catches what a subprocess or a raw-syscall C extension
+       wrote, which layer 1 has no way to observe. Coarse attribution (the
+       session, not the test) and ~165ms per walk × 2, so it is session-scoped
+       only — per-test would add ~14 minutes to the suite.
+
+    Remaining blind spot, stated: writes during interpreter shutdown land after
+    this teardown. That vector is the ``atexit`` flush in
+    ``image_rejection_metrics``, handled by the module-level redirect at the top
+    of this file (and covered by its own harness case).
     """
-    from _tree_write_guard import TreeWriteGuard, Violation
+    from _tree_write_guard import (
+        TreeWriteGuard,
+        Violation,
+        assert_no_out_of_process_writes,
+        capture_session_baseline,
+    )
 
     def _fail(violation: Violation) -> None:
         raise AssertionError(
@@ -395,8 +415,10 @@ def _detect_real_tree_writes():
             "_EXEMPT_PREFIXES 에 근거와 함께 추가하세요."
         )
 
+    baseline = capture_session_baseline()
     with TreeWriteGuard(_fail):
         yield
+    assert_no_out_of_process_writes(baseline)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_suite_isolation_guard.py
+++ b/tests/test_suite_isolation_guard.py
@@ -307,7 +307,7 @@ def test_tvl_history_redirected_off_repo_tree():
 def test_real_tree_writes_detected():
     """``_detect_real_tree_writes`` must have every write entry point patched.
 
-    Two layers, because either alone can pass while the guard is useless:
+    Three layers, because any one alone can pass while the guard is useless:
 
     1. *Tripwire* — each patch point carries ``_tree_write_guard_stub``.
        ``builtins.open`` and ``io.open`` are the same function object reached
@@ -317,9 +317,15 @@ def test_real_tree_writes_detected():
     2. *Behaviour* — an actual write into the committed tree must be refused.
        A live tripwire on a detector whose path logic no longer fires would
        still pass layer 1.
+    3. *Session baseline* — the out-of-process snapshot half must have run. It
+       only manifests at session teardown, so nothing else in the suite would
+       notice if the capture were dropped; an unwired snapshot is a silent
+       no-op that reads as coverage.
     """
     import builtins
     import io
+
+    from _tree_write_guard import session_baseline
 
     for owner, name in ((builtins, "open"), (io, "open"), (os, "open"), (os, "replace"), (os, "remove")):
         target = getattr(owner, name)
@@ -337,3 +343,15 @@ def test_real_tree_writes_detected():
     finally:
         if probe.exists():
             probe.unlink()
+
+    baseline = session_baseline()
+    assert baseline is not None, (
+        "no session baseline was captured — the out-of-process snapshot half of "
+        "_detect_real_tree_writes is not wired in. Subprocess writes into the "
+        "committed tree would go unnoticed."
+    )
+    assert len(baseline) > 100, (
+        f"session baseline holds only {len(baseline)} files; the snapshot walk is "
+        "broken (wrong dirs, or every path filtered out) and the comparison at "
+        "teardown would be vacuous."
+    )

--- a/tests/test_tree_write_guard.py
+++ b/tests/test_tree_write_guard.py
@@ -15,22 +15,25 @@ from __future__ import annotations
 
 import contextlib
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from _tree_write_guard import (
+    _EXEMPT_PARTS,
     REPO_ROOT,
     TreeWriteGuard,
     Violation,
     _is_write_mode,
     _relative_if_protected,
+    assert_no_out_of_process_writes,
     diff_tree,
+    snapshot_tree,
     suspended,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
 
 class _Blocked(Exception):
@@ -236,3 +239,52 @@ class TestSnapshotDiff:
 
     def test_identical_snapshots_are_clean(self) -> None:
         assert diff_tree({"a": 1}, {"a": 1}) == []
+
+
+class TestOutOfProcessNet:
+    """The session-snapshot layer: what the interceptor structurally cannot see."""
+
+    def test_snapshot_covers_the_content_dirs(self) -> None:
+        snapshot = snapshot_tree()
+        assert len(snapshot) > 100, f"snapshot walked only {len(snapshot)} files — wrong dirs?"
+        assert all(not _EXEMPT_PARTS.intersection(Path(p).parts) for p in snapshot), (
+            "snapshot includes exempt build artifacts; churn there would fail the suite spuriously"
+        )
+        prefixes = {p.split("/", 1)[0] for p in snapshot}
+        assert prefixes <= {"_posts", "_state", "assets"}, f"snapshot reached outside the content dirs: {prefixes}"
+
+    def test_unchanged_tree_passes(self) -> None:
+        assert_no_out_of_process_writes(snapshot_tree())
+
+    def test_added_file_is_reported(self) -> None:
+        """Simulated by dropping an entry from the baseline — no write needed.
+
+        Removing a known file from ``before`` makes the *real* tree look like it
+        gained that file, which is exactly the subprocess-write signature.
+        """
+        baseline = snapshot_tree()
+        victim = next(iter(sorted(baseline)))
+        del baseline[victim]
+
+        with pytest.raises(AssertionError, match="in-process 가로채기가 놓친 쓰기") as excinfo:
+            assert_no_out_of_process_writes(baseline)
+        assert f"added: {victim}" in str(excinfo.value)
+
+    def test_removed_and_modified_files_are_reported(self) -> None:
+        baseline = snapshot_tree()
+        real = next(iter(sorted(baseline)))
+        baseline["_state/__never_existed.json"] = 1  # looks removed
+        baseline[real] = baseline[real] + 12345  # looks modified
+
+        with pytest.raises(AssertionError) as excinfo:
+            assert_no_out_of_process_writes(baseline)
+        message = str(excinfo.value)
+        assert "removed: _state/__never_existed.json" in message
+        assert f"modified: {real}" in message
+
+    def test_message_admits_coarse_attribution(self) -> None:
+        """The failure must not imply it knows which test did it — it does not."""
+        baseline = snapshot_tree()
+        del baseline[next(iter(sorted(baseline)))]
+        with pytest.raises(AssertionError, match="어느 테스트인지는 알 수 없습니다"):
+            assert_no_out_of_process_writes(baseline)


### PR DESCRIPTION
## 배경

PR #1076 의 탐지기는 **in-process 쓰기만** 본다 — 서브프로세스는 자기 인터프리터로 쓰므로 우리 패치가 존재하지 않는다. 그 PR 에서 사각으로 명시하고 `snapshot_tree()`/`diff_tree()` 를 만들어 뒀지만 **어디에도 연결하지 않았다.** 이번에 세션 fixture 에 실제로 배선했다.

## 측정 → 세션 단위로 결정

| 단위 | 비용 | 판정 |
|---|---|---|
| 세션 (2회 walk) | 15751 파일 × 165ms × 2 ≈ **330ms** (3분 스위트의 0.2%) | 채택 |
| per-test | 4991 × 165ms ≈ **14분** | 불가 |

세션 단위이므로 귀속이 거칠다(세션 전체 대비, 테스트 지목 불가). 실패 메시지에 그 한계를 명시해 있지도 않은 정밀도를 암시하지 않는다:

```
테스트 세션이 커밋된 트리를 변경했습니다 (in-process 가로채기가 놓친 쓰기 — 서브프로세스나 raw syscall 경로):
  - added: _state/foo.json

세션 단위 비교이므로 어느 테스트인지는 알 수 없습니다. subprocess 를 쓰는 테스트부터 좁히세요 ...
```

## 현재 서브프로세스 쓰기는 0건 (실측)

배선 전에 스냅샷 → 전체 스위트 → 스냅샷으로 직접 확인했다:

```
$ (before 스냅샷 저장) && pytest tests/ -q && (diff)
4986 passed, 16 skipped in 182.18s
=== 세션 전후 트리 변화 ===
(변화 없음)
```

즉 이 층은 **발굴이 아니라 회귀 방지망**으로 붙는다. 테스트 6개 파일이 `subprocess` 를 쓰지만 현재는 트리에 쓰지 않는다.

## 층별 falsifiability — 조용한 no-op 을 막는 게 핵심

이 층은 세션 teardown 에서만 발현한다. 배선을 끊으면 **스위트 어디서도 red 가 나지 않는다** — 커버리지처럼 보이는 침묵. 세 갈래로 falsify 했다:

| 층 | 어떻게 falsify 되나 | 하네스 케이스 |
|---|---|---|
| baseline 등록 | `session_baseline()` tripwire (`_tree_write_guard_stub` 패턴과 동일) | 세션 baseline 미등록 |
| 비교 로직 | `assert_no_out_of_process_writes()` 로 추출해 단위 테스트가 직접 구동 | 세션 스냅샷 비교 무력화 |
| 스냅샷 범위 | 파일 수 / 경로 프리픽스 단언 | 세션 스냅샷 범위 붕괴 (빈 스냅샷) |

**added 케이스는 트리에 쓰지 않고 검증한다.** baseline 에서 기존 항목 하나를 빼면 실제 트리가 그 파일을 얻은 것처럼 보이고, 그게 정확히 서브프로세스 쓰기의 서명이다. 가드를 시험하려고 가드가 막는 일을 할 필요가 없다.

`test_real_tree_writes_detected` 는 이제 3층 단언이다 (tripwire → 실제 쓰기 거부 → baseline 포착).

## 남은 사각 (명시)

**인터프리터 종료 중 쓰기는 이 teardown 이후에 착지한다.** 그 벡터는 `image_rejection_metrics` 의 `atexit` flush 이며, conftest 모듈 레벨 리다이렉트가 담당한다 (자체 하네스 케이스 `module-level:image_rejection_metrics` 보유). 이 층으로 덮지 않았고, 덮은 척하지도 않았다.

## 검증

**하네스 — 37/37 falsifiable** (34 → 37)

```
$ PYTHONPATH=scripts python3 scripts/tools/guard_falsifiability.py
...
FALSIFIABLE | patched_rc=1 control_rc=0 | 세션 baseline 미등록 (tripwire 무력화)
FALSIFIABLE | patched_rc=1 control_rc=0 | 세션 스냅샷 비교 무력화 (변화를 무시)
FALSIFIABLE | patched_rc=1 control_rc=0 | 세션 스냅샷 범위 붕괴 (빈 스냅샷)

37/37 guards falsifiable
```

**red 의 원인 개별 확인** (`rc != 0` 만으로는 부족 — PR #1075 규약)

```
[assert] 세션 baseline 미등록
  E  AssertionError: no session baseline was captured — the out-of-process snapshot half ... is not wired in
[assert] 세션 스냅샷 비교 무력화
  E  Failed: DID NOT RAISE <class 'AssertionError'>
[assert] 세션 스냅샷 범위 붕괴
  E  AssertionError: snapshot walked only 0 files — wrong dirs?
```

**기타**

```
$ PYTHONPATH=scripts python3 -m pytest tests/ -q
4991 passed, 16 skipped in 193.95s
Required test coverage of 70% reached. Total coverage: 72.63%

$ python3 -m ruff check scripts/ tests/ && python3 -m ruff format --check scripts/ tests/
All checks passed!  /  265 files already formatted

$ python3 -m basedpyright
0 errors, 0 warnings, 0 notes
```

세션 teardown 의 스냅샷 비교가 통과한 상태로 전체 스위트 green 이고, 하네스 실행 후 신규 트리 오염이 없다. `component_counts` 드리프트 없음 (새 테스트 *파일* 은 추가하지 않고 기존 파일에 덧붙였다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)