### PR TITLE
feat: 공급망/시크릿 가드군 3종 + 하네스 편입 (37 → 47)

### DIFF
--- a/.github/workflows/guard-falsifiability.yml
+++ b/.github/workflows/guard-falsifiability.yml
@@ -17,6 +17,13 @@ on:
       - 'tests/test_coverage_floor_guard.py'
       - 'pyproject.toml'
       - '.github/workflows/code-quality.yml'
+      # 공급망/시크릿 가드 — 가드 본체와 감시 대상 설정 양쪽
+      - 'tests/test_workflow_action_pinning_guard.py'
+      - 'tests/test_secret_scan_gate_guard.py'
+      - 'tests/test_workflow_permission_gate_guard.py'
+      - '.gitleaks.toml'
+      - '.github/workflows/security-scan.yml'
+      - '.github/workflows/lighthouse-ci.yml'
       # 하네스 자신
       - 'scripts/tools/guard_falsifiability.py'
       - '.github/workflows/guard-falsifiability.yml'
@@ -36,9 +43,9 @@ concurrency:
 jobs:
   falsifiability:
     runs-on: ubuntu-latest
-    # 케이스당 pytest 를 2회(patched/control) 띄우므로 8종 = 16회 프로세스 기동.
+    # 케이스당 pytest 를 2회(patched/control) 띄우므로 47종 = 94회 프로세스 기동.
     # 가드 테스트 자체는 각 1초 미만이고 대부분이 인터프리터 시작 비용이다.
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 49 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 126 |
+| 테스트 파일 (tests/test_*.py) | 129 |
 
 <!-- component-counts:end -->

--- a/docs/devsecops/ci-regression-guards.md
+++ b/docs/devsecops/ci-regression-guards.md
@@ -22,8 +22,18 @@ System Configuration), NIST SSDF(SP 800-218) **PO.3 / PW.4**.
 | `tests/test_generated_image_guard.py` | 2 | 레이아웃이 렌더하는 생성 이미지가 404 나지 않음(존재 보장) | 30일 이미지 정리가 참조 살아있는 og/hero 이미지를 삭제 → 깨진 이미지 |
 | `tests/test_encoding_guard.py` | 16 | `encoding_guard` 모듈의 UTF-8/CP949 라벨 교정 동작 불변 | 한국어 텍스트 인코딩 깨짐(mojibake) |
 | `tests/test_requirements_lock_coverage.py` | 6 | `requirements.txt` 직접 의존성 전부가 `requirements.lock` 에 ==핀(부분집합) + 락의 모든 핀이 최소 1개 `--hash` 보유(presence) | 락 staleness(검증 안 되는 새 의존성) / hashless 핀이 `--require-hashes` 무결성 검증을 무력화하는 공급망 변조 창 |
+| `tests/test_workflow_action_pinning_guard.py` | 4 | `.github/workflows/**` · `.github/actions/**` 의 모든 외부 `uses:` 가 40-hex SHA 핀(presence) + 탐지기 양방향 | 가변 태그(`@v4`)/브랜치 참조 → 업스트림 변조가 diff 없이 CI 에서 실행 |
+| `tests/test_secret_scan_gate_guard.py` | 7 | Gitleaks 게이트 무결성: `useDefault=true`(presence), allowlist `targetRules`/`paths` 집합 동일(==), 게이트 차단성(no `continue-on-error`/`\|\| true`), `fetch-depth: 0`(presence) | 잡은 남아있는데 룰셋 해제·allowlist 확대·exit 흡수·히스토리 절단으로 시크릿 스캔이 조용히 무력화 |
+| `tests/test_workflow_permission_gate_guard.py` | 4 | `code-quality.yml` 이 `check_workflow_permissions.py` 를 `--workflows-dir .github/workflows` 로 차단 실행(presence) | 도구 단위 테스트는 green 인데 CI 배선만 끊겨 2026-04-23 수집기 장애 클래스가 재무방비 |
 
-총 **103 케이스**.
+총 **118 케이스**.
+
+> 공급망/시크릿 3종(2026-08-06 추가)의 배경: `security-scan.yml` 의
+> `actions-permissions` 잡은 이름과 달리 **build 를 실패시킬 수 없다** — 모든 발견이
+> `::warning::` 이고 exit 하지 않으며, 핀닝 체크의 `has_issues=true` 는
+> `grep ... | while` 파이프라인 서브셸에 갇혀 전파조차 안 된다. 게다가
+> `grep -v '@v'` 는 문제의 대상인 가변 태그를 "핀됨"으로 분류한다. 위 3개 가드는
+> 그 잡을 대체하는 게 아니라, 차단 가능한 pytest 잡에 실제 강제를 처음으로 만든다.
 
 ## 설계 규약 (신규 가드 작성 시)
 

--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -26,6 +26,14 @@ in-process 가로채기 3건과 서브프로세스용 세션 스냅샷 3건. 스
 teardown 에서만 발현해 배선을 끊어도 스위트가 조용하므로, baseline 등록
 tripwire · 비교 로직 · 스냅샷 범위를 각각 별도 케이스로 falsify 한다.
 
+Part 4 (2026-08-06): 공급망/시크릿 축 10건 — 액션 SHA 핀닝 3, Gitleaks 게이트 4,
+reusable workflow permission lint 배선 3. 감사 시점까지 이 세 축에는 falsifiable
+가드가 없었다: 핀닝은 `security-scan.yml` 의 `actions-permissions` 잡이 경고만
+내고 exit 하지 않아 구조적으로 vacuous 였고(`has_issues=true` 는 파이프라인
+서브셸에 갇혀 전파조차 안 된다), Gitleaks 는 `.gitleaks.toml` 을 어떻게 풀어도
+잡이 green 이었으며, permission lint 는 도구 단위 테스트만 있어 CI 배선이 끊겨도
+조용했다.
+
 사용법:
     python scripts/tools/guard_falsifiability.py            # 표 출력
     python scripts/tools/guard_falsifiability.py --json     # JSON 출력
@@ -304,6 +312,85 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         '_SNAPSHOT_DIRS: tuple[str, ...] = ("_posts", "_state", "assets/images/generated")',
         "_SNAPSHOT_DIRS: tuple[str, ...] = ()",
         "tests/test_tree_write_guard.py::TestOutOfProcessNet::test_snapshot_covers_the_content_dirs",
+    ),
+    # ---------------------------------------------------------------------
+    # Part 4 (2026-08-06): 공급망/시크릿 축. 액션 SHA 핀닝 · Gitleaks 게이트 ·
+    # reusable workflow permission lint 배선. 이 세 축은 감사 시점까지
+    # falsifiable 한 가드가 없었다 — 특히 액션 핀닝은 security-scan.yml 의
+    # `actions-permissions` 잡이 "감사"라는 이름으로 경고만 내고 exit 하지
+    # 않아(그리고 `has_issues=true` 가 파이프라인 서브셸에 갇혀) 무엇을 풀어도
+    # green 이었다. 아래 케이스들이 붙는 대상은 그 잡이 아니라 blocking pytest
+    # 잡에서 도는 신규 가드다.
+    # ---------------------------------------------------------------------
+    StaticCase(
+        "외부 액션 핀 해제 (SHA -> 가변 태그)",
+        ".github/workflows/lighthouse-ci.yml",
+        "treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18",
+        "treosh/lighthouse-ci-action@v12",
+        "tests/test_workflow_action_pinning_guard.py::test_all_external_actions_are_sha_pinned",
+    ),
+    StaticCase(
+        "핀닝 탐지기 완화 (가변 ref 를 핀으로 인정)",
+        "tests/test_workflow_action_pinning_guard.py",
+        '_SHA_PINNED_RE = re.compile(r"^[^@\\s]+@[0-9a-f]{40}$")',
+        '_SHA_PINNED_RE = re.compile(r"^[^@\\s]+@.+$")',
+        "tests/test_workflow_action_pinning_guard.py::test_pinning_detector_rejects_mutable_refs",
+    ),
+    StaticCase(
+        "핀닝 스캐너 붕괴 (uses: 를 하나도 못 찾음)",
+        "tests/test_workflow_action_pinning_guard.py",
+        '_USES_RE = re.compile(r"^\\s*(?:-\\s+)?uses:\\s*(?P<ref>\\S+)", re.M)',
+        '_USES_RE = re.compile(r"^\\s*(?:-\\s+)?uses-absent:\\s*(?P<ref>\\S+)", re.M)',
+        "tests/test_workflow_action_pinning_guard.py::test_external_action_reference_count_is_plausible",
+    ),
+    StaticCase(
+        "Gitleaks 기본 룰셋 해제 (useDefault=false)",
+        ".gitleaks.toml",
+        "useDefault = true",
+        "useDefault = false",
+        "tests/test_secret_scan_gate_guard.py::test_gitleaks_config_extends_default_rules",
+    ),
+    StaticCase(
+        "Gitleaks allowlist 를 전체 룰로 확대 (targetRules 제거)",
+        ".gitleaks.toml",
+        'targetRules = ["linkedin-client-secret", "generic-api-key"]',
+        "targetRules = []",
+        "tests/test_secret_scan_gate_guard.py::test_gitleaks_allowlist_is_scoped_to_known_false_positives",
+    ),
+    StaticCase(
+        "Gitleaks 게이트 비차단화 (|| true)",
+        ".github/workflows/security-scan.yml",
+        "gitleaks detect --source . --config .gitleaks.toml --no-banner --verbose --redact",
+        "gitleaks detect --source . --config .gitleaks.toml --no-banner --verbose --redact || true",
+        "tests/test_secret_scan_gate_guard.py::test_gitleaks_gate_is_blocking",
+    ),
+    StaticCase(
+        "Gitleaks 히스토리 절단 (fetch-depth 0 -> 1)",
+        ".github/workflows/security-scan.yml",
+        "fetch-depth: 0",
+        "fetch-depth: 1",
+        "tests/test_secret_scan_gate_guard.py::test_gitleaks_job_checks_out_full_history",
+    ),
+    StaticCase(
+        "permission lint 스텝 제거 (도구는 그대로, 배선만 끊김)",
+        ".github/workflows/code-quality.yml",
+        "run: python3 scripts/tools/check_workflow_permissions.py --workflows-dir .github/workflows",
+        "run: 'true'",
+        "tests/test_workflow_permission_gate_guard.py::test_permission_lint_runs_in_ci",
+    ),
+    StaticCase(
+        "permission lint 대상 디렉토리 우회 (--workflows-dir)",
+        ".github/workflows/code-quality.yml",
+        "run: python3 scripts/tools/check_workflow_permissions.py --workflows-dir .github/workflows",
+        "run: python3 scripts/tools/check_workflow_permissions.py --workflows-dir tests/fixtures",
+        "tests/test_workflow_permission_gate_guard.py::test_permission_lint_scans_the_real_workflow_tree",
+    ),
+    StaticCase(
+        "permission lint 비차단화 (continue-on-error)",
+        ".github/workflows/code-quality.yml",
+        "      - name: Check reusable workflow permission coverage\n",
+        "      - name: Check reusable workflow permission coverage\n        continue-on-error: true\n",
+        "tests/test_workflow_permission_gate_guard.py::test_permission_lint_step_is_blocking",
     ),
 )
 

--- a/tests/test_secret_scan_gate_guard.py
+++ b/tests/test_secret_scan_gate_guard.py
@@ -1,0 +1,209 @@
+"""CI config regression guard: the Gitleaks secret-scan gate stays load-bearing.
+
+`security-scan.yml`'s `gitleaks` job is the repo's only blocking secret scanner.
+Unlike a coverage floor there is no number to watch — the gate is a `gitleaks
+detect` exit code, and several one-line edits leave the job in place while
+making it incapable of failing. Each is asserted separately below.
+
+## The four ways this gate dies quietly
+
+* **Config neutered** — `[extend] useDefault = false` drops the ~100 upstream
+  rules (AWS, GCP, Slack, GitHub PAT). `gitleaks detect` then reports "no leaks
+  found" on a repo full of them.
+* **Allowlist widened** — the allowlist is deliberately narrow: two
+  low-precision rules (`targetRules`) on two auto-generated public-data paths.
+  Dropping `targetRules` applies the suppression to *every* rule on those
+  paths; adding a path extends it to real source. Both keep the file looking
+  like a working config. Pinned by set equality, so any change trips here and
+  has to be re-justified.
+* **Invocation softened** — `|| true`, `--exit-code 0`, or
+  `continue-on-error: true` turn a red scan into an annotation.
+* **History truncated** — the scan is `gitleaks detect` over git history, so it
+  needs `fetch-depth: 0`. At the default depth of 1 it inspects a single commit
+  and a secret introduced earlier goes unseen.
+
+Direction: `useDefault` and `fetch-depth: 0` are presence; the allowlist sets
+are `==` (any widening *or* narrowing trips — narrowing is safe but should be a
+deliberate edit here too). If a suppression is genuinely needed, update
+`_ALLOWED_TARGET_RULES` / `_ALLOWED_PATHS` in the same commit.
+
+Config parsing only (`tomllib` + text scan; no PyYAML) per the guard conventions
+in `docs/devsecops/ci-regression-guards.md`.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "security-scan.yml"
+_GITLEAKS_CONFIG = _REPO_ROOT / ".gitleaks.toml"
+
+# The allowlist as justified in .gitleaks.toml's header comment. Both are
+# auto-generated, public-data-only files; see that file for the full rationale.
+_ALLOWED_TARGET_RULES = frozenset({"linkedin-client-secret", "generic-api-key"})
+_ALLOWED_PATHS = frozenset({r"_state/translation_cache\.json", r"_posts/.*\.md"})
+
+_JOB_START_RE = re.compile(r"^  (?P<name>[A-Za-z0-9_-]+):$", re.M)
+_STEP_START_RE = re.compile(r"^ *- name: ", re.M)
+_CONTINUE_ON_ERROR_RE = re.compile(r"continue-on-error:\s*(\S+)")
+_FETCH_DEPTH_RE = re.compile(r"fetch-depth:\s*(\S+)")
+
+# Shell escapes that swallow a non-zero exit: `|| true`, `; true`, `|| :`.
+# `\b` cannot terminate `:` (not a word character), so the trailing context is
+# spelled as an explicit lookahead — otherwise `|| :` slips through.
+_SWALLOW_RE = re.compile(r"(\|\||;)\s*(true|:)(?=\s|$)")
+
+
+def _gitleaks_job() -> str:
+    """The `gitleaks:` job block of security-scan.yml, as text.
+
+    Job-scoped rather than file-scoped on purpose: the sibling `bandit` job
+    legitimately uses `continue-on-error` (it re-raises in a later step), so a
+    whole-file scan would be permanently red.
+    """
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    starts = [(m.start(), m.group("name")) for m in _JOB_START_RE.finditer(text)]
+    bounds = [*(s for s, _ in starts[1:]), len(text)]
+    for (start, name), end in zip(starts, bounds, strict=True):
+        if name == "gitleaks":
+            return text[start:end]
+    raise AssertionError(
+        "security-scan.yml no longer defines a `gitleaks:` job — the secret-scan "
+        "gate was removed or renamed. Restore it, or update this guard if it "
+        "moved, with justification."
+    )
+
+
+def _detect_commands() -> list[str]:
+    """Lines in the gitleaks job that invoke `gitleaks detect`."""
+    return [line.strip() for line in _gitleaks_job().splitlines() if "gitleaks detect" in line]
+
+
+def test_gate_files_exist() -> None:
+    """Canary: a moved/renamed config fails loudly instead of vacuously."""
+    assert _WORKFLOW.is_file(), f"{_WORKFLOW} not found"
+    assert _GITLEAKS_CONFIG.is_file(), f"{_GITLEAKS_CONFIG} not found"
+
+
+def test_gitleaks_config_extends_default_rules() -> None:
+    """`[extend] useDefault` must stay true.
+
+    With it false the scan keeps running and keeps passing while checking
+    against an empty rule set — the quietest possible failure mode.
+    """
+    config = tomllib.loads(_GITLEAKS_CONFIG.read_text(encoding="utf-8"))
+    assert config.get("extend", {}).get("useDefault") is True, (
+        "`.gitleaks.toml` no longer sets `[extend] useDefault = true`. Without "
+        "the upstream rule set (AWS, GCP, Slack, GitHub PAT, ...) the scan "
+        "reports 'no leaks found' regardless of what is committed."
+    )
+
+
+def test_gitleaks_allowlist_is_scoped_to_known_false_positives() -> None:
+    """The allowlist must stay pinned to the two justified rules and paths.
+
+    Dropping `targetRules` silently promotes a two-rule suppression into a
+    blanket one covering every rule on those paths.
+    """
+    allowlist = tomllib.loads(_GITLEAKS_CONFIG.read_text(encoding="utf-8")).get("allowlist", {})
+
+    target_rules = set(allowlist.get("targetRules", []))
+    assert target_rules == set(_ALLOWED_TARGET_RULES), (
+        f"gitleaks allowlist targetRules changed: {sorted(target_rules)} != "
+        f"{sorted(_ALLOWED_TARGET_RULES)}. An empty/absent targetRules "
+        f"suppresses *all* rules on the allowlisted paths. If the change is "
+        f"intended, update _ALLOWED_TARGET_RULES here in the same commit."
+    )
+
+    paths = set(allowlist.get("paths", []))
+    assert paths == set(_ALLOWED_PATHS), (
+        f"gitleaks allowlist paths changed: {sorted(paths)} != "
+        f"{sorted(_ALLOWED_PATHS)}. Each added path is a directory where "
+        f"secrets stop being reported. If intended, update _ALLOWED_PATHS here "
+        f"in the same commit."
+    )
+
+
+def test_gitleaks_step_uses_the_repo_config() -> None:
+    """The scan must run against `.gitleaks.toml`.
+
+    gitleaks v8.24.2 does not auto-load the file; without `--config` the tuned
+    allowlist disappears and the job drowns in false positives (244 of them,
+    recorded in that file's header).
+    """
+    commands = _detect_commands()
+    assert commands, "the `gitleaks:` job no longer runs `gitleaks detect` — the secret-scan gate is gone."
+
+    unconfigured = [c for c in commands if "--config" not in c]
+    assert not unconfigured, "`gitleaks detect` invoked without `--config .gitleaks.toml`:\n" + "\n".join(
+        f"  - {c}" for c in unconfigured
+    )
+
+
+def test_gitleaks_gate_is_blocking() -> None:
+    """A finding must fail the job — no `continue-on-error`, no swallowed exit.
+
+    Checked at job level, at step level, and in the shell command itself:
+    any one of the three turns the gate into an annotation.
+    """
+    job = _gitleaks_job()
+
+    soft: list[str] = []
+
+    job_header = job.split("steps:", 1)[0]
+    job_match = _CONTINUE_ON_ERROR_RE.search(job_header)
+    if job_match and job_match.group(1).lower() != "false":
+        soft.append(f"job-level -> continue-on-error: {job_match.group(1)}")
+
+    starts = [m.start() for m in _STEP_START_RE.finditer(job)]
+    steps = [job[s:e] for s, e in zip(starts, [*starts[1:], len(job)], strict=True)]
+    for step in steps:
+        if "gitleaks detect" not in step:
+            continue
+        match = _CONTINUE_ON_ERROR_RE.search(step)
+        if match and match.group(1).lower() != "false":
+            soft.append(f"{step.splitlines()[0].strip()} -> continue-on-error: {match.group(1)}")
+
+    for command in _detect_commands():
+        if _SWALLOW_RE.search(command):
+            soft.append(f"exit code swallowed by shell: {command}")
+        if "--exit-code" in command and "--exit-code 0" in command:
+            soft.append(f"`--exit-code 0` makes findings non-fatal: {command}")
+
+    assert not soft, "the secret-scan gate is non-blocking (findings would not fail the job):\n" + "\n".join(
+        f"  - {s}" for s in soft
+    )
+
+
+def test_gitleaks_job_checks_out_full_history() -> None:
+    """`fetch-depth: 0` — `gitleaks detect` scans history, not the worktree.
+
+    At the runner default (depth 1) only the tip commit is present, so a secret
+    committed earlier and never touched again is invisible to the scan.
+    """
+    job = _gitleaks_job()
+    depths = _FETCH_DEPTH_RE.findall(job)
+    assert depths, (
+        "the `gitleaks:` job's checkout no longer sets `fetch-depth: 0`. "
+        "A shallow checkout limits `gitleaks detect` to the tip commit, so "
+        "secrets already in history are never reported."
+    )
+    assert "0" in depths, (
+        f"the `gitleaks:` job checks out at fetch-depth {depths} — history scan needs `fetch-depth: 0`."
+    )
+
+
+def test_swallow_detector_recognises_the_common_escapes() -> None:
+    """The shell-escape detector must not rot into a no-op.
+
+    A `_SWALLOW_RE` that stopped matching would leave
+    `test_gitleaks_gate_is_blocking` permanently green.
+    """
+    for swallowed in ("gitleaks detect --source . || true", "gitleaks detect --source .; true", "gitleaks detect || :"):
+        assert _SWALLOW_RE.search(swallowed), f"detector misses swallowed exit in {swallowed!r}"
+    assert not _SWALLOW_RE.search("gitleaks detect --source . --config .gitleaks.toml --no-banner --redact"), (
+        "detector flags a clean invocation"
+    )

--- a/tests/test_workflow_action_pinning_guard.py
+++ b/tests/test_workflow_action_pinning_guard.py
@@ -1,0 +1,131 @@
+"""CI config regression guard: every external GitHub Action stays SHA-pinned.
+
+A `uses:` reference resolved by tag (`@v4`) or branch (`@main`) is a mutable
+pointer: whoever controls the upstream repo can move it to new code that runs
+inside this repo's CI with the job's `GITHUB_TOKEN`. Pinning to a full 40-hex
+commit SHA is what makes the dependency reproducible and reviewable — Dependabot
+still bumps the SHA, but the bump lands as a reviewable diff.
+
+Every one of this repo's external references is already SHA-pinned; this guard
+locks that state in. Direction: presence — adding a SHA-pinned action stays
+green, only an unpinned (tag/branch) reference trips it.
+
+## Why a *test* and not the workflow audit
+
+`.github/workflows/security-scan.yml` has an `actions-permissions` job that
+greps for unpinned actions, but it cannot fail a build:
+
+* it never exits non-zero — every finding is an `::warning::` annotation;
+* its `has_issues=true` for the pinning check runs inside a `grep ... | while`
+  pipeline, i.e. a subshell, so the assignment cannot even escape;
+* `grep -v '@v'` treats `@v4` — a mutable tag, the exact thing at issue — as
+  pinned, and `grep -v '#'` skips any line carrying a trailing comment.
+
+So before this guard the pinning invariant had zero enforcement. Anything under
+`tests/` runs in the blocking Code Quality pytest job.
+
+Text scan only (no PyYAML, no import of workflow tooling) per the guard
+conventions in `docs/devsecops/ci-regression-guards.md`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+_ACTIONS_DIR = _REPO_ROOT / ".github" / "actions"
+
+# Canary floor: the repo had 60+ external references when this guard was
+# written. A glob that silently stops matching would otherwise pass vacuously.
+_MIN_EXTERNAL_REFS = 20
+
+# Anchored at the start of a YAML key so shell text that merely mentions
+# `uses:` (security-scan.yml greps for it) is not mistaken for a reference.
+_USES_RE = re.compile(r"^\s*(?:-\s+)?uses:\s*(?P<ref>\S+)", re.M)
+
+# `owner/repo@<40 hex>` or `owner/repo/sub/path@<40 hex>`.
+_SHA_PINNED_RE = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+
+
+def _yaml_sources() -> list[Path]:
+    """Workflow definitions plus composite action definitions."""
+    return sorted(_WORKFLOWS_DIR.glob("*.yml")) + sorted(_ACTIONS_DIR.glob("*/action.yml"))
+
+
+def _external_refs() -> list[tuple[Path, str]]:
+    """`(file, ref)` for every `uses:` that points outside this repo.
+
+    Local references (`./.github/actions/x`, `./.github/workflows/y.yml`) are
+    checked out with the calling commit, so they carry no upstream mutability.
+    """
+    refs: list[tuple[Path, str]] = []
+    for path in _yaml_sources():
+        for match in _USES_RE.finditer(path.read_text(encoding="utf-8")):
+            ref = match.group("ref").strip("'\"")
+            if ref.startswith("./"):
+                continue
+            refs.append((path, ref))
+    return refs
+
+
+def test_workflow_sources_exist() -> None:
+    """Canary: a moved/renamed workflow tree fails loudly instead of vacuously."""
+    assert _WORKFLOWS_DIR.is_dir(), f"{_WORKFLOWS_DIR} not found"
+    assert _ACTIONS_DIR.is_dir(), f"{_ACTIONS_DIR} not found"
+    assert _yaml_sources(), "no workflow or composite-action YAML found — the glob no longer matches anything."
+
+
+def test_external_action_reference_count_is_plausible() -> None:
+    """Canary: the scan must still see the bulk of the references.
+
+    Without this, a regex that stops matching turns the pinning assertion below
+    into a check over an empty list — green, and proving nothing.
+    """
+    refs = _external_refs()
+    assert len(refs) >= _MIN_EXTERNAL_REFS, (
+        f"only {len(refs)} external `uses:` references found (expected "
+        f">= {_MIN_EXTERNAL_REFS}). The scanner is likely broken rather than the "
+        f"repo having shrunk; fix the parser before trusting this guard."
+    )
+
+
+def test_all_external_actions_are_sha_pinned() -> None:
+    """Every external action must be pinned to a full 40-hex commit SHA.
+
+    Tags and branches are mutable: `@v4` today and `@v4` after an upstream
+    compromise are different code with the same name.
+    """
+    unpinned = sorted(
+        {f"{path.relative_to(_REPO_ROOT)}: {ref}" for path, ref in _external_refs() if not _SHA_PINNED_RE.match(ref)}
+    )
+    assert not unpinned, (
+        "external action(s) not pinned to a full commit SHA:\n"
+        + "\n".join(f"  - {entry}" for entry in unpinned)
+        + "\n\nPin with `uses: owner/repo@<40-hex-sha>  # vX.Y` — a tag or branch "
+        "lets upstream change what runs in CI without a diff here."
+    )
+
+
+def test_pinning_detector_rejects_mutable_refs() -> None:
+    """The detector itself must classify mutable refs as unpinned.
+
+    A `_SHA_PINNED_RE` loosened to accept `@v4` would leave the assertion above
+    permanently green. Both directions are pinned here so the detector cannot
+    rot into a no-op.
+    """
+    pinned = "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+    assert _SHA_PINNED_RE.match(pinned), "detector rejects a legitimately SHA-pinned ref"
+    assert _SHA_PINNED_RE.match("github/codeql-action/upload-sarif@" + "0" * 40), (
+        "detector rejects a SHA-pinned sub-path action"
+    )
+
+    for mutable in (
+        "actions/checkout@v6",
+        "actions/checkout@main",
+        "actions/checkout@de0fac2",  # abbreviated SHA — still ambiguous
+        "actions/checkout",  # no ref at all -> default branch
+        "actions/checkout@DE0FAC2E4500DABE0009E67214FF5F5447CE83DD",  # not lowercase hex
+    ):
+        assert not _SHA_PINNED_RE.match(mutable), f"detector accepts mutable ref {mutable!r} as pinned"

--- a/tests/test_workflow_permission_gate_guard.py
+++ b/tests/test_workflow_permission_gate_guard.py
@@ -1,0 +1,121 @@
+"""CI config regression guard: the reusable-workflow permission lint stays wired.
+
+`scripts/tools/check_workflow_permissions.py` exists because of the 2026-04-23
+collector outage: `alert-consecutive-failures.yml` required `actions: read` but
+all 13 `collect-*.yml` callers declared only `contents: write`, so every alert
+path failed silently (postmortem: `docs/postmortem-2026-04-collector-outages.md`).
+
+`tests/test_workflow_permission_lint.py` proves the *tool* detects that
+mismatch, but it exercises the tool against synthetic `tmp_path` fixtures. It
+would keep passing if CI stopped running the tool over the real workflow tree —
+and then the outage class is unprotected again with a green suite. This guard
+covers the wiring the unit tests cannot see.
+
+## The three ways the wiring dies quietly
+
+* **Step removed** — the tool still exists and its unit tests still pass; the
+  real `.github/workflows` tree is simply never scanned.
+* **Scope redirected** — `--workflows-dir` pointed at a fixture directory or an
+  empty path keeps the step green while checking nothing.
+* **Non-blocking** — `continue-on-error: true` or a `|| true` turns the lint
+  into an annotation.
+
+Direction: presence — extra permission checks stay green; only removing,
+redirecting, or softening this one trips the test.
+
+Text scan only (no PyYAML, and the checked tool is not imported so the guard
+cannot move the coverage gate) per the guard conventions in
+`docs/devsecops/ci-regression-guards.md`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "code-quality.yml"
+_LINT_TOOL = _REPO_ROOT / "scripts" / "tools" / "check_workflow_permissions.py"
+
+# The lint is only meaningful against the live workflow tree.
+_REQUIRED_SCOPE = ".github/workflows"
+
+_TOOL_NAME = "check_workflow_permissions.py"
+_STEP_START_RE = re.compile(r"^ *- name: ", re.M)
+_CONTINUE_ON_ERROR_RE = re.compile(r"continue-on-error:\s*(\S+)")
+_SWALLOW_RE = re.compile(r"(\|\||;)\s*(true|:)(?=\s|$)")
+_WORKFLOWS_DIR_ARG_RE = re.compile(r"--workflows-dir[= ]+(\S+)")
+
+
+def _lint_steps() -> list[str]:
+    """The `code-quality.yml` step blocks that invoke the permission lint."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    starts = [m.start() for m in _STEP_START_RE.finditer(text)]
+    steps = [text[s:e] for s, e in zip(starts, [*starts[1:], len(text)], strict=True)]
+    return [step for step in steps if _TOOL_NAME in step]
+
+
+def test_gate_files_exist() -> None:
+    """Canary: a moved/renamed tool or workflow fails loudly, not vacuously."""
+    assert _WORKFLOW.is_file(), f"{_WORKFLOW} not found"
+    assert _LINT_TOOL.is_file(), (
+        f"{_LINT_TOOL} not found — the reusable-workflow permission lint was "
+        f"deleted. See docs/postmortem-2026-04-collector-outages.md before "
+        f"removing this guard."
+    )
+
+
+def test_permission_lint_runs_in_ci() -> None:
+    """code-quality.yml must invoke the permission lint."""
+    assert _lint_steps(), (
+        f"code-quality.yml no longer runs `{_TOOL_NAME}`. The tool's unit tests "
+        f"still pass against tmp_path fixtures, so nothing else notices that the "
+        f"real workflow tree stopped being checked — this is exactly the 2026-04-23 "
+        f"outage class. Restore the step, or delete this guard with justification."
+    )
+
+
+def test_permission_lint_scans_the_real_workflow_tree() -> None:
+    """`--workflows-dir` must point at `.github/workflows`.
+
+    Redirected at a fixture directory the step exits 0 forever while the live
+    callers drift out of compliance.
+    """
+    scopes = [scope for step in _lint_steps() for scope in _WORKFLOWS_DIR_ARG_RE.findall(step)]
+    assert scopes, (
+        f"`{_TOOL_NAME}` is invoked without an explicit `--workflows-dir`; the "
+        f"scanned scope is implicit and can drift. Pass `--workflows-dir {_REQUIRED_SCOPE}`."
+    )
+
+    wrong = [scope for scope in scopes if scope.strip("'\"").rstrip("/") != _REQUIRED_SCOPE]
+    assert not wrong, (
+        f"the permission lint scans {wrong} instead of `{_REQUIRED_SCOPE}` — "
+        f"it passes without checking the workflows that actually run."
+    )
+
+
+def test_permission_lint_step_is_blocking() -> None:
+    """A permission mismatch must fail the job.
+
+    Checked at job level, step level, and in the shell command — any one of the
+    three downgrades the gate to an annotation.
+    """
+    soft: list[str] = []
+
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    job_header = text.split("steps:", 1)[0]
+    job_match = _CONTINUE_ON_ERROR_RE.search(job_header)
+    if job_match and job_match.group(1).lower() != "false":
+        soft.append(f"job-level -> continue-on-error: {job_match.group(1)}")
+
+    for step in _lint_steps():
+        match = _CONTINUE_ON_ERROR_RE.search(step)
+        if match and match.group(1).lower() != "false":
+            soft.append(f"{step.splitlines()[0].strip()} -> continue-on-error: {match.group(1)}")
+        for line in step.splitlines():
+            if _TOOL_NAME in line and _SWALLOW_RE.search(line):
+                soft.append(f"exit code swallowed by shell: {line.strip()}")
+
+    assert not soft, "the permission lint is non-blocking (violations would not fail the job):\n" + "\n".join(
+        f"  - {s}" for s in soft
+    )


### PR DESCRIPTION
## 배경

`workflow permissions` / `secret detection` / `action pinning` 세 축의 **우회 경로를 감사**하고, 각 축에 falsifiable 가드를 만들어 falsifiability 하네스에 편입한다.

## 감사 결과 — 3축 모두 강제가 없거나 배선만 있었다

### 1. 액션 SHA 핀닝 — 강제 0건 (구조적 vacuous)

`security-scan.yml` 의 `actions-permissions` 잡은 이름과 달리 **build 를 실패시킬 수 없다**:

- 모든 발견이 `::warning::` 이고 어떤 경로로도 `exit` 하지 않는다
- 핀닝 체크의 `has_issues=true` 는 `grep ... | while` 파이프라인 **서브셸에 갇혀** 전파조차 안 된다
- `grep -v '@v'` 가 문제의 대상인 **가변 태그(`@v4`)를 "핀됨"으로 분류**하고, `grep -v '#'` 는 트레일링 주석이 붙은 줄을 통째로 건너뛴다

레포의 외부 `uses:` 는 실측 결과 전부 40-hex SHA 핀 상태였으나, 그것을 지키는 강제는 없었다.

### 2. 시크릿 스캔 — 잡은 차단이지만 설정은 무방비

`gitleaks` 잡 자체는 blocking 이나, 아래 편집은 모두 **잡을 green 으로 둔 채** 스캔을 무력화한다:

- `[extend] useDefault = false` → 업스트림 ~100개 룰(AWS/GCP/Slack/GitHub PAT) 소실, "no leaks found"
- `targetRules = []` → 2개 저정밀 룰 억제가 **전체 룰 억제**로 승격
- allowlist `paths` 확대 → 실제 소스 디렉토리까지 억제 확산
- `|| true` / `continue-on-error` → red 가 annotation 으로
- `fetch-depth: 0 → 1` → history 스캔이 tip 커밋 1개로 축소

### 3. reusable workflow permission lint — 배선을 지키는 게 없음

`code-quality.yml` 이 `check_workflow_permissions.py --workflows-dir .github/workflows` 를 blocking 으로 돌리지만, 그 배선 자체는 무방비다. `tests/test_workflow_permission_lint.py` 는 도구를 `tmp_path` 합성 fixture 로만 검증하므로 **스텝 제거 · `--workflows-dir` 리다이렉트 · `continue-on-error` 어느 쪽이든 스위트는 조용하다** — 2026-04-23 수집기 장애(`docs/postmortem-2026-04-collector-outages.md`) 클래스가 그대로 재무방비.

## 변경

| 파일 | 케이스 | 불변식 |
|---|---|---|
| `tests/test_workflow_action_pinning_guard.py` | 4 | 모든 외부 `uses:` 가 40-hex SHA 핀(presence) + 스캐너 카나리 + 탐지기 양방향 |
| `tests/test_secret_scan_gate_guard.py` | 7 | `useDefault=true`(presence), allowlist `targetRules`/`paths` 집합 동일(==), 게이트 차단성, `fetch-depth: 0` |
| `tests/test_workflow_permission_gate_guard.py` | 4 | lint 스텝 존재 · 실제 워크플로우 트리 스캔 · 차단성 |

- `scripts/tools/guard_falsifiability.py`: STATIC_CASES +10 (Part 4)
- `.github/workflows/guard-falsifiability.yml`: 신규 감시 대상 6개를 `paths` 에 추가, `timeout-minutes` 15 → 20
- `docs/devsecops/ci-regression-guards.md`: 카탈로그 3행 추가 (103 → 118 케이스)

## 검증

```
$ python3 scripts/tools/guard_falsifiability.py
47/47 guards falsifiable          # 1m54s (로컬)

$ python3 -m pytest tests/ -q -p no:randomly
5006 passed, 16 skipped in 199.69s
Required test coverage of 70% reached. Total coverage: 72.63%

$ python3 -m ruff check scripts/ tests/     # All checks passed!
$ python3 -m ruff format --check scripts/ tests/   # 268 files already formatted
$ python3 -m basedpyright <신규 4파일>       # 0 errors, 0 warnings, 0 notes
```

**허위 FALSIFIABLE 배제**: `rc != 0` 만으로는 import 에러발 오탐을 구분할 수 없으므로, 신규 10건 각각에 mutation 을 주입해 실패 메시지를 개별 확인했다 — 10건 전부 **자기 가드의 `AssertionError`** 로 실패 (collection/import 에러 0건).

## 범위 밖으로 남긴 것

깨진 `actions-permissions` 잡 자체는 **고치지 않았다**. 신규 핀닝 가드가 그 불변식을 blocking 으로 대체했지만 잡은 여전히 "감사"라는 이름으로 남아 잘못된 안심을 준다 — 별도 PR 로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)