### PR TITLE
fix: 본문 URL 요약에 새는 사이트 보일러플레이트 탐지 (적중 15.9% → 56.8%)

### DIFF
--- a/scripts/common/summary_quality.py
+++ b/scripts/common/summary_quality.py
@@ -166,7 +166,71 @@ _SITE_BOILERPLATE_PATTERNS = [
     ),
     re.compile(r"(?:에 참여하세요|구독하세요|가입하세요)$", re.I),
     re.compile(r"\d+년 (?:넘게|이상) .{0,40}(?:제공|서비스)", re.I),
+    # ------------------------------------------------------------------
+    # Body-level leakage (2026-08-06 corpus audit).
+    #
+    # The classes below were found in per-article ``news-desc`` blurbs, not in
+    # post front matter — the quality report only measured the latter, so they
+    # went unnoticed while ~790 card summaries carried site chrome instead of
+    # article content. Each pattern is anchored or keyed to a phrase that only
+    # occurs in site furniture, because the same words appear in legitimate
+    # reporting (an exchange outage, a P2P lending round, a real "분석 및 의견"
+    # piece) and those must survive.
+    # ------------------------------------------------------------------
+    # "What is Bitcoin/Ethereum" explainer copy from a sidebar or footer.
+    re.compile(
+        r"P2P 네트워크에서 실행|분산형 컴퓨팅 플랫폼입니다|중개자 없이 다른 사람에게 직접 가치",
+        re.I,
+    ),
+    # Market-data error / staleness notice. Anchored at the start: an article
+    # *about* an outage mentions the same phrase mid-sentence.
+    re.compile(r"^일시적인 문제가 발생했습니다|시장 데이터는 현재 지연", re.I),
+    # Newsletter solicitation ("want to know what happened today? here is …").
+    re.compile(r"알고 싶으십니까\?|일일 동향 및 이벤트에 대한 요약", re.I),
+    # Publisher / terminal taglines, tail-anchored so factual prose that merely
+    # contains the words is unaffected.
+    re.compile(r"뉴스, 분석 및 의견\s*$", re.I),
+    re.compile(r"거래 아이디어 및 전문가", re.I),
+    # ------------------------------------------------------------------
+    # Outlet self-introduction (second batch of the same audit). The largest
+    # remaining class once the above landed, and structurally uniform across
+    # publishers: "<outlet> is <superlative> <section list> media/platform".
+    # Keyed on the self-referential copula rather than on outlet names, so new
+    # sources are covered without a list to maintain.
+    # ------------------------------------------------------------------
+    re.compile(r"뉴스 미디어입니다|콘텐츠 플랫폼|무료로 제공하고 있습니다", re.I),
+    # "…최신 뉴스를 빠르고 정확하게 전달합니다" — the outlet describing its own
+    # delivery rather than an article.
+    re.compile(r"최신 뉴스를\s.{0,20}(?:전달|제공)합니다", re.I),
+    # Superlative self-promo. "가장 권위 있는" is paired with 뉴스/미디어 because
+    # the bare phrase also describes awards in real reporting.
+    re.compile(r"가장 권위 있는 (?:뉴스|미디어|매체)|신뢰할 수 있는 소스", re.I),
+    # Imperative site CTA at the tail — an instruction to the reader, never a
+    # description of an article.
+    re.compile(r"(?:받아보세요|만나보세요|읽어보세요|확인해\s?보세요)\s*[!.]?\s*$", re.I),
 ]
+
+# Navigation bars scraped as a description: a pipe-delimited *list* of section
+# or city names ("KCRG | 시더 래피즈, … | 뉴스, 스포츠, 날씨"). Two or more
+# separators is the discriminator — a single pipe shows up in real headlines
+# ("삼성전자 | 2026년 2분기 실적"), a list of them does not.
+_NAV_LINK_LIST_RE = re.compile(r"\s\|\s.*\s\|\s")
+
+# Outlet "we cover X, Y, Z" blurb. Neither half is decisive alone: real
+# reporting enumerates sectors, and outlet verbs appear in ordinary prose. The
+# *conjunction* is the signal — a five-plus item section list sitting next to a
+# verb the publisher uses about itself.
+#
+# Measured on the 2309-post corpus before adopting: the list alone added 74
+# cards with a real article lede among them; requiring the verb narrowed it to
+# 39 cards, every sampled one of which was genuine outlet chrome (한겨레,
+# 조선비즈, Forbes, 뉴스핌, Business Insider, Quartz …).
+_SECTION_LIST_RE = re.compile(
+    r"(?:[가-힣A-Za-z][가-힣A-Za-z ]{1,8},\s*){4,}[가-힣A-Za-z][가-힣A-Za-z ]{1,8}\s*(?:등|및|,)"
+)
+_OUTLET_VERB_RE = re.compile(
+    r"제공합니다|제공하고|다룹니다|알려드립니다|살펴보세요|알아보세요|경험해|중점을 두|안내자입니다|미디어(?:입니다|로,| 회사)"
+)
 
 # Known site boilerplate phrases (case-insensitive substring match)
 _SITE_BOILERPLATE_PHRASES = [
@@ -226,7 +290,17 @@ def _is_site_boilerplate(desc: str) -> bool:
             logger.debug("Boilerplate pattern matched: %r", desc[:80])
             return True
 
-    # 3. Very short descriptions without any article-specific tokens
+    # 3. Pipe-delimited navigation list
+    if _NAV_LINK_LIST_RE.search(desc):
+        logger.debug("Navigation link list matched: %r", desc[:80])
+        return True
+
+    # 4. Section list next to an outlet verb ("we cover X, Y, Z")
+    if _SECTION_LIST_RE.search(desc) and _OUTLET_VERB_RE.search(desc):
+        logger.debug("Outlet section-list blurb matched: %r", desc[:80])
+        return True
+
+    # 5. Very short descriptions without any article-specific tokens
     # Threshold kept low (35) to catch pure site taglines ("전 세계 시장에 대한 뉴스 및 분석.")
     # while preserving medium-length Korean sentences that lack numbers/acronyms.
     if len(desc) < 35 and not ARTICLE_SPECIFIC_RE.search(desc):

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -2528,6 +2528,142 @@ class TestIsSiteBoilerplate:
 
 
 # =============================================================================
+# Body-level per-URL summary leakage (2026-08-06 audit)
+# =============================================================================
+
+
+class TestBodyUrlSummaryBoilerplate:
+    """Boilerplate classes found leaking into per-article `news-desc` blurbs.
+
+    The post-level `description` front matter measured 99.3% real content while
+    the *body* card summaries carried site chrome — `check_description_quality.py`
+    only inspects front matter, so the gap stayed invisible. A corpus scan over
+    2309 posts / 4504 cards surfaced ~790 bad summaries in the classes below,
+    and all but one passed the filter as it stood, i.e. these are still being
+    produced, not just historical residue.
+
+    Counts are "distinct posts carrying that exact string" at audit time.
+    """
+
+    @pytest.mark.parametrize(
+        "desc",
+        [
+            # Asset explainer lifted from a site sidebar (59 posts)
+            "비트코인은 정부, 은행 등에 의해 통제되는 대신 P2P 네트워크에서 실행됩니다. "
+            "이를 통해 중개자 없이 다른 사람에게 직접 가치를 보낼 수 있습니다.",
+            # Asset explainer, Ethereum variant (17 posts)
+            "이더리움은 단순한 디지털 화폐가 아닙니다. 이는 분산형 컴퓨팅 플랫폼입니다. "
+            "즉, 사용자는 회사나 은행의 감독 없이 앱을 구축하고 실행할 수 있습니다.",
+            # Market-data error / staleness notice scraped as a summary (30 posts)
+            "일시적인 문제가 발생했습니다. 이 페이지의 시장 데이터는 현재 지연되었습니다.",
+            # Newsletter solicitation (21 posts)
+            "오늘 암호화폐 업계에서 무슨 일이 일어났는지 알고 싶으십니까? 다음은 비트코인 가격, "
+            "블록체인, 디파이, Web3 및 암호화폐 규제에 영향을 미치는 일일 동향 및 이벤트에 대한 요약입니다.",
+            # Publisher tagline (14 posts)
+            "시장, 경제, 정치 최신 소식에 대한 Financial Times의 뉴스, 분석 및 의견",
+            # Broker/terminal tagline (14 posts)
+            "주식 시장 시세, 비즈니스 뉴스, 금융 뉴스, 거래 아이디어 및 전문가가 제공하는 주식 조사.",
+            # Local-newsroom nav bar, pipe-delimited
+            "KCRG | 시더 래피즈, 아이오와 시티, 워털루, 더뷰크 | 뉴스, 스포츠, 날씨",
+            "콜로 | 8 뉴스 지금 | 리노, 네바다",
+        ],
+    )
+    def test_body_boilerplate_is_flagged(self, desc: str):
+        assert _is_site_boilerplate(desc) is True
+
+    @pytest.mark.parametrize(
+        "desc",
+        [
+            # An outage *is* the story — the error phrase mid-sentence is factual.
+            "바이낸스 거래소 출금에서 일시적인 문제가 발생했습니다. 약 2시간 동안 1,200건의 출금이 지연됐습니다.",
+            # P2P as article subject, not as the "what is bitcoin" explainer.
+            "P2P 대출 플랫폼 렌딧이 300억 원 규모의 시리즈B 투자를 유치했다고 밝혔습니다.",
+            # A single pipe appears in real headlines; only link *lists* are chrome.
+            "삼성전자 | 2026년 2분기 영업이익 14조 원으로 전년 대비 32% 증가했습니다.",
+            # Real analysis that happens to mention a computing platform.
+            "이더리움 재단은 2026년 3분기까지 검증자 수수료 구조를 개편한다고 발표했습니다.",
+            # Mentions "분석 및 의견" but carries specific facts.
+            "금리 인하 기대가 후퇴하며 10년물 국채 금리가 4.7%까지 올랐다는 분석 및 의견이 나왔습니다.",
+        ],
+    )
+    def test_real_article_summaries_survive(self, desc: str):
+        assert _is_site_boilerplate(desc) is False
+
+    @pytest.mark.parametrize(
+        "desc",
+        [
+            # Outlet self-introduction — the largest remaining class after the
+            # first pattern batch. Structurally identical across publishers:
+            # "<outlet> is <superlative> <category list> media/platform".
+            "토큰포스트는 대한민국 No.1 블록체인·암호화폐 뉴스 미디어입니다. 비트코인, 이더리움, "
+            "솔라나, XRP, 리플, 밈코인, 스테이블코인, NFT, 디파이 등 최신 트렌드를 전합니다.",
+            "인베스팅닷컴(Investing.com)은 실시간 시세, 포트폴리오, 챠트, 최신 금융 뉴스, "
+            "실시간 주식시장 데이터를 무료로 제공하고 있습니다.",
+            "소셜 뉴스 미디어 위키트리 - 경제, 사회, 정치, 엔터테인먼트, 스포츠 등 최신 뉴스를 "
+            "빠르고 정확하게 전달합니다.",
+            "The Globe and Mail은 국내 및 국제 뉴스를 포함하여 캐나다에서 가장 권위 있는 뉴스를 제공합니다.",
+            "성공 투자를 위한 신뢰할 수 있는 소스 | 2008년부터 리소스, 기술, 생명 과학 및 대마초 "
+            "분야의 뉴스, 교육 및 전문가 추천에 중점을 두었습니다.",
+            # Site CTA in the imperative — a call to action, never a summary.
+            "국민은행의 금융 콘텐츠 플랫폼 KB Think. 저축, 투자, 대출, 라이프, 부동산, 세금, 보험, "
+            "연금, 사업자 콘텐츠를 KB의 생각에서 만나보세요!",
+            "다음 재정적 단계는 무엇입니까? 모기지, 대출, 보험, 투자 등에 관해 현명한 결정을 "
+            "내리는 데 도움이 되는 전문가의 조언, 최신 뉴스 및 무료 도구를 받아보세요.",
+        ],
+    )
+    def test_outlet_self_introduction_is_flagged(self, desc: str):
+        assert _is_site_boilerplate(desc) is True
+
+    @pytest.mark.parametrize(
+        "desc",
+        [
+            # "가장 권위 있는" about an award, not about a newsroom.
+            "이 회사는 업계에서 가장 권위 있는 디자인상을 수상하며 3년 연속 1위를 기록했습니다.",
+            # An outlet named as the *subject of the news*, not self-promoting.
+            "토큰포스트가 보도한 바에 따르면 국내 거래소 원화 거래량이 전월 대비 18% 줄었습니다.",
+            # Repo-generated synthetic summaries are a separate (lesser) concern —
+            # fact-based and intentional, they must not be swept up here.
+            "시장 반등 움직임이 포착되었습니다. 기술적 반등인지 추세 전환인지 거래량과 수급 확인이 필요합니다.",
+            "반도체 산업 관련 주요 소식입니다. 한국 증시에서 반도체는 시가총액 비중이 가장 높은 핵심 섹터입니다.",
+        ],
+    )
+    def test_second_batch_does_not_overreach(self, desc: str):
+        assert _is_site_boilerplate(desc) is False
+
+    @pytest.mark.parametrize(
+        "desc",
+        [
+            "한겨레는 신뢰, 공정을 바탕으로 최신 뉴스와 심층 보도, 칼럼 등을 제공합니다. "
+            "정치, 사회, 경제, 문화, 젠더, 기후변화 등 각 분야의 폭 넓은 인사이트를 경험해보세요.",
+            "Business Insider는 글로벌 기술, 금융, 주식 시장, 미디어, 경제, 라이프스타일, 부동산, "
+            "AI 및 여러분이 알고 싶은 이야기를 알려드립니다.",
+            "뉴스핌은 종합 민영 뉴스통신사로 정치, 경제, 사회, 글로벌, 증권.금융, 산업, 부동산, 전국, "
+            "라이프, 문화, 스포츠 등 기사 제공하고 있습니다.",
+            "Quartz는 새로운 세계 경제에 대한 안내자입니다. 우리는 비즈니스, 금융, 경제, 기술, "
+            "라이프스타일 및 리더십을 다룹니다.",
+        ],
+    )
+    def test_outlet_section_list_blurb_is_flagged(self, desc: str):
+        """ "We cover X, Y, Z" chrome — needs both halves of the conjunction."""
+        assert _is_site_boilerplate(desc) is True
+
+    @pytest.mark.parametrize(
+        "desc",
+        [
+            # A section list with no outlet verb: real reporting enumerating movers.
+            "삼성전자, SK하이닉스, LG에너지솔루션, 현대차, 기아 등 시가총액 상위 5개 종목이 일제히 3% 넘게 올랐습니다.",
+            # An outlet verb with no section list: ordinary prose. Kept well over
+            # the 35-char short-generic threshold so this case isolates the
+            # conjunction rather than tripping the pre-existing length rule.
+            "금융감독원은 이번 주 중으로 검사 결과와 후속 제재 방침을 담은 보고서를 국회 정무위원회에 제공합니다.",
+        ],
+    )
+    def test_section_list_needs_both_halves(self, desc: str):
+        """Either half alone must stay green — the conjunction is the signal."""
+        assert _is_site_boilerplate(desc) is False
+
+
+# =============================================================================
 # _is_desc_duplicate_of_title
 # =============================================================================
 


### PR DESCRIPTION
## 배경

포스트 front matter 의 `description` 은 전 코퍼스 기준 **99.3% 실제 콘텐츠**로 이미 목표(90%)를 넘어섰다. 그런데 정작 본문의 per-article `news-desc` 블러브에는 사이트 크롬이 그대로 실려 있었다 — `check_description_quality.py` 가 front matter 만 측정하기 때문에 이 층은 지표에 **전혀 잡히지 않았다**.

예 (`_posts/2026-08-05-daily-crypto-news-digest.md`):

> 제목: "2026년 8월 4일 비트코인의 현재 가격 - Fortune"
> 요약: "이 백만장자 투자자가 수십억 달러 규모의 아이디어를 발견한 방법 | 텀 시트 2026년 6월 24일 …"

기사 요약이 아니라 Fortune 사이드바의 뉴스레터 링크 목록이다.

## 실측 (2309개 포스트 / 4504개 카드 전수 스캔)

| 불량 클래스 | 규모 |
|---|---|
| 사이트 소개문·에러문구가 기사 요약 자리에 반복 | **725 카드** (고유 123종) |
| 사이트 내비/링크목록 스크랩 | 32 카드 |
| 애그리게이터 헤드라인 연결 (`p0-desc`) | 43건 |

관측 샘플 6종 중 **5종이 현재 필터를 통과** — 과거 데이터만의 잔재가 아니라 지금도 재발 중인 활성 버그다.

## 변경 — `summary_quality._is_site_boilerplate` 탐지기 추가

- 자산 explainer (`"비트코인은 … P2P 네트워크에서 실행됩니다"`, `"분산형 컴퓨팅 플랫폼입니다"`)
- 시장 데이터 에러/지연 안내 — **문두 앵커**. 장애 자체가 기사인 경우(`"바이낸스 출금에서 일시적인 문제가 발생했습니다"`)는 통과해야 하므로 substring 이 아니라 `^` 로 묶었다
- 뉴스레터 권유, 매체 태그라인, 매체 자기소개 copula, 명령형 CTA 종결
- 파이프 구분 내비 목록 — 구분자 **2개 이상**. 실제 헤드라인의 단일 파이프(`"삼성전자 | 2026년 2분기 실적"`)는 통과
- **"섹션 나열 + 매체 동사" 결합 조건**

### 결합 조건을 채택 전에 실측한 이유

어느 쪽도 단독으로는 신호가 아니다. 실제 기사도 섹터를 나열하고, 매체 동사는 평범한 산문에도 나온다. 코퍼스로 재보니:

- 나열 조건만: **74 카드** 적중, 그 안에 진짜 기사 리드가 섞임
- 나열 AND 매체 동사: **39 카드**로 좁혀지고 표본 전부가 실제 매체 크롬 (한겨레·조선비즈·Forbes·뉴스핌·Business Insider·Quartz)

## 효과 (동일 코퍼스, before 는 `git show HEAD:` 버전으로 실측)

| | 카드 적중 | 반복 filler 적중 |
|---|---|---|
| before | 430 / 4504 (9.5%) | 115 / 725 (15.9%) |
| **after** | **758 / 4504 (16.8%)** | **412 / 725 (56.8%)** |

## 오탐 방지

"막혀선 안 되는" 케이스를 함께 고정했다 — 거래소 장애 기사, P2P 대출 투자 유치, 단일 파이프 헤드라인, 시총 상위 종목 나열, 매체 동사만 있는 평범한 문장, 그리고 레포가 **의도적으로** 생성하는 팩트 기반 합성 요약(`"시장 반등 움직임이 포착되었습니다…"`)까지.

작성 중 테스트 케이스 하나가 신규 조건이 아니라 기존 "35자 미만 generic" 규칙에 걸리는 걸 발견해 조건이 격리되도록 수정했다 — 통과했더라도 신규 코드를 검증하지 못하는 케이스였다.

## 검증

```
$ python3 -m pytest tests/ -q -p no:randomly
5021 passed, 16 skipped in 195.47s
Required test coverage of 70% reached. Total coverage: 72.64%

$ python3 -m ruff check scripts/ tests/          # All checks passed!
$ python3 -m ruff format --check scripts/ tests/ # 265 files already formatted
```

TDD 로 진행 — 신규 케이스 8건 중 7건 RED 확인 후 구현.

## 후속

남은 롱테일(미적중 고유 90종 / 카드 339건)은 매체별 표현이 제각각이라 패턴 추가의 오탐 위험 대비 수확이 떨어진다. 과거 포스트 백필 PR 에서 문자열 단위로 검토하고, 재수집으로 대체한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)