### PR TITLE
feat: URL 요약 백필 도구 + 본문 블러브 품질 지표

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 49 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 126 |
+| 테스트 파일 (tests/test_*.py) | 127 |
 
 <!-- component-counts:end -->

--- a/scripts/check_description_quality.py
+++ b/scripts/check_description_quality.py
@@ -80,6 +80,37 @@ def _count_body_artifacts(body: str) -> int:
     return sum(1 for m in _BODY_DESC_SEG_RE.finditer(body) if _segment_has_artifact(m.group(1) or m.group(2) or ""))
 
 
+_BLURB_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def count_blurb_quality(body: str) -> tuple[int, int]:
+    """Return ``(bad, total)`` per-URL blurbs in a post body.
+
+    The artifact scan above looks for *tails* — leftover ad copy, truncated
+    figures. It does not ask the more basic question: is this blurb about the
+    article at all? A 2026-08-06 corpus scan found ~758 blurbs that were pure
+    site chrome (outlet self-introductions, market-data error notices,
+    navigation bars) while the front-matter report read 99.3% real content.
+    Nothing measured that layer, so it drifted unobserved for months.
+
+    Boilerplate only — title-repeat is deliberately excluded here because a
+    blurb legitimately leads with the headline far more often than a front
+    matter description does.
+    """
+    if not body:
+        return 0, 0
+    bad = total = 0
+    for match in _BODY_DESC_SEG_RE.finditer(body):
+        segment = match.group(1) or match.group(2) or ""
+        text = _BLURB_TAG_RE.sub("", segment).strip()
+        if not text:
+            continue
+        total += 1
+        if _is_boilerplate(text):
+            bad += 1
+    return bad, total
+
+
 # Front matter description field patterns (description_ko or description)
 _DESC_KO_RE = re.compile(r'^description_ko:\s*["\']?(.+?)["\']?\s*$', re.MULTILINE)
 _DESC_RE = re.compile(r'^description:\s*["\']?(.+?)["\']?\s*$', re.MULTILINE)
@@ -230,6 +261,9 @@ def _is_ascii_ratio_high(desc: str) -> bool:
 def classify_posts(posts: list[dict]) -> dict:
     """Classify each post description and return aggregated stats."""
     total = len(posts)
+    blurb_bad = 0
+    blurb_total = 0
+    blurb_posts: list[dict] = []
     boilerplate_items = []
     title_repeat_items = []
     real_items = []
@@ -267,9 +301,18 @@ def classify_posts(posts: list[dict]) -> dict:
         artifact_count = _count_body_artifacts(body)
         if artifact_count:
             body_artifact_items.append({**p, "artifact_count": artifact_count})
+        # Per-URL blurb chrome — the layer the front-matter checks never see.
+        bad_blurbs, total_blurbs = count_blurb_quality(body)
+        blurb_bad += bad_blurbs
+        blurb_total += total_blurbs
+        if bad_blurbs:
+            blurb_posts.append({**p, "bad_blurbs": bad_blurbs, "total_blurbs": total_blurbs})
 
     return {
         "total": total,
+        "blurb_bad": blurb_bad,
+        "blurb_total": blurb_total,
+        "blurb_posts": blurb_posts,
         "no_desc": no_desc_items,
         "boilerplate": boilerplate_items,
         "title_repeat": title_repeat_items,
@@ -300,6 +343,9 @@ def format_text(stats: dict, days: int) -> str:
     ba_items = stats.get("body_artifacts", [])
     ba_posts = len(ba_items)
     ba_segs = sum(p.get("artifact_count", 0) for p in ba_items)
+    bl_bad = stats.get("blurb_bad", 0)
+    bl_total = stats.get("blurb_total", 0)
+    bl_posts = len(stats.get("blurb_posts", []))
 
     lines = [
         f"Description Quality Report (last {days} day(s))",
@@ -311,6 +357,7 @@ def format_text(stats: dict, days: int) -> str:
         f"  ASCII-heavy desc: {ar_count} ({_pct(ar_count, total)})",
         f"  Mojibake (body) : {mj_count} ({_pct(mj_count, total)})",
         f"  Body desc artifacts: {ba_posts} post(s), {ba_segs} segment(s)",
+        f"  URL blurb chrome: {bl_bad}/{bl_total} ({_pct(bl_bad, bl_total)}) in {bl_posts} post(s)",
         f"  No description  : {nd_count} ({_pct(nd_count, total)})",
     ]
     if stats["boilerplate"]:
@@ -380,6 +427,8 @@ def format_markdown(stats: dict, days: int) -> str:
         f"| 번역 품질 이슈 | {ti_count} | {_pct(ti_count, total)} |",
         f"| ASCII 과다 desc | {ar_count} | {_pct(ar_count, total)} |",
         f"| Mojibake (인코딩) | {mj_count} | {_pct(mj_count, total)} |",
+        f"| URL 블러브 크롬 | {stats.get('blurb_bad', 0)} | "
+        f"{_pct(stats.get('blurb_bad', 0), stats.get('blurb_total', 0))} (블러브 기준) |",
         f"| 본문 desc 잔재 | {ba_posts} | {ba_segs} segment(s) |",
         f"| description 없음 | {nd_count} | {_pct(nd_count, total)} |",
     ]

--- a/scripts/common/summary_quality.py
+++ b/scripts/common/summary_quality.py
@@ -202,6 +202,14 @@ _SITE_BOILERPLATE_PATTERNS = [
     # "…최신 뉴스를 빠르고 정확하게 전달합니다" — the outlet describing its own
     # delivery rather than an article.
     re.compile(r"최신 뉴스를\s.{0,20}(?:전달|제공)합니다", re.I),
+    # Institutional slogan strip — a comma list of aspirational phrases closing
+    # on the organisation's own name ("혁신적 금융, 포용적 금융, 신뢰받는 금융,
+    # 금융위원회 입니다."). Surfaced by the backfill run, which pulled this off
+    # fsc.go.kr and wrote it into a card as if it were the article.
+    re.compile(
+        r"(?:[가-힣]{2,10}\s?[가-힣]{0,10},\s*){2,}[가-힣]{0,8}(?:위원회|공사|공단|협회|진흥원|거래소|은행)\s*입니다",
+        re.I,
+    ),
     # Superlative self-promo. "가장 권위 있는" is paired with 뉴스/미디어 because
     # the bare phrase also describes awards in real reporting.
     re.compile(r"가장 권위 있는 (?:뉴스|미디어|매체)|신뢰할 수 있는 소스", re.I),

--- a/scripts/fix_post_url_summaries.py
+++ b/scripts/fix_post_url_summaries.py
@@ -25,7 +25,16 @@ indistinguishable from a well-collected one:
    (dead link, consent wall, paywall).
 
 Sampling 10 flagged URLs before this was written gave 7 usable re-fetches, so
-the fetch path carries the bulk and synthesis is the tail.
+the fetch path carries the bulk.
+
+**Run this incrementally.** 90% of flagged blurbs point at `news.google.com`
+redirect links, and Google throttles the resolver hard: across three
+back-to-back full passes the re-fetch yield fell 523 → 71 → 0, with the
+resolver returning empty for every link by the third. Direct publisher URLs
+kept working throughout, so the ceiling is the redirect resolver, not this
+tool. Use `--limit` with a few hundred per run and space the runs out; a pass
+that reports mostly "해결 실패" is a throttled pass, not a corpus without
+recoverable summaries.
 
 Usage:
     python scripts/fix_post_url_summaries.py                  # dry-run report
@@ -291,6 +300,7 @@ def apply_repairs(repairs: list[tuple[Blurb, str, str]]) -> tuple[int, int]:
             by_post.setdefault(blurb.path, []).append((blurb, text))
 
     written = 0
+    posts_written = 0
     for path, items in by_post.items():
         content = path.read_text(encoding="utf-8", errors="replace")
         changed_here = 0
@@ -303,7 +313,8 @@ def apply_repairs(repairs: list[tuple[Blurb, str, str]]) -> tuple[int, int]:
         if changed_here:
             path.write_text(content, encoding="utf-8")
             written += changed_here
-    return written, len([p for p, items in by_post.items() if items])
+            posts_written += 1
+    return written, posts_written
 
 
 def format_report(repairs: list[tuple[Blurb, str, str]], applied: bool) -> str:

--- a/scripts/fix_post_url_summaries.py
+++ b/scripts/fix_post_url_summaries.py
@@ -219,22 +219,24 @@ def replace_in_post(content: str, old_raw: str, new_text: str) -> tuple[str, boo
     return content.replace(old_raw, escaped, 1), True
 
 
-def _repair_one(blurb: Blurb) -> tuple[Blurb, str, str]:
+def _repair_one(blurb: Blurb, allow_synthesis: bool = True) -> tuple[Blurb, str, str]:
     """Resolve a replacement for one blurb. Returns (blurb, text, source)."""
     recovered = refetch(blurb)
     if recovered:
         return blurb, recovered, "refetch"
+    if not allow_synthesis:
+        return blurb, "", "unresolved"
     synthetic = synthesize(blurb)
     if synthetic and not _is_bad(synthetic, blurb.title):
         return blurb, synthetic, "synthetic"
     return blurb, "", "unresolved"
 
 
-def repair(targets: list[Blurb], workers: int) -> list[tuple[Blurb, str, str]]:
+def repair(targets: list[Blurb], workers: int, allow_synthesis: bool = True) -> list[tuple[Blurb, str, str]]:
     """Resolve replacements concurrently, preserving input order."""
     results: list[tuple[Blurb, str, str] | None] = [None] * len(targets)
     with ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = {pool.submit(_repair_one, b): i for i, b in enumerate(targets)}
+        futures = {pool.submit(_repair_one, b, allow_synthesis): i for i, b in enumerate(targets)}
         for future in as_completed(futures):
             index = futures[future]
             try:
@@ -305,6 +307,11 @@ def main() -> int:
     parser.add_argument("--limit", type=int, default=None, help="처리할 블러브 최대 개수")
     parser.add_argument("--workers", type=int, default=6, help="동시 재수집 스레드 수 (기본 6)")
     parser.add_argument("--apply", action="store_true", help="실제 파일에 기록 (기본: dry-run)")
+    parser.add_argument(
+        "--skip-synthetic",
+        action="store_true",
+        help="재수집 실패 시 합성 폴백을 쓰지 않고 원문 유지 (품질 저하 방지)",
+    )
     args = parser.parse_args()
 
     setup_logging()
@@ -318,7 +325,7 @@ def main() -> int:
         return 0
 
     logger.info("Repairing %d flagged blurbs with %d workers", len(targets), args.workers)
-    repairs = repair(targets, args.workers)
+    repairs = repair(targets, args.workers, allow_synthesis=not args.skip_synthetic)
 
     print(format_report(repairs, applied=args.apply))
 

--- a/scripts/fix_post_url_summaries.py
+++ b/scripts/fix_post_url_summaries.py
@@ -56,6 +56,7 @@ from common.enrichment_synthetic import (  # noqa: E402
     generate_synthetic_description,
 )
 from common.summary_quality import is_boilerplate  # noqa: E402
+from common.text_utils import _strip_trailing_artifacts  # noqa: E402
 from common.translator import translate_to_korean  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,15 @@ POSTS_DIR = REPO_ROOT / "_posts"
 
 # A recovered blurb shorter than this says less than the headline already does.
 _MIN_DESC_LEN = 30
+
+# …and longer than this is not a summary. `fetch_page_metadata` happily returns
+# a whole article body when a page has no meta description; the first apply run
+# put 400-800 character walls of text into cards sized for a sentence or two.
+# Recovered text is trimmed back to a sentence boundary under this length.
+_MAX_DESC_LEN = 300
+
+# Sentence terminators used to trim without cutting mid-word.
+_SENTENCE_END_RE = re.compile(r"(?<=[.!?。])\s+|(?<=니다\.)\s*|(?<=습니다\.)\s*")
 
 # Card blurb: the anchor and its `<p class="news-desc">` sit in the same card
 # div, with the source tag and severity badge in between.
@@ -176,7 +186,13 @@ def refetch(blurb: Blurb) -> str:
         logger.debug("Fetch failed for %s: %s", link[:60], exc)
         return ""
 
-    desc = (meta or {}).get("description", "").strip()
+    # Unescape first: fetched text carries raw entities (`&hellip;`, `&amp;`).
+    # Writing it back without this produced `&amp;hellip;` on the page — the
+    # entity rendered as literal text instead of the character it names.
+    desc = html.unescape((meta or {}).get("description", "")).strip()
+    # Ad tails ride along with fetched copy ("Priority Gold에서 무료 가이드 받기").
+    # Delegated to the canonical stripper the quality checker already uses.
+    desc = _trim_to_sentence(_strip_trailing_artifacts(desc))
     if len(desc) < _MIN_DESC_LEN:
         return ""
     if is_boilerplate(desc) or _is_desc_duplicate_of_title(desc, blurb.title):
@@ -194,6 +210,22 @@ def refetch(blurb: Blurb) -> str:
             desc = translated
 
     return desc
+
+
+def _trim_to_sentence(text: str, limit: int = _MAX_DESC_LEN) -> str:
+    """Cut ``text`` back to the last sentence boundary at or under ``limit``.
+
+    Falls back to a hard cut with an ellipsis when the first sentence alone
+    already exceeds the limit, so a run-on page never lands whole in a card.
+    """
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    head = text[:limit]
+    boundaries = [m.end() for m in _SENTENCE_END_RE.finditer(head)]
+    if boundaries and boundaries[-1] >= _MIN_DESC_LEN:
+        return head[: boundaries[-1]].strip()
+    return head.rstrip() + "…"
 
 
 def synthesize(blurb: Blurb) -> str:

--- a/scripts/fix_post_url_summaries.py
+++ b/scripts/fix_post_url_summaries.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Backfill per-URL summaries in published posts.
+
+``fix_post_descriptions.py`` repairs a post's front-matter ``description``.
+This tool repairs the layer underneath it: the per-article blurbs rendered
+inside the post body (``<p class="news-desc">`` cards and ``<span class="p0-desc">``
+alert entries).
+
+That layer was never measured. The front-matter report reads 99.3% real
+content, while a 2026-08-06 scan over 2309 posts / 4504 cards found ~758 blurbs
+carrying site chrome instead of article content — outlet self-introductions,
+market-data error notices, navigation bars, newsletter solicitations. The
+detector strengthening that keeps *new* posts clean ships separately; this
+backfills what is already published.
+
+Sourcing order, mirroring the collection pipeline so a repaired blurb is
+indistinguishable from a well-collected one:
+
+1. **Re-fetch** the article URL (Google News redirects resolved first) and take
+   its description, accepting it only if it passes the same quality gates a
+   fresh collection would apply — not boilerplate, not a restatement of the
+   title, long enough to inform.
+2. **Translate** to Korean when the recovered text is not already Korean.
+3. **Synthesize** from title + source when the fetch yields nothing usable
+   (dead link, consent wall, paywall).
+
+Sampling 10 flagged URLs before this was written gave 7 usable re-fetches, so
+the fetch path carries the bulk and synthesis is the tail.
+
+Usage:
+    python scripts/fix_post_url_summaries.py                  # dry-run report
+    python scripts/fix_post_url_summaries.py --days 30        # recent posts only
+    python scripts/fix_post_url_summaries.py --apply          # write changes
+    python scripts/fix_post_url_summaries.py --apply --limit 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import logging
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import NamedTuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from common.config import setup_logging  # noqa: E402
+from common.enrichment import _is_desc_duplicate_of_title  # noqa: E402
+from common.enrichment_network import _resolve_google_news_url, fetch_page_metadata  # noqa: E402
+from common.enrichment_synthetic import (  # noqa: E402
+    _is_title_related_description,
+    generate_synthetic_description,
+)
+from common.summary_quality import is_boilerplate  # noqa: E402
+from common.translator import translate_to_korean  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO_ROOT / "_posts"
+
+# A recovered blurb shorter than this says less than the headline already does.
+_MIN_DESC_LEN = 30
+
+# Card blurb: the anchor and its `<p class="news-desc">` sit in the same card
+# div, with the source tag and severity badge in between.
+_CARD_RE = re.compile(
+    r'<a href="(?P<url>[^"]+)"[^>]*class="news-title"[^>]*>(?P<title>.*?)</a>'
+    r'(?P<between>.*?)<p class="news-desc">(?P<desc>.*?)</p>',
+    re.S,
+)
+
+# Alert-box entry: `<a href=...>title</a> <span class="p0-desc">blurb</span>`.
+_P0_RE = re.compile(
+    r'<a href="(?P<url>[^"]+)"[^>]*>(?P<title>.*?)</a>\s*<span class="p0-desc">(?P<desc>.*?)</span>',
+    re.S,
+)
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})-")
+_HANGUL_RE = re.compile(r"[가-힣]")
+
+
+class Blurb(NamedTuple):
+    """One per-URL summary found in a post body."""
+
+    path: Path
+    kind: str  # "news-desc" | "p0-desc"
+    url: str
+    title: str
+    raw: str  # the exact inner text to replace, as it appears on disk
+    text: str  # unescaped, tag-stripped text for quality checks
+
+
+def _plain(fragment: str) -> str:
+    """Tag-stripped, entity-decoded text for quality checks."""
+    return html.unescape(_TAG_RE.sub("", fragment)).strip()
+
+
+def _post_date(path: Path) -> date | None:
+    match = _DATE_RE.match(path.name)
+    if not match:
+        return None
+    try:
+        return date(*(int(g) for g in match.groups()))
+    except ValueError:
+        return None
+
+
+def _is_bad(text: str, title: str) -> bool:
+    """A blurb worth replacing: site chrome, or the headline restated."""
+    if not text:
+        return True
+    return is_boilerplate(text) or _is_desc_duplicate_of_title(text, title)
+
+
+def find_blurbs(path: Path) -> list[Blurb]:
+    """Every per-URL summary in a post, flagged or not."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    found: list[Blurb] = []
+    for kind, pattern in (("news-desc", _CARD_RE), ("p0-desc", _P0_RE)):
+        for match in pattern.finditer(text):
+            found.append(
+                Blurb(
+                    path=path,
+                    kind=kind,
+                    url=match.group("url"),
+                    title=_plain(match.group("title")),
+                    raw=match.group("desc"),
+                    text=_plain(match.group("desc")),
+                )
+            )
+    return found
+
+
+def collect_targets(posts_dir: Path, days: int | None) -> list[Blurb]:
+    """Flagged blurbs across the corpus, newest post first."""
+    cutoff = None if days is None else datetime.now(UTC).date() - timedelta(days=days)
+    targets: list[Blurb] = []
+    for path in sorted(posts_dir.glob("*.md"), reverse=True):
+        posted = _post_date(path)
+        if cutoff is not None and (posted is None or posted < cutoff):
+            continue
+        targets.extend(b for b in find_blurbs(path) if _is_bad(b.text, b.title))
+    return targets
+
+
+def _resolve(url: str) -> str:
+    """Follow a Google News redirect to the publisher, best effort."""
+    if "news.google.com" not in url:
+        return url
+    try:
+        resolved = _resolve_google_news_url(url)
+    except Exception as exc:  # network/parse failures are expected on old links
+        logger.debug("Google News resolve failed for %s: %s", url[:60], exc)
+        return ""
+    return resolved if resolved and "news.google.com" not in resolved else ""
+
+
+def refetch(blurb: Blurb) -> str:
+    """A usable replacement from the live article, or "" if none.
+
+    Applies the gates a fresh collection would: not boilerplate, not a
+    restatement of the headline, related to the headline, long enough.
+    """
+    link = _resolve(blurb.url)
+    if not link:
+        return ""
+    try:
+        meta = fetch_page_metadata(link, title=blurb.title)
+    except Exception as exc:
+        logger.debug("Fetch failed for %s: %s", link[:60], exc)
+        return ""
+
+    desc = (meta or {}).get("description", "").strip()
+    if len(desc) < _MIN_DESC_LEN:
+        return ""
+    if is_boilerplate(desc) or _is_desc_duplicate_of_title(desc, blurb.title):
+        return ""
+    if not _is_title_related_description(blurb.title, desc):
+        return ""
+
+    if not _HANGUL_RE.search(desc):
+        try:
+            translated = translate_to_korean(desc)
+        except Exception as exc:
+            logger.debug("Translation failed, keeping source text: %s", exc)
+            translated = ""
+        if translated and not is_boilerplate(translated):
+            desc = translated
+
+    return desc
+
+
+def synthesize(blurb: Blurb) -> str:
+    """Fact-based fallback built from the headline when the link is unusable."""
+    try:
+        return generate_synthetic_description(blurb.title, "", None).strip()
+    except Exception as exc:
+        logger.debug("Synthesis failed for %r: %s", blurb.title[:60], exc)
+        return ""
+
+
+def replace_in_post(content: str, old_raw: str, new_text: str) -> tuple[str, bool]:
+    """Swap one blurb's inner text, leaving the surrounding markup untouched.
+
+    The replacement is HTML-escaped because it lands inside an element body,
+    and it is applied only when ``old_raw`` occurs exactly once — a blurb
+    repeated verbatim in the same post would otherwise have every copy
+    rewritten from one URL's fetch.
+    """
+    if content.count(old_raw) != 1:
+        return content, False
+    escaped = html.escape(new_text, quote=False)
+    return content.replace(old_raw, escaped, 1), True
+
+
+def _repair_one(blurb: Blurb) -> tuple[Blurb, str, str]:
+    """Resolve a replacement for one blurb. Returns (blurb, text, source)."""
+    recovered = refetch(blurb)
+    if recovered:
+        return blurb, recovered, "refetch"
+    synthetic = synthesize(blurb)
+    if synthetic and not _is_bad(synthetic, blurb.title):
+        return blurb, synthetic, "synthetic"
+    return blurb, "", "unresolved"
+
+
+def repair(targets: list[Blurb], workers: int) -> list[tuple[Blurb, str, str]]:
+    """Resolve replacements concurrently, preserving input order."""
+    results: list[tuple[Blurb, str, str] | None] = [None] * len(targets)
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_repair_one, b): i for i, b in enumerate(targets)}
+        for future in as_completed(futures):
+            index = futures[future]
+            try:
+                results[index] = future.result(timeout=60)
+            except Exception as exc:
+                logger.debug("Repair failed for %s: %s", targets[index].url[:60], exc)
+                results[index] = (targets[index], "", "unresolved")
+    return [r for r in results if r is not None]
+
+
+def apply_repairs(repairs: list[tuple[Blurb, str, str]]) -> tuple[int, int]:
+    """Write resolved replacements to disk, grouped per post.
+
+    Returns ``(blurbs_written, posts_changed)``. Ambiguous anchors are skipped
+    rather than guessed at.
+    """
+    by_post: dict[Path, list[tuple[Blurb, str]]] = {}
+    for blurb, text, _source in repairs:
+        if text:
+            by_post.setdefault(blurb.path, []).append((blurb, text))
+
+    written = 0
+    for path, items in by_post.items():
+        content = path.read_text(encoding="utf-8", errors="replace")
+        changed_here = 0
+        for blurb, text in items:
+            content, ok = replace_in_post(content, blurb.raw, text)
+            if ok:
+                changed_here += 1
+            else:
+                logger.warning("Skipped ambiguous blurb anchor in %s: %r", path.name, blurb.raw[:60])
+        if changed_here:
+            path.write_text(content, encoding="utf-8")
+            written += changed_here
+    return written, len([p for p, items in by_post.items() if items])
+
+
+def format_report(repairs: list[tuple[Blurb, str, str]], applied: bool) -> str:
+    """Human-readable summary with a sample of each outcome."""
+    total = len(repairs)
+    counts = {"refetch": 0, "synthetic": 0, "unresolved": 0}
+    for _blurb, _text, source in repairs:
+        counts[source] = counts.get(source, 0) + 1
+
+    lines = [
+        f"URL 요약 백필 {'적용' if applied else '(dry-run)'}",
+        f"  대상 블러브   : {total}",
+        f"  재수집 성공   : {counts['refetch']}",
+        f"  합성 대체     : {counts['synthetic']}",
+        f"  해결 실패     : {counts['unresolved']}",
+    ]
+
+    for source in ("refetch", "synthetic"):
+        samples = [(b, t) for b, t, s in repairs if s == source][:3]
+        if not samples:
+            continue
+        lines.append(f"\n  --- {source} 샘플 ---")
+        for blurb, text in samples:
+            lines.append(f"  [{blurb.path.name}] {blurb.title[:60]}")
+            lines.append(f"    before: {blurb.text[:80]}")
+            lines.append(f"    after : {text[:80]}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill per-URL summaries in published posts.")
+    parser.add_argument("--days", type=int, default=None, help="최근 N일 포스트만 (기본: 전체)")
+    parser.add_argument("--limit", type=int, default=None, help="처리할 블러브 최대 개수")
+    parser.add_argument("--workers", type=int, default=6, help="동시 재수집 스레드 수 (기본 6)")
+    parser.add_argument("--apply", action="store_true", help="실제 파일에 기록 (기본: dry-run)")
+    args = parser.parse_args()
+
+    setup_logging()
+
+    targets = collect_targets(POSTS_DIR, args.days)
+    if args.limit is not None:
+        targets = targets[: args.limit]
+
+    if not targets:
+        print("불량 URL 요약 없음.")
+        return 0
+
+    logger.info("Repairing %d flagged blurbs with %d workers", len(targets), args.workers)
+    repairs = repair(targets, args.workers)
+
+    print(format_report(repairs, applied=args.apply))
+
+    if args.apply:
+        written, posts = apply_repairs(repairs)
+        print(f"\n적용: 블러브 {written}건 / 포스트 {posts}개")
+    else:
+        print("\n(dry-run — 적용하려면 --apply)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_description_quality.py
+++ b/tests/test_check_description_quality.py
@@ -646,3 +646,51 @@ def test_main_fails_on_body_artifacts(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["prog", "--days", "1", "--posts-dir", str(tmp_path)])
     assert cdq.main() == 1
     assert "body description artifact" in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Per-URL blurb chrome (2026-08-06) — the layer the front-matter checks miss
+# ---------------------------------------------------------------------------
+
+
+def test_count_blurb_quality_counts_chrome_and_total():
+    """Front matter can read clean while every blurb under it is site chrome."""
+    chrome = (
+        "한겨레는 신뢰, 공정을 바탕으로 최신 뉴스와 심층 보도, 칼럼 등을 제공합니다. "
+        "정치, 사회, 경제, 문화, 젠더, 기후변화 등 각 분야의 인사이트를 경험해보세요."
+    )
+    real = "비트코인이 24시간 동안 8% 오르며 시가총액 1조 달러를 회복했다고 거래소 데이터가 보여줍니다."
+    body = _NEWS_DESC.format(chrome) + _NEWS_DESC.format(real)
+
+    assert cdq.count_blurb_quality(body) == (1, 2)
+
+
+def test_count_blurb_quality_counts_p0_segments():
+    body = '<span class="p0-desc">일시적인 문제가 발생했습니다. 이 페이지의 시장 데이터는 현재 지연되었습니다.</span>'
+    assert cdq.count_blurb_quality(body) == (1, 1)
+
+
+def test_count_blurb_quality_ignores_empty_segments():
+    assert cdq.count_blurb_quality(_NEWS_DESC.format("")) == (0, 0)
+
+
+def test_count_blurb_quality_on_empty_body():
+    assert cdq.count_blurb_quality("") == (0, 0)
+
+
+def test_classify_posts_aggregates_blurb_counts():
+    chrome = "일시적인 문제가 발생했습니다. 이 페이지의 시장 데이터는 현재 지연되었습니다."
+    posts = [_make_post_dict("정상 요약입니다.", body=_NEWS_DESC.format(chrome))]
+    stats = cdq.classify_posts(posts)
+
+    assert (stats["blurb_bad"], stats["blurb_total"]) == (1, 1)
+    assert len(stats["blurb_posts"]) == 1
+    assert stats["blurb_posts"][0]["bad_blurbs"] == 1
+
+
+def test_format_text_reports_blurb_chrome():
+    chrome = "일시적인 문제가 발생했습니다. 이 페이지의 시장 데이터는 현재 지연되었습니다."
+    posts = [_make_post_dict("정상 요약입니다.", body=_NEWS_DESC.format(chrome))]
+    report = cdq.format_text(cdq.classify_posts(posts), days=7)
+
+    assert "URL blurb chrome: 1/1" in report

--- a/tests/test_fix_post_url_summaries.py
+++ b/tests/test_fix_post_url_summaries.py
@@ -294,3 +294,22 @@ def test_format_report_counts_each_outcome() -> None:
 
 def test_format_report_marks_applied_runs() -> None:
     assert "적용" in mod.format_report([(_blurb(), "x", "refetch")], applied=True)
+
+
+def test_repair_one_skips_synthesis_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--skip-synthetic` keeps the original blurb rather than degrading it.
+
+    Measured on the corpus before this flag existed: the synthesis fallback
+    appended source suffixes and stop-word "주요 키워드" tails, producing output
+    worse than the title restatement it replaced. Re-fetch is a clear win;
+    synthesis is not, so it must be switchable off.
+    """
+    monkeypatch.setattr(mod, "refetch", lambda blurb: "")
+
+    def _never(blurb):  # pragma: no cover - must not be reached
+        raise AssertionError("synthesis must be skipped")
+
+    monkeypatch.setattr(mod, "synthesize", _never)
+
+    _blurb_out, text, source = mod._repair_one(_blurb(), allow_synthesis=False)
+    assert (text, source) == ("", "unresolved")

--- a/tests/test_fix_post_url_summaries.py
+++ b/tests/test_fix_post_url_summaries.py
@@ -384,3 +384,19 @@ def test_refetch_rejects_institutional_slogan(monkeypatch: pytest.MonkeyPatch) -
         lambda url, title="": {"description": "혁신적 금융, 포용적 금융, 신뢰받는 금융, 금융위원회 입니다."},
     )
     assert mod.refetch(_blurb(title="긴급 금융시장상황 점검회의 개최")) == ""
+
+
+def test_apply_repairs_counts_only_posts_actually_written(tmp_path: Path) -> None:
+    """A post whose every anchor was ambiguous is not a changed post.
+
+    The first apply run reported "블러브 50건 / 포스트 62개" — more posts than
+    blurbs, because the count included posts where every replacement was
+    skipped as ambiguous.
+    """
+    body = '---\ntitle: T\n---\n<p class="news-desc">dup</p><p class="news-desc">dup</p>\n'
+    path = tmp_path / "2026-08-05-dup.md"
+    path.write_text(body, encoding="utf-8")
+
+    blurb = mod.Blurb(path, "news-desc", "https://example.com/a", "제목", "dup", "dup")
+    assert mod.apply_repairs([(blurb, "코스피가 3% 올라 2,900선을 회복했습니다.", "refetch")]) == (0, 0)
+    assert path.read_text(encoding="utf-8") == body

--- a/tests/test_fix_post_url_summaries.py
+++ b/tests/test_fix_post_url_summaries.py
@@ -1,0 +1,296 @@
+"""Tests for scripts/fix_post_url_summaries.py — per-URL summary backfill.
+
+Network paths are stubbed throughout: the value under test is the parsing,
+gating, and rewriting logic, not the fetcher (which `tests/test_enrichment*.py`
+already covers).
+
+Paths are derived from ``__file__`` rather than imported from the module under
+test — importing production ``REPO_ROOT`` / ``POSTS_DIR`` into a test trips the
+hermetic-writes guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import fix_post_url_summaries as mod
+import pytest
+
+# A post body shaped like the real generated cards: anchor, severity badge and
+# source tag in between, then the blurb.
+_CARD_POST = """---
+title: "테스트 포스트"
+---
+
+<div class="news-card-item">
+<span class="news-severity news-severity-med">MED</span>
+<a href="https://news.google.com/rss/articles/ABC?oc=5" class="news-title" \
+target="_blank" rel="noopener noreferrer">코스피 3% 상승, 반도체 주도</a>
+<p class="news-desc">한겨레는 신뢰, 공정을 바탕으로 최신 뉴스와 심층 보도, 칼럼 등을 제공합니다. \
+정치, 사회, 경제, 문화, 젠더, 기후변화 등 각 분야의 인사이트를 경험해보세요.</p>
+<span class="source-tag">Google News KR</span>
+</div>
+
+<div class="news-card-item">
+<a href="https://example.com/good" class="news-title">비트코인 8% 급등</a>
+<p class="news-desc">비트코인이 24시간 동안 8% 오르며 시가총액 1조 달러를 회복했다고 거래소 데이터가 보여줍니다.</p>
+</div>
+"""
+
+_P0_POST = """---
+title: "알림 포스트"
+---
+
+<div class="alert-box alert-urgent"><strong>긴급</strong><ul>
+<li><a href="https://example.com/p0">FBI 요원 암호화폐 절도 혐의</a> \
+<span class="p0-desc">일시적인 문제가 발생했습니다. 이 페이지의 시장 데이터는 현재 지연되었습니다.</span></li>
+</ul></div>
+"""
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def test_find_blurbs_extracts_card_url_title_and_desc(tmp_path: Path) -> None:
+    path = _write(tmp_path, "2026-08-05-x.md", _CARD_POST)
+    blurbs = mod.find_blurbs(path)
+
+    assert len(blurbs) == 2
+    first = blurbs[0]
+    assert first.kind == "news-desc"
+    assert first.url == "https://news.google.com/rss/articles/ABC?oc=5"
+    assert first.title == "코스피 3% 상승, 반도체 주도"
+    assert first.text.startswith("한겨레는 신뢰")
+
+
+def test_find_blurbs_extracts_p0_alert_entries(tmp_path: Path) -> None:
+    path = _write(tmp_path, "2026-08-05-y.md", _P0_POST)
+    blurbs = [b for b in mod.find_blurbs(path) if b.kind == "p0-desc"]
+
+    assert len(blurbs) == 1
+    assert blurbs[0].url == "https://example.com/p0"
+    assert "시장 데이터는 현재 지연" in blurbs[0].text
+
+
+def test_plain_strips_tags_and_decodes_entities() -> None:
+    assert mod._plain("<b>KCRG</b> &#124; 뉴스") == "KCRG | 뉴스"
+
+
+def test_post_date_parses_filename() -> None:
+    assert mod._post_date(Path("2026-08-05-daily.md")).isoformat() == "2026-08-05"
+
+
+@pytest.mark.parametrize("name", ["no-date.md", "2026-13-45-bad.md"])
+def test_post_date_returns_none_for_unparseable(name: str) -> None:
+    assert mod._post_date(Path(name)) is None
+
+
+# ---------------------------------------------------------------------------
+# Flagging
+# ---------------------------------------------------------------------------
+
+
+def test_is_bad_flags_site_chrome() -> None:
+    assert (
+        mod._is_bad("일시적인 문제가 발생했습니다. 이 페이지의 시장 데이터는 현재 지연되었습니다.", "코스피 상승")
+        is True
+    )
+
+
+def test_is_bad_flags_title_restatement() -> None:
+    title = "코스피·코스닥, 오름세로 장 출발"
+    assert mod._is_bad(f"{title} 한강타임즈", title) is True
+
+
+def test_is_bad_passes_real_summary() -> None:
+    desc = "비트코인이 24시간 동안 8% 오르며 시가총액 1조 달러를 회복했다고 거래소 데이터가 보여줍니다."
+    assert mod._is_bad(desc, "비트코인 8% 급등") is False
+
+
+def test_is_bad_flags_empty() -> None:
+    assert mod._is_bad("", "제목") is True
+
+
+def test_collect_targets_returns_only_flagged(tmp_path: Path) -> None:
+    _write(tmp_path, "2026-08-05-x.md", _CARD_POST)
+    targets = mod.collect_targets(tmp_path, days=None)
+
+    assert len(targets) == 1, "the well-formed second card must not be flagged"
+    assert targets[0].title == "코스피 3% 상승, 반도체 주도"
+
+
+def test_collect_targets_honours_days_window(tmp_path: Path) -> None:
+    _write(tmp_path, "2020-01-01-old.md", _CARD_POST)
+    assert mod.collect_targets(tmp_path, days=30) == []
+
+
+# ---------------------------------------------------------------------------
+# Rewriting
+# ---------------------------------------------------------------------------
+
+
+def test_replace_in_post_swaps_only_the_blurb_body() -> None:
+    content = '<p class="news-desc">낡은 요약</p>'
+    updated, ok = mod.replace_in_post(content, "낡은 요약", "새 요약입니다")
+
+    assert ok is True
+    assert updated == '<p class="news-desc">새 요약입니다</p>'
+
+
+def test_replace_in_post_escapes_html_in_replacement() -> None:
+    content = '<p class="news-desc">old</p>'
+    updated, ok = mod.replace_in_post(content, "old", "삼성 & LG <b>급등</b>")
+
+    assert ok is True
+    assert "&amp;" in updated and "&lt;b&gt;" in updated
+    assert "<b>" not in updated.replace('<p class="news-desc">', "")
+
+
+def test_replace_in_post_refuses_ambiguous_anchor() -> None:
+    """A blurb repeated verbatim must not be rewritten from one URL's fetch."""
+    content = '<p class="news-desc">dup</p><p class="news-desc">dup</p>'
+    updated, ok = mod.replace_in_post(content, "dup", "새 요약")
+
+    assert ok is False
+    assert updated == content
+
+
+def test_apply_repairs_writes_only_resolved_blurbs(tmp_path: Path) -> None:
+    path = _write(tmp_path, "2026-08-05-x.md", _CARD_POST)
+    blurbs = mod.find_blurbs(path)
+    repairs = [
+        (blurbs[0], "코스피가 3% 올라 2,900선을 회복했다고 거래소가 밝혔습니다.", "refetch"),
+        (blurbs[1], "", "unresolved"),
+    ]
+
+    written, posts = mod.apply_repairs(repairs)
+    updated = path.read_text(encoding="utf-8")
+
+    assert (written, posts) == (1, 1)
+    assert "코스피가 3% 올라" in updated
+    assert "한겨레는 신뢰" not in updated
+    assert "비트코인이 24시간 동안 8%" in updated, "untouched blurb must survive"
+
+
+def test_apply_repairs_is_a_noop_without_resolutions(tmp_path: Path) -> None:
+    path = _write(tmp_path, "2026-08-05-x.md", _CARD_POST)
+    before = path.read_text(encoding="utf-8")
+
+    assert mod.apply_repairs([(mod.find_blurbs(path)[0], "", "unresolved")]) == (0, 0)
+    assert path.read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
+# Sourcing gates (network stubbed)
+# ---------------------------------------------------------------------------
+
+
+def _blurb(url: str = "https://example.com/a", title: str = "코스피 3% 상승") -> mod.Blurb:
+    return mod.Blurb(Path("x.md"), "news-desc", url, title, "old", "old")
+
+
+def test_refetch_rejects_boilerplate_from_the_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The full observed string — the shortened form does not carry the
+    # five-item section list the outlet-blurb detector pairs with the verb.
+    chrome = (
+        "한겨레는 신뢰, 공정을 바탕으로 최신 뉴스와 심층 보도, 칼럼 등을 제공합니다. "
+        "정치, 사회, 경제, 문화, 젠더, 기후변화 등 각 분야의 폭 넓은 인사이트를 경험해보세요."
+    )
+    monkeypatch.setattr(mod, "fetch_page_metadata", lambda url, title="": {"description": chrome})
+    assert mod.refetch(_blurb()) == ""
+
+
+def test_refetch_rejects_too_short(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "fetch_page_metadata", lambda url, title="": {"description": "짧음"})
+    assert mod.refetch(_blurb()) == ""
+
+
+def test_refetch_accepts_related_korean_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    good = "코스피가 3% 올라 2,900선을 회복했으며 반도체 업종이 상승을 주도했다고 거래소가 밝혔습니다."
+    monkeypatch.setattr(mod, "fetch_page_metadata", lambda url, title="": {"description": good})
+    assert mod.refetch(_blurb()) == good
+
+
+def test_refetch_translates_non_korean_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    english = "The KOSPI index rose 3% on Tuesday as semiconductor shares led broad gains across the market."
+    korean = "코스피 지수가 화요일 3% 상승했으며 반도체주가 시장 전반의 상승을 이끌었습니다."
+    monkeypatch.setattr(mod, "fetch_page_metadata", lambda url, title="": {"description": english})
+    monkeypatch.setattr(mod, "translate_to_korean", lambda text: korean)
+    monkeypatch.setattr(mod, "_is_title_related_description", lambda title, desc: True)
+
+    assert mod.refetch(_blurb()) == korean
+
+
+def test_refetch_returns_empty_when_google_news_link_unresolvable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_resolve_google_news_url", lambda url: "")
+
+    def _boom(url, title=""):  # pragma: no cover - must never be reached
+        raise AssertionError("unresolved link must not be fetched")
+
+    monkeypatch.setattr(mod, "fetch_page_metadata", _boom)
+    assert mod.refetch(_blurb(url="https://news.google.com/rss/articles/ABC")) == ""
+
+
+def test_refetch_survives_fetch_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(url, title=""):
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(mod, "fetch_page_metadata", _raise)
+    assert mod.refetch(_blurb()) == ""
+
+
+def test_repair_one_falls_back_to_synthesis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "refetch", lambda blurb: "")
+    monkeypatch.setattr(mod, "synthesize", lambda blurb: "코스피가 3% 상승하며 2,900선을 회복했습니다.")
+
+    _blurb_out, text, source = mod._repair_one(_blurb())
+    assert source == "synthetic"
+    assert text.startswith("코스피가 3%")
+
+
+def test_repair_one_reports_unresolved_when_synthesis_is_bad(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "refetch", lambda blurb: "")
+    monkeypatch.setattr(mod, "synthesize", lambda blurb: "관련 소식입니다.")
+
+    _blurb_out, text, source = mod._repair_one(_blurb())
+    assert (text, source) == ("", "unresolved")
+
+
+def test_synthesize_survives_generator_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(title, source, context_map):
+        raise ValueError("bad title")
+
+    monkeypatch.setattr(mod, "generate_synthetic_description", _raise)
+    assert mod.synthesize(_blurb()) == ""
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_counts_each_outcome() -> None:
+    repairs = [
+        (_blurb(), "새 요약 A", "refetch"),
+        (_blurb(), "새 요약 B", "synthetic"),
+        (_blurb(), "", "unresolved"),
+    ]
+    report = mod.format_report(repairs, applied=False)
+
+    assert "대상 블러브   : 3" in report
+    assert "재수집 성공   : 1" in report
+    assert "합성 대체     : 1" in report
+    assert "해결 실패     : 1" in report
+    assert "(dry-run)" in report
+
+
+def test_format_report_marks_applied_runs() -> None:
+    assert "적용" in mod.format_report([(_blurb(), "x", "refetch")], applied=True)

--- a/tests/test_fix_post_url_summaries.py
+++ b/tests/test_fix_post_url_summaries.py
@@ -313,3 +313,74 @@ def test_repair_one_skips_synthesis_when_disabled(monkeypatch: pytest.MonkeyPatc
 
     _blurb_out, text, source = mod._repair_one(_blurb(), allow_synthesis=False)
     assert (text, source) == ("", "unresolved")
+
+
+# ---------------------------------------------------------------------------
+# Defects found by the first apply run (2026-08-06), reverted before commit
+# ---------------------------------------------------------------------------
+
+
+def test_refetch_unescapes_entities_before_storing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`&hellip;` must become `…`, not survive to be re-escaped as `&amp;hellip;`.
+
+    The first apply wrote `&amp;hellip;` into a card, which renders as the
+    literal string `&hellip;` — the entity named a character the reader never saw.
+    """
+    fetched = "코스피가 3% 올라 2,900선을 회복했습니다&hellip; 반도체가 상승을 주도했다고 거래소가 밝혔습니다."
+    monkeypatch.setattr(mod, "fetch_page_metadata", lambda url, title="": {"description": fetched})
+    monkeypatch.setattr(mod, "_is_title_related_description", lambda title, desc: True)
+
+    result = mod.refetch(_blurb())
+    assert "…" in result
+    assert "&hellip;" not in result and "&amp;" not in result
+
+
+def test_refetch_trims_article_bodies_to_a_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A page with no meta description yields its whole body — cards want a sentence.
+
+    The first apply put 400-800 character walls of text into cards sized for
+    one or two sentences.
+    """
+    body = " ".join(f"{i}일 코스피가 3% 올라 2,900선을 회복했다고 한국거래소가 발표했습니다." for i in range(1, 20))
+    monkeypatch.setattr(mod, "fetch_page_metadata", lambda url, title="": {"description": body})
+    monkeypatch.setattr(mod, "_is_title_related_description", lambda title, desc: True)
+
+    result = mod.refetch(_blurb())
+    assert len(result) <= mod._MAX_DESC_LEN
+    assert result.endswith(("다.", "…")), "trim must land on a sentence boundary or mark the cut"
+
+
+def test_trim_to_sentence_keeps_short_text_untouched() -> None:
+    text = "코스피가 3% 올라 2,900선을 회복했습니다."
+    assert mod._trim_to_sentence(text) == text
+
+
+def test_trim_to_sentence_hard_cuts_a_run_on() -> None:
+    """A single sentence longer than the cap still has to be cut somewhere."""
+    result = mod._trim_to_sentence("가" * 500)
+    assert len(result) <= mod._MAX_DESC_LEN + 1
+    assert result.endswith("…")
+
+
+def test_refetch_strips_advertising_tails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ad copy rides along with fetched text and must not land in a card."""
+    monkeypatch.setattr(
+        mod,
+        "fetch_page_metadata",
+        lambda url, title="": {
+            "description": "코스피가 3% 올라 2,900선을 회복했다고 한국거래소가 발표했습니다. 관련 광고 홍보."
+        },
+    )
+    monkeypatch.setattr(mod, "_is_title_related_description", lambda title, desc: True)
+
+    assert "관련 광고" not in mod.refetch(_blurb())
+
+
+def test_refetch_rejects_institutional_slogan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The regulator's own slogan strip is not a description of its press release."""
+    monkeypatch.setattr(
+        mod,
+        "fetch_page_metadata",
+        lambda url, title="": {"description": "혁신적 금융, 포용적 금융, 신뢰받는 금융, 금융위원회 입니다."},
+    )
+    assert mod.refetch(_blurb(title="긴급 금융시장상황 점검회의 개최")) == ""


### PR DESCRIPTION
> Base 는 `main` 이 아니라 **#1079(필터 강화)** 입니다. 그 PR 의 탐지기를 그대로 쓰기 때문입니다.

## 무엇을 담고 무엇을 담지 않는가

담는 것: **백필 도구**, **사각지대를 메우는 품질 지표**, 그리고 실제 실행에서 드러난 **결함 4건의 수정**.

담지 **않는** 것: 백필된 포스트. 실행해 봤고, 결과가 출시 가능한 수준이 아니어서 커밋 전에 되돌렸습니다. 자세한 내용은 아래.

## 1. `scripts/fix_post_url_summaries.py`

`fix_post_descriptions.py` 가 front matter 의 `description` 을 고친다면, 이 도구는 그 아래 층 — 본문에 렌더되는 per-article 블러브 — 을 고칩니다. 수집 파이프라인과 같은 순서로 대체 텍스트를 구합니다:

1. **재수집** — Google News 리다이렉트 해소 → 기사 description 회수 → 신규 수집과 동일한 게이트(보일러플레이트 아님 · 제목 재진술 아님 · 제목 관련성 · 길이) 통과 시에만 채택
2. **번역** — 회수 텍스트가 한국어가 아니면 한국어로
3. **합성** — 링크가 죽었으면 제목+출처 기반 팩트 합성 (단, 아래 이유로 기본 비권장)

안전장치: 기본 dry-run · HTML 이스케이프 · 앵커가 포스트 내 정확히 1회일 때만 치환(동일 블러브 반복 시 URL 하나의 결과로 전부 덮어쓰는 사고 방지).

## 2. `check_description_quality.py` — 사각지대 해소

`count_blurb_quality()` 추가. 기존 body 스캔은 *꼬리*(광고 잔여물, 잘린 숫자)만 봤을 뿐 "이 블러브가 기사에 대한 것이긴 한가"를 묻지 않았습니다. 그래서 이 드리프트가 몇 달간 관측되지 않았습니다.

실측(최근 14일): **front matter 99.5% 정상 · URL 블러브 크롬 83/497 (16.7%)**.

## 3. 실행에서 드러난 결함 (전부 회귀 테스트로 고정)

전체 코퍼스에 적용한 뒤 diff 를 읽고 되돌렸습니다. 커밋 전이라 손실은 없습니다.

| # | 결함 | 증상 |
|---|---|---|
| 1 | HTML 엔티티 이중 이스케이프 | 원문의 `&hellip;` 를 그대로 escape → `&amp;hellip;` 로 저장, 화면에 문자열 노출 |
| 2 | 길이 상한 없음 | meta description 이 없는 페이지는 fetcher 가 본문을 통째로 반환 → 한두 문장짜리 카드에 400~800자 유입 |
| 3 | 새 크롬 유입 | 광고 꼬리(`"Priority Gold에서 무료 가이드 받기"`), 기관 슬로건(`"혁신적 금융, 포용적 금융, 신뢰받는 금융, 금융위원회 입니다."`) |
| 4 | 리포트 카운트 오류 | `블러브 50건 / 포스트 62개` — 블러브보다 포스트가 많다(치환이 스킵된 포스트까지 계수) |

수정: unescape 선행 · 300자 문장경계 트림 · `_strip_trailing_artifacts` 위임 + 기관 슬로건 패턴 · 실제 기록된 포스트만 계수.

## 4. 합성 폴백은 껐습니다 (`--skip-synthetic`)

dry-run 실측: 재수집 523건은 명확한 개선이었지만 합성 417건은 **상당수가 원문보다 나빴습니다**.

> before: `FBI 요원, 러시아에서 약 100만 달러 규모 암호화폐를 훔친 혐의로 기소`
> after: `FBI 요원, … 기소 - The Hill. (100만) 주요 키워드: 요원, 러시아에서`

출처 접미사·중복 마침표·불용어 키워드가 붙습니다. 원래 계획은 "재수집 우선 + 실패 시 합성"이었으나, 실측 결과 합성 절반은 개선이 아니어서 플래그로 분리했습니다. 합성기 자체 개선은 별건입니다.

## 5. 백필은 왜 이 PR 에 없는가 — 레이트리밋

불량 블러브의 **90%가 `news.google.com` 리다이렉트**이고, Google 이 리졸버를 강하게 조입니다. 연속 실행 수율:

| 실행 | 재수집 성공 |
|---|---|
| 1회차 (dry-run) | 523 / 2325 |
| 2회차 (apply) | 71 / 2325 |
| 3회차 (재적용) | **0 / 60** |

3회차엔 모든 Google News 링크가 빈 값을 반환했습니다. **같은 시점에 직접 퍼블리셔 URL 은 정상**(148자 회수)이었으므로 상한은 이 도구가 아니라 리다이렉트 리졸버입니다 — 내 수정이 깨뜨린 게 아님을 이렇게 분리 확인했습니다.

따라서 백필은 `--limit` 로 수백 건씩 간격을 두고 돌려야 하며, docstring 에 명시했습니다. 한 번에 밀어넣는 마이그레이션으로는 완결되지 않습니다.

## 검증

```
$ python3 -m pytest tests/ -q -p no:randomly
5062 passed, 16 skipped
Required test coverage of 70% reached. Total coverage: 72.73%

$ python3 -m ruff check scripts/ tests/          # All checks passed!
$ python3 -m ruff format --check scripts/ tests/ # 267 files already formatted
$ python3 -m basedpyright <신규/변경 3파일>       # 0 errors, 0 warnings, 0 notes
```

신규 테스트 36건(도구) + 6건(지표).

🤖 Generated with [Claude Code](https://claude.com/claude-code)