### PR TITLE
fix: 합성 요약 출력 품질 — 출처 접미사·불용어 키워드·중복 마침표

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 49 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 130 |
+| 테스트 파일 (tests/test_*.py) | 131 |
 
 <!-- component-counts:end -->

--- a/scripts/common/enrichment_synthetic.py
+++ b/scripts/common/enrichment_synthetic.py
@@ -712,11 +712,15 @@ def _analyze_korean_title(title: str) -> str:
         return _join_clauses(clean[:120], f"{context_suffix.strip()} 기업 실적 보도.".strip())
 
     # Fallback: use clean title + entity context
-    if kr_entities:
-        entity_str = ", ".join(kr_entities)
-        return _join_clauses(clean[:120], f"{context_suffix.strip()} 주요 키워드: {entity_str}.".strip())
+    # A figure lifted from the title informs; a bag of the title's own words
+    # does not. When both are available the number wins and the keyword tail is
+    # dropped — emitting "(3.2% 변동) 주요 키워드: 국내, 관광객, 늘어난." padded
+    # the sentence without adding anything.
     if context_suffix:
         return _join_clauses(clean[:120], context_suffix.strip())
+    if kr_entities:
+        entity_str = ", ".join(kr_entities)
+        return _join_clauses(clean[:120], f"주요 키워드: {entity_str}.")
     return _join_clauses(clean[:150]) if len(clean) > 15 else _join_clauses(title)
 
 

--- a/scripts/common/enrichment_synthetic.py
+++ b/scripts/common/enrichment_synthetic.py
@@ -469,16 +469,197 @@ _KOREAN_TITLE_CATEGORIES: Dict[str, str] = {
 _KOREAN_TITLE_KW_SETS: list = [(frozenset(k.split("|")), v) for k, v in _KOREAN_TITLE_CATEGORIES.items()]
 
 
+# ---------------------------------------------------------------------------
+# Output hygiene for synthesised descriptions (2026-08-06).
+#
+# The 2026-08-06 backfill dry-run synthesised 417 replacements and a large share
+# read worse than the title restatement they replaced. Three causes, each fixed
+# below and pinned in tests/test_enrichment_synthetic_quality.py.
+# ---------------------------------------------------------------------------
+
+# Outlet suffix: `… - The Hill`, `… | 공감신문`. Bounded and digit-free so an
+# informative subtitle ("삼성전자 - 2분기 영업이익 14조 원") is left alone; the
+# previous single-token pattern (`\S+$`) stripped 프리진경제 but not "The Hill".
+_SOURCE_SUFFIX_RE = re.compile(r"\s*[-–—|]\s*(?![^-–—|]*\d)[^-–—|]{2,20}$")
+
+# Grammatical particles that ride along when Hangul runs are taken verbatim,
+# turning "러시아" into the non-word "러시아에서".
+_KO_PARTICLES = (
+    "에서의",
+    "으로서",
+    "으로써",
+    "에게서",
+    "이라는",
+    "라는",
+    "에서",
+    "에게",
+    "으로",
+    "부터",
+    "까지",
+    "보다",
+    "처럼",
+    "만큼",
+    "조차",
+    "마저",
+    "에",
+    "은",
+    "는",
+    "이",
+    "가",
+    "을",
+    "를",
+    "의",
+    "와",
+    "과",
+    "로",
+    "도",
+    "만",
+    "및",
+)
+
+# Adverbs, conjunctions and reporting verbs that carry no topical information.
+_KO_STOPWORDS = frozenset(
+    {
+        "그리고",
+        "그러나",
+        "따라서",
+        "하지만",
+        "그런데",
+        "이렇게",
+        "그래서",
+        "또한",
+        "다만",
+        "따르면",
+        "일제히",
+        "관련",
+        "대해",
+        "위해",
+        "통해",
+        "대한",
+        "가장",
+        "이번",
+        "올해",
+        "지난",
+        "최근",
+        "오늘",
+        "내일",
+        "어제",
+        "우리",
+        "자신",
+        "경우",
+        "이후",
+        "이전",
+        "예정",
+        "전망",
+        "발표",
+        "기록",
+        "확인",
+        "가능",
+        "필요",
+        "시작",
+        "종료",
+        "진행",
+        "연구",
+        "선정",
+        "규모",
+        "혐의",
+        "결과",
+        "상황",
+        "내용",
+        "설명",
+        "언급",
+        "제기",
+    }
+)
+
+# Conjugated predicates. A Hangul run ending in one of these is a verb phrase,
+# not a topic — "하락했습니다" read as a keyword in the first filtering pass.
+_KO_PREDICATE_ENDINGS = (
+    "습니다",
+    "합니다",
+    "됩니다",
+    "입니다",
+    "했다",
+    "한다",
+    "된다",
+    "였다",
+    "이다",
+    "있다",
+    "없다",
+    "간다",
+    "온다",
+    "했고",
+    "하며",
+    "되며",
+    "하고",
+    "되고",
+    "할까",
+    "될까",
+)
+
+# Bare units and currencies: the figure carries the information, the unit alone
+# does not ("주요 키워드: 요원, 러시아, 달러").
+_KO_UNIT_WORDS = frozenset({"달러", "원화", "유로", "엔화", "위안", "포인트", "퍼센트", "억원", "조원"})
+
+_SENTENCE_ENDERS = (".", "!", "?", "…")
+
+
+def _strip_source_suffix(title: str) -> str:
+    """Drop a trailing outlet name, keeping informative subtitles."""
+    return _SOURCE_SUFFIX_RE.sub("", title).strip()
+
+
+def _strip_particle(token: str) -> str:
+    """Remove one trailing grammatical particle, longest match first."""
+    for particle in _KO_PARTICLES:
+        if token.endswith(particle) and len(token) - len(particle) >= 2:
+            return token[: -len(particle)]
+    return token
+
+
+def korean_keywords(title: str, limit: int = 3) -> list:
+    """Topical Hangul keywords from a title, or ``[]`` when none survive.
+
+    Returning an empty list is a real outcome: a `주요 키워드:` label with one
+    filler word under it is worse than no label, so callers omit the clause.
+    """
+    seen: list = []
+    for raw in re.findall(r"[가-힣]{2,}", title):
+        token = _strip_particle(raw)
+        if len(token) < 2 or token in seen:
+            continue
+        if token in _KO_STOPWORDS or token in _KO_UNIT_WORDS:
+            continue
+        if token.endswith(_KO_PREDICATE_ENDINGS):
+            continue
+        seen.append(token)
+        if len(seen) >= limit:
+            break
+    return seen if len(seen) >= 2 else []
+
+
+def _join_clauses(head: str, *tails: str) -> str:
+    """Join a title with generated clauses without doubling terminators."""
+    text = head.strip()
+    if text and not text.endswith(_SENTENCE_ENDERS):
+        text += "."
+    for tail in tails:
+        tail = tail.strip()
+        if tail:
+            text = f"{text} {tail}".strip()
+    return text
+
+
 def _analyze_korean_title(title: str) -> str:
     """Analyze a Korean news title and generate a fact-based description.
 
     Produces clean, factual descriptions based on the title content
     rather than speculative or template-heavy commentary.
     """
-    clean = re.sub(r"\s*[-–—|]\s*\S+$", "", title).strip()
+    clean = _strip_source_suffix(title)
     pct = re.search(r"(\d+(?:\.\d+)?)\s*%", title)
     amount = re.search(r"(\d[\d,.]*)\s*(?:억|조|만|원|달러)", title)
-    kr_entities = re.findall(r"[가-힣]{2,}", title)[:3]
+    kr_entities = korean_keywords(title)
 
     # Build context suffix from extracted data
     context_parts = []
@@ -491,50 +672,52 @@ def _analyze_korean_title(title: str) -> str:
     # Circuit breaker / market crash
     if any(kw in title for kw in ["서킷브레이커", "사이드카"]):
         trigger = "매수 사이드카" if "매수" in title else "서킷브레이커/사이드카"
-        return f"{clean[:120]}. {trigger} 발동{context_suffix}."
+        return _join_clauses(clean[:120], f"{trigger} 발동{context_suffix}.")
 
     # Crash / panic
     if any(kw in title for kw in ["폭락", "급락", "패닉"]):
-        return f"{clean[:120]}.{context_suffix} 급락 관련 보도."
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} 급락 관련 보도.".strip())
 
     # Semiconductor
     if any(kw in title for kw in ["삼성전자", "하이닉스", "반도체"]):
-        return f"{clean[:120]}.{context_suffix} 반도체 섹터 보도."
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} 반도체 섹터 보도.".strip())
 
     # Fixed-response categories via dict table
     for kw_set, category_label in _KOREAN_TITLE_KW_SETS:
         if any(kw in title for kw in kw_set):
-            return f"{clean[:120]}.{context_suffix} {category_label}"
+            return _join_clauses(clean[:120], f"{context_suffix.strip()} {category_label}".strip())
 
     # Crypto majors
     if any(kw in title for kw in ["비트코인", "이더리움", "알트코인", "리플"]):
-        return f"{clean[:120]}.{context_suffix} 암호화폐 시장 보도."
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} 암호화폐 시장 보도.".strip())
 
     # DeFi / digital assets
     if any(kw in title for kw in ["디파이", "디지털자산", "가상자산", "코인", "블록체인"]):
-        return f"{clean[:120]}.{context_suffix} 디지털 자산 보도."
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} 디지털 자산 보도.".strip())
 
     # AI / tech
     if any(kw in title for kw in ["AI", "인공지능", "챗봇", "생성형"]):
-        return f"{clean[:120]}.{context_suffix} AI 산업 보도."
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} AI 산업 보도.".strip())
 
     # EV / battery
     if any(kw in title for kw in ["2차전지", "배터리", "전기차", "EV"]):
-        return f"{clean[:120]}.{context_suffix} 전기차·배터리 보도."
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} 전기차·배터리 보도.".strip())
 
     # Foreign / institutional flow
     if any(kw in title for kw in ["외국인", "기관", "순매수", "순매도", "수급"]):
-        return f"{clean[:120]}.{context_suffix} 수급 동향 보도."
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} 수급 동향 보도.".strip())
 
     # Earnings
     if any(kw in title for kw in ["실적", "어닝", "매출", "영업이익"]):
-        return f"{clean[:120]}.{context_suffix} 기업 실적 보도."
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} 기업 실적 보도.".strip())
 
     # Fallback: use clean title + entity context
     if kr_entities:
-        entity_str = ", ".join(kr_entities[:3])
-        return f"{clean[:120]}.{context_suffix} 주요 키워드: {entity_str}."
-    return clean[:150] if len(clean) > 15 else title
+        entity_str = ", ".join(kr_entities)
+        return _join_clauses(clean[:120], f"{context_suffix.strip()} 주요 키워드: {entity_str}.".strip())
+    if context_suffix:
+        return _join_clauses(clean[:120], context_suffix.strip())
+    return _join_clauses(clean[:150]) if len(clean) > 15 else _join_clauses(title)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_enrichment_synthetic_quality.py
+++ b/tests/test_enrichment_synthetic_quality.py
@@ -153,3 +153,14 @@ def test_keyword_tail_excludes_predicates_and_units(title: str, junk: str) -> No
     if "주요 키워드" in result:
         tail = result.split("주요 키워드:", 1)[1]
         assert junk not in tail
+
+
+def test_numeric_context_is_preferred_over_a_keyword_bag() -> None:
+    """A figure from the title informs; a bag of its own words does not.
+
+    The fallback branch used to reach for `주요 키워드:` first, so a title
+    carrying a percentage got a word list instead of the number.
+    """
+    result = _synth("국내 관광객 수 3.2% 늘어난 것으로 집계")
+    assert "3.2%" in result
+    assert "주요 키워드" not in result

--- a/tests/test_enrichment_synthetic_quality.py
+++ b/tests/test_enrichment_synthetic_quality.py
@@ -1,0 +1,155 @@
+"""Output-quality tests for the synthetic description generator.
+
+`tests/test_enrichment.py` covers which category branch a title routes to.
+These cover what the reader actually sees, which is a different question — a
+correctly-categorised description can still be unpublishable.
+
+The three defects pinned here were measured on the 2026-08-06 backfill dry-run:
+of 417 synthesised replacements, a large share read worse than the title
+restatement they were meant to improve. That is why
+`fix_post_url_summaries.py` ships with `--skip-synthetic`; these tests are the
+precondition for turning it back on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from common.enrichment_synthetic import generate_synthetic_description
+
+
+def _synth(title: str, source: str = "") -> str:
+    return generate_synthetic_description(title, source, None)
+
+
+# ---------------------------------------------------------------------------
+# 1. Source suffix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("title", "source_name"),
+    [
+        ("FBI 요원, 러시아에서 약 100만 달러 규모의 암호화폐를 훔친 혐의로 기소 - The Hill", "The Hill"),
+        ("코스피, 롤러코스터 장세 끝에 1.6%↑ - 프리진경제", "프리진경제"),
+        ("삼성전자·SK하이닉스, 주식시장 상승세 | 공감신문", "공감신문"),
+        ("비트코인 8% 급등, 기관 매수세 유입 — Bloomberg News", "Bloomberg News"),
+    ],
+)
+def test_source_suffix_is_dropped(title: str, source_name: str) -> None:
+    """A trailing outlet name is metadata, not part of the summary.
+
+    The single-token pattern that shipped stripped `- 프리진경제` but left
+    `- The Hill`, so multi-word outlets survived into published text.
+    """
+    assert source_name not in _synth(title)
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        # Not an outlet: a real subtitle carrying the substance of the story.
+        "삼성전자 - 2분기 영업이익 14조 원으로 32% 증가",
+        "코스피 급등 - 외국인 순매수 1조 2000억 원 유입",
+    ],
+)
+def test_informative_tail_is_kept(title: str) -> None:
+    """Only outlet-shaped tails go. A tail carrying figures is the story."""
+    result = _synth(title)
+    assert "조" in result or "억" in result or "%" in result
+
+
+# ---------------------------------------------------------------------------
+# 2. Keyword tail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("title", "junk"),
+    [
+        ("FBI 요원, 러시아에서 약 100만 달러 규모의 암호화폐를 훔친 혐의로 기소", "러시아에서"),
+        ("연구에 따르면 플로리다는 암호화폐 사기 손실이 가장 많은 주로 선정되었습니다", "따르면"),
+        ("美 증시 3대 지수 일제히 하락했습니다", "일제히"),
+    ],
+)
+def test_keyword_tail_excludes_particles_and_filler(title: str, junk: str) -> None:
+    """`주요 키워드: 요원, 러시아에서, 달러` is noise wearing a label.
+
+    Hangul runs were taken verbatim, so particle-suffixed fragments
+    (`러시아에서`) and adverbs (`일제히`, `따르면`) were presented as keywords.
+    """
+    result = _synth(title)
+    if "주요 키워드" in result:
+        tail = result.split("주요 키워드:", 1)[1]
+        assert junk not in tail
+
+
+def test_keyword_tail_is_omitted_when_nothing_survives_filtering() -> None:
+    """A label with one filler word under it is worse than no label."""
+    result = _synth("그리고 그러나 따라서 하지만 그런데 이렇게")
+    assert "주요 키워드" not in result
+
+
+def test_keyword_tail_keeps_real_entities() -> None:
+    """Filtering must not empty out titles that do carry entities."""
+    result = _synth("현대차와 기아, 미국 관세 협상 결과에 촉각")
+    if "주요 키워드" in result:
+        tail = result.split("주요 키워드:", 1)[1]
+        assert "현대차" in tail or "기아" in tail
+
+
+# ---------------------------------------------------------------------------
+# 3. Punctuation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "美 증시 3대 지수 일제히 하락했습니다.",
+        "코스피가 2,900선을 회복했다.",
+        "비트코인 급등!",
+        "이번에도 반등할까?",
+    ],
+)
+def test_no_doubled_sentence_punctuation(title: str) -> None:
+    """A title that already ends a sentence must not gain a second terminator."""
+    result = _synth(title)
+    assert ".." not in result
+    assert "!." not in result
+    assert "?." not in result
+
+
+def test_output_still_ends_as_a_sentence() -> None:
+    result = _synth("코스피가 2,900선을 회복했다")
+    assert result.rstrip().endswith((".", "!", "?"))
+
+
+# ---------------------------------------------------------------------------
+# Regression: the generator must still say something
+# ---------------------------------------------------------------------------
+
+
+def test_output_is_not_empty_for_a_plain_title() -> None:
+    assert _synth("한국은행 기준금리 동결 결정").strip()
+
+
+@pytest.mark.parametrize(
+    ("title", "junk"),
+    [
+        ("美 증시 3대 지수 일제히 하락했습니다", "하락했습니다"),
+        ("코스피가 2,900선을 회복했다", "회복했다"),
+        ("한국은행이 기준금리를 동결한다", "동결한다"),
+        ("FBI 요원, 러시아에서 약 100만 달러 규모의 암호화폐 절도", "달러"),
+    ],
+)
+def test_keyword_tail_excludes_predicates_and_units(title: str, junk: str) -> None:
+    """A conjugated verb is not a keyword, and neither is a bare currency unit.
+
+    `주요 키워드: 증시, 지수, 하락했습니다` survived the first pass of filtering —
+    the particle strip does not touch verb endings.
+    """
+    result = _synth(title)
+    if "주요 키워드" in result:
+        tail = result.split("주요 키워드:", 1)[1]
+        assert junk not in tail


### PR DESCRIPTION
## 배경

#1081 백필 dry-run 에서 합성 417건 중 상당수가 **원문(제목 재진술)보다 나빴습니다**. 그래서 백필 도구가 `--skip-synthetic` 을 달고 나갔고, 이 PR 은 그 플래그를 되돌릴 수 있는지 판단하기 위한 선행 작업입니다.

## 세 결함

### 1. 출처 접미사 잔존

`\s*[-–—|]\s*\S+$` 는 **단일 토큰만** 잡습니다. `- 프리진경제` 는 지우고 `- The Hill` 은 남겼습니다.

다중 토큰을 허용하되 길이(2~20자)와 숫자 제외로 조여, 정보가 담긴 부제는 보존합니다:

- `"삼성전자 - 2분기 영업이익 14조 원으로 32% 증가"` → 꼬리에 숫자가 있으므로 유지
- `"… 기소 - The Hill"` → 제거

### 2. 불용어/파편 키워드

한글 런을 그대로 잘라 써서 조사 붙은 파편(`러시아에서`), 부사(`일제히`, `따르면`), 서술어(`하락했습니다`), 단위(`달러`)가 `주요 키워드:` 라벨을 달고 나갔습니다. `_COMMON_WORDS` 에는 **한글 항목이 0개**라 사실상 필터가 없었습니다.

조사 제거 + 불용어/단위/서술어 어미 필터를 추가하고, 살아남은 키워드가 2개 미만이면 **라벨 자체를 생략**합니다 — filler 한 단어짜리 라벨은 없느니만 못합니다.

### 3. 중복 마침표

`f"{clean}.{suffix}"` 가 이미 마침표로 끝나는 제목에 하나를 더 붙였습니다. 종결부호를 확인하고 잇는 헬퍼로 통일했습니다.

### 4. 폴백 순서 (추가)

수치와 키워드를 둘 다 붙여 `(3.2% 변동) 주요 키워드: 국내, 관광객, 늘어난.` 이 됐습니다. 제목에서 뽑은 **수치는 정보를 더하지만 제목 자신의 단어 주머니는 그렇지 않으므로**, 수치가 있으면 그것만 씁니다.

## before / after

```
before: 美 증시 3대 지수 일제히 하락했습니다.. 주요 키워드: 증시, 지수, 일제히.
after : 美 증시 3대 지수 일제히 하락했습니다. 주요 키워드: 증시, 지수.

before: FBI 요원 … 기소 - The Hill. (100만) 주요 키워드: 요원, 러시아에서, 달러.
after : FBI 요원 … 기소. (100만)

before: 국내 관광객 수 3.2% … 집계. (3.2% 변동) 주요 키워드: 국내, 관광객, 늘어난.
after : 국내 관광객 수 3.2% … 집계. (3.2% 변동)
```

## `--skip-synthetic` 해제 판단 — **아직 하지 않기를 권합니다**

실제 백필 대상 제목 300건으로 오프라인 평가했습니다(네트워크 불필요):

| 지표 | 결과 |
|---|---|
| 합성 결과가 품질 게이트를 통과 | **67 / 300 (22.3%)** |
| 키워드 주머니가 남는 비율 | 60 / 300 (20%) |

통과한 것들도 대체로 `제목 + 카테고리 라벨`(`급락 관련 보도.`) 수준이라, 원문이 `제목 + 출처명` 인 경우 대비 개선폭이 크지 않습니다. 재수집이 가능할 때는 재수집이 명백히 우월하므로, **백필 기본값은 `--skip-synthetic` 유지**를 권합니다.

다만 이 수정은 **실시간 수집에서 의미가 있습니다** — 거기서는 합성이 유일한 폴백이라, `주요 키워드: 러시아에서, 달러` 나 `..` 가 그대로 발행되고 있었습니다.

## 검증

```
$ python3 -m pytest tests/ -q -p no:randomly
5105 passed, 16 skipped · Total coverage: 72.78%

$ python3 -m ruff check scripts/ tests/          # All checks passed!
$ python3 -m ruff format --check scripts/ tests/ # clean
$ python3 -m basedpyright scripts/common/enrichment_synthetic.py  # 0 errors
```

TDD 로 진행 — 신규 테스트 22건 중 10건 RED 확인 후 구현. 작성 중 테스트 케이스 하나가 폴백이 아니라 카테고리 분기에 걸리는 걸 발견해 실제로 폴백을 타는 제목으로 교체했습니다(통과했더라도 대상 코드를 검증하지 못하는 케이스였습니다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)