### PR TITLE
fix: 권한 감사 잡 차단 전환 + falsifiability 하네스 8샤드 병렬화

### DIFF
--- a/.github/workflows/guard-falsifiability.yml
+++ b/.github/workflows/guard-falsifiability.yml
@@ -45,7 +45,24 @@ jobs:
     runs-on: ubuntu-latest
     # 케이스당 pytest 를 2회(patched/control) 띄우므로 47종 = 94회 프로세스 기동.
     # 가드 테스트 자체는 각 1초 미만이고 대부분이 인터프리터 시작 비용이다.
-    timeout-minutes: 20
+    #
+    # 샤딩: 케이스가 **실제 레포 파일**을 변형했다 복원하므로 한 체크아웃 안에서
+    # 병렬로 돌릴 수 없다(두 케이스가 같은 파일을 노리면 서로의 복원을 덮어쓴다).
+    # 대신 매트릭스로 나눠 샤드마다 독립 체크아웃을 쓴다. 분할이 정확한지는
+    # tests/test_guard_falsifiability_shard.py 가 강제한다 — 조용히 빠진 케이스는
+    # 가드 하나가 검증되지 않은 채 CI 가 그린인 상태를 만든다.
+    #
+    # 실측 추이: 11케이스 1m44s -> 37케이스 3m49s -> 47케이스 4m09s (약 5s/케이스).
+    # 8샤드면 샤드당 6케이스 안팎으로 ~1분.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    # 샤드 수는 매트릭스 길이에서 파생한다. `/8` 을 하드코딩하면 매트릭스를
+    # 줄였을 때 남는 샤드의 케이스가 조용히 미실행된다 — 정확히 이 하네스가
+    # 막으려는 종류의 침묵이다.
+    name: falsifiability (${{ matrix.shard }}/${{ strategy.job-total }})
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -65,7 +82,7 @@ jobs:
       - name: Run falsifiability harness
         # 하네스는 tests/conftest.py 를 덮어썼다 복원한다. 러너 체크아웃은
         # 일회성이고 permissions 도 read 이므로 유출 경로가 없다.
-        run: python scripts/tools/guard_falsifiability.py --check
+        run: python scripts/tools/guard_falsifiability.py --check --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: Verify working tree restored
         # 하네스가 finally 에서 복원하지 못하고 죽는 회귀를 잡는다. 대상은 두 가지:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,12 +6,16 @@ on:
     branches: [main]
     paths:
       - 'scripts/**'
-      - '.github/workflows/security-scan.yml'
+      - '.github/workflows/**'
       - '.gitleaks.toml'
   pull_request:
     branches: [main]
     paths:
       - 'scripts/**'
+      # 권한 감사가 의미를 가지려면 워크플로우 변경에서 돌아야 한다. 이전 필터는
+      # `scripts/**` 와 `.gitleaks.toml` 뿐이어서, 새 워크플로우를 permissions
+      # 블록 없이 추가해도 이 잡이 실행조차 되지 않았다.
+      - '.github/workflows/**'
       - '.gitleaks.toml'
   schedule:
     - cron: '0 3 * * 1'  # Every Monday 03:00 UTC
@@ -125,8 +129,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
+      # 이 잡은 2026-08-06 감사 전까지 **build 를 실패시킬 수 없었다**:
+      #   - 모든 발견이 `::warning::` 이고 어떤 경로로도 exit 하지 않았다.
+      #   - 액션 핀닝 체크의 `has_issues=true` 는 `grep ... | while` 파이프라인
+      #     서브셸에 갇혀 전파조차 되지 않았다.
+      #   - `grep -v '@v'` 가 문제의 대상인 가변 태그를 "핀됨"으로 분류했다.
+      # 즉 "감사"라는 이름으로 잘못된 안심을 주고 있었다. 이제 차단한다.
+      #
+      # 액션 핀닝은 여기서 빠졌다 — `tests/test_workflow_action_pinning_guard.py`
+      # 가 40-hex SHA 핀을 blocking pytest 로 강제하고, falsifiability 하네스가
+      # 그 가드가 vacuous 하지 않음을 매 PR 검증한다. 여기 grep 을 남겨두면
+      # 같은 불변식을 두 곳에서, 그것도 한쪽은 틀리게 검사하는 셈이다.
       - name: Audit workflow permissions
+        shell: bash
         run: |
+          set -euo pipefail
+
           echo "## Workflow Permissions Audit" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
@@ -135,27 +153,25 @@ jobs:
           for wf in .github/workflows/*.yml; do
             name=$(basename "$wf")
 
-            # Check for overly permissive permissions (use word boundary to avoid self-match)
+            # 과대 권한: 최소권한 원칙 위반. GITHUB_TOKEN 노출면이 전 스코프로 열린다.
             if grep -qP '^permissions:\s+write-all' "$wf" 2>/dev/null; then
-              echo "::warning file=$wf::Uses write-all permissions - consider restricting"
-              echo "- :warning: \`$name\`: Uses \`write-all\` permissions" >> "$GITHUB_STEP_SUMMARY"
+              echo "::error file=$wf::Uses write-all permissions"
+              echo "- :x: \`$name\`: Uses \`write-all\` permissions" >> "$GITHUB_STEP_SUMMARY"
               has_issues=true
             fi
 
-            # Check for missing permissions block (top-level only)
+            # 최상위 permissions 누락: 레포 기본값(대개 write)이 그대로 적용된다.
             if ! grep -qP '^permissions:' "$wf" 2>/dev/null; then
-              echo "::warning file=$wf::Missing explicit permissions block"
-              echo "- :warning: \`$name\`: Missing explicit \`permissions:\` block" >> "$GITHUB_STEP_SUMMARY"
+              echo "::error file=$wf::Missing explicit permissions block"
+              echo "- :x: \`$name\`: Missing explicit \`permissions:\` block" >> "$GITHUB_STEP_SUMMARY"
               has_issues=true
             fi
-
-            # Check for unpinned third-party actions (not GitHub official)
-            grep -n 'uses:' "$wf" | grep -v 'actions/' | grep -v '@v' | grep -v '\./' | grep -v '#' | while read -r line; do
-              echo "::warning file=$wf::Unpinned third-party action: $line"
-              has_issues=true
-            done
           done
 
-          if [ "$has_issues" = false ]; then
-            echo "All workflows passed permissions audit." >> "$GITHUB_STEP_SUMMARY"
+          if [ "$has_issues" = true ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "권한 감사 실패 — 위 워크플로우에 최소권한 \`permissions:\` 블록을 명시하세요." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
+
+          echo "All workflows passed permissions audit." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 49 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 131 |
+| 테스트 파일 (tests/test_*.py) | 132 |
 
 <!-- component-counts:end -->

--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -395,6 +395,36 @@ STATIC_CASES: tuple[StaticCase, ...] = (
 )
 
 
+def parse_shard(spec: str) -> tuple[int, int]:
+    """``"2/5"`` -> ``(2, 5)``. Index is 1-based, as it appears in CI job names."""
+    try:
+        index_text, total_text = spec.split("/", 1)
+        index, total = int(index_text), int(total_text)
+    except ValueError as exc:
+        raise SystemExit(f"--shard 형식은 'N/M' 이다 (받은 값: {spec!r})") from exc
+    if total < 1 or not (1 <= index <= total):
+        raise SystemExit(f"--shard 범위 오류: 1 <= N <= M 이어야 한다 (받은 값: {spec!r})")
+    return index, total
+
+
+def select_shard(items: list, shard: tuple[int, int] | None) -> list:
+    """Round-robin slice of ``items`` for one shard.
+
+    Round-robin rather than contiguous blocks: cases are grouped by guard file
+    in source order, so a contiguous split would put every coverage case in one
+    shard and every tree-write case in another, making shard runtimes lopsided.
+    Interleaving spreads the slow ones evenly.
+
+    Every item lands in exactly one shard for any (index, total), so a run split
+    across shards covers the same set as an unsharded run — asserted in
+    ``tests/test_guard_falsifiability.py``.
+    """
+    if shard is None:
+        return list(items)
+    index, total = shard
+    return [item for position, item in enumerate(items) if position % total == index - 1]
+
+
 def apply_static_mutation(source: str, case: StaticCase) -> str:
     """정적 케이스의 변형을 적용한다.
 
@@ -531,10 +561,10 @@ def _verdict(rc_mutated: int, rc_control: int) -> str:
     return "CONTROL-FAIL"
 
 
-def _run_static_cases() -> list[dict]:
+def _run_static_cases(shard: tuple[int, int] | None = None) -> list[dict]:
     """정적 가드 케이스를 검증한다 (각각 자기 대상 파일만 변형/복원)."""
     results: list[dict] = []
-    for case in STATIC_CASES:
+    for case in select_shard(list(STATIC_CASES), shard):
         target = REPO_ROOT / case.target
         original = target.read_text(encoding="utf-8")
         try:
@@ -570,17 +600,23 @@ def _run_static_cases() -> list[dict]:
     return results
 
 
-def run_all() -> list[dict]:
-    """모든 케이스를 검증하고 결과 리스트를 돌려준다."""
+def run_all(shard: tuple[int, int] | None = None) -> list[dict]:
+    """모든 케이스를 검증하고 결과 리스트를 돌려준다.
+
+    ``shard`` 가 주어지면 해당 샤드에 배정된 케이스만 실행한다. 드리프트 검사
+    (CASES 미등록 fixture)는 샤드와 무관하게 항상 전수로 돈다 — 특정 샤드에서만
+    보이는 미등록 fixture 는 없고, 누락은 어느 샤드에서든 즉시 드러나야 한다.
+    """
     _assert_safe_to_run()
     original = CONFTEST.read_text(encoding="utf-8")
     state_snapshot = _snapshot_state()
 
     unmapped = [f for f in discover_autouse_fixtures(original) if f not in CASES]
+    fixture_cases = select_shard(list(CASES.items()), shard)
 
     results: list[dict] = []
     try:
-        for name, node in CASES.items():
+        for name, node in fixture_cases:
             patched = (
                 _disable_module_level(original) if name == _MODULE_LEVEL_CASE else _disable_fixture(original, name)
             )
@@ -618,7 +654,7 @@ def run_all() -> list[dict]:
             }
         )
 
-    results.extend(_run_static_cases())
+    results.extend(_run_static_cases(shard))
     return results
 
 
@@ -641,9 +677,10 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--json", action="store_true", help="JSON 출력")
     mode.add_argument("--check", action="store_true", help="vacuous/미등록 시 exit 1 (CI)")
+    parser.add_argument("--shard", metavar="N/M", help="N번째/M개 샤드만 실행 (CI 매트릭스용)")
     args = parser.parse_args()
 
-    results = run_all()
+    results = run_all(parse_shard(args.shard) if args.shard else None)
 
     if args.json:
         print(json.dumps(results, ensure_ascii=False, indent=2))

--- a/tests/test_guard_falsifiability_shard.py
+++ b/tests/test_guard_falsifiability_shard.py
@@ -1,0 +1,59 @@
+"""Sharding correctness for the falsifiability harness.
+
+The harness mutates real repository files, so two cases that target the same
+file cannot run concurrently in one checkout. CI parallelises by *sharding*
+instead: each matrix job gets a disjoint slice and its own checkout.
+
+That only holds if the partition is exact. A shard split that silently dropped
+a case would leave a guard unverified while CI stayed green — the same class of
+failure the harness exists to catch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tools.guard_falsifiability import CASES, STATIC_CASES, parse_shard, select_shard
+
+
+@pytest.mark.parametrize("total", [1, 2, 3, 5, 8, 47, 64])
+def test_shards_partition_every_case_exactly_once(total: int) -> None:
+    """Union of all shards == the full list, with no duplicates."""
+    items = list(range(len(CASES) + len(STATIC_CASES)))
+    collected: list[int] = []
+    for index in range(1, total + 1):
+        collected.extend(select_shard(items, (index, total)))
+
+    assert sorted(collected) == items
+    assert len(collected) == len(set(collected)), "a case landed in more than one shard"
+
+
+def test_no_shard_argument_runs_everything() -> None:
+    items = list(range(10))
+    assert select_shard(items, None) == items
+
+
+def test_shards_are_balanced_within_one_case() -> None:
+    """Round-robin keeps sizes within 1 of each other, so no shard is the tail."""
+    items = list(range(47))
+    sizes = [len(select_shard(items, (i, 8))) for i in range(1, 9)]
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_more_shards_than_cases_yields_empty_slices_not_errors() -> None:
+    items = list(range(3))
+    slices = [select_shard(items, (i, 6)) for i in range(1, 7)]
+    assert sum(len(s) for s in slices) == 3
+    assert any(s == [] for s in slices)
+
+
+@pytest.mark.parametrize("spec", ["3/8", "1/1", "8/8"])
+def test_parse_shard_accepts_valid_specs(spec: str) -> None:
+    index, total = parse_shard(spec)
+    assert 1 <= index <= total
+
+
+@pytest.mark.parametrize("spec", ["0/8", "9/8", "-1/4", "3/0", "abc", "3", "3/x", ""])
+def test_parse_shard_rejects_invalid_specs(spec: str) -> None:
+    """A malformed spec must stop the run, not silently verify a subset."""
+    with pytest.raises(SystemExit):
+        parse_shard(spec)


### PR DESCRIPTION
## 1. `actions-permissions` 잡 — "감사"인데 실패시킬 수 없었다

`security-scan.yml` 의 이 잡은 이름과 달리 **build 를 실패시킬 수 없는 구조**였습니다:

- 모든 발견이 `::warning::` 이고 어떤 경로로도 `exit` 하지 않음
- 액션 핀닝 체크의 `has_issues=true` 는 `grep ... | while` 파이프라인 **서브셸에 갇혀** 전파조차 안 됨
- `grep -v '@v'` 가 문제의 대상인 **가변 태그를 "핀됨"으로 분류**

즉 잘못된 안심을 주고 있었습니다.

### 변경

1. **차단으로 전환** — `write-all` / `permissions:` 누락 시 `exit 1`.
   실측 결과 현재 위반 **0건**(write-all 0, 누락 0)이라 켜도 아무 워크플로우가 깨지지 않습니다.
2. **액션 핀닝 grep 제거** — 같은 불변식을 `tests/test_workflow_action_pinning_guard.py` 가 blocking pytest 로 강제하고, falsifiability 하네스가 그 가드의 non-vacuous 를 매 PR 검증합니다. 틀린 grep 을 남겨두면 이중 검사 중 한쪽이 계속 오답입니다.
3. **트리거 `paths` 에 `.github/workflows/**` 추가** — 이전 필터는 `scripts/**` 와 `.gitleaks.toml` 뿐이라 **permissions 블록 없는 워크플로우를 새로 추가해도 이 잡이 실행조차 되지 않았습니다.** 감사의 전제가 빠져 있었습니다.

### 검증 (양방향)

| 상태 | 결과 |
|---|---|
| 현재 | `exit 0` |
| `write-all` 주입 | `exit 1` |
| `permissions:` 블록 제거 | `exit 1` |

> 첫 시뮬레이션은 전량 오탐이 났습니다 — `bash -c` 안에서 PATH 가 달라져 `-P` 미지원 BSD grep 으로 떨어졌기 때문입니다. CI 와 동일하게 `-P` 를 지원하는 grep 으로 다시 검증했습니다.

## 2. 하네스 8샤드 병렬화

### 왜 in-process 병렬이 아닌 샤딩인가

케이스가 **실제 레포 파일**을 변형했다 복원합니다. 한 체크아웃 안에서 병렬로 돌리면 같은 파일을 노리는 두 케이스가 서로의 복원을 덮어씁니다(예: `code-quality.yml` 을 노리는 케이스가 6개). 매트릭스로 나눠 샤드마다 독립 체크아웃을 쓰는 쪽이 유일하게 안전합니다.

### 실측 근거

| 케이스 수 | CI 실행시간 |
|---|---|
| 11 | 1m44s |
| 37 | 3m49s |
| 47 | **4m09s** |

약 5s/케이스(대부분 인터프리터 시작 비용). 8샤드면 샤드당 6케이스 안팎.

### 설계 결정

- **라운드로빈 분할** — 케이스가 가드 파일별로 소스 순서대로 묶여 있어 연속 블록으로 자르면 커버리지 케이스가 한 샤드에 몰립니다. 인터리빙으로 느린 케이스를 고르게 분산합니다(샤드 크기 편차 ≤1).
- **샤드 수를 `strategy.job-total` 에서 파생** — `/8` 을 하드코딩하면 매트릭스를 6으로 줄였을 때 7·8 샤드의 케이스가 **조용히 미실행**됩니다. 정확히 이 하네스가 막으려는 종류의 침묵입니다.
- **드리프트 검사는 샤드 무관 전수** — CASES 미등록 fixture 는 어느 샤드에서든 즉시 드러나야 합니다.
- `fail-fast: false` — 한 샤드가 red 여도 나머지 결과를 봐야 합니다.

### 검증

8샤드를 전부 로컬 실행해 분할이 전수를 정확히 덮는지 확인했습니다:

```
shard 1: 7/7   shard 5: 6/6
shard 2: 7/7   shard 6: 5/5
shard 3: 6/6   shard 7: 5/5
shard 4: 6/6   shard 8: 5/5
합계: 47/47 guards falsifiable
```

실행 후 워킹 트리 미복원 파일 **0건**.

분할 정확성은 `tests/test_guard_falsifiability_shard.py` 가 고정합니다 — 전수를 정확히 1회씩 덮는지(총 7가지 샤드 수), 균형이 1 이내인지, 케이스보다 샤드가 많아도 에러가 아닌지, 잘못된 spec 은 `SystemExit` 인지.

## 전체 검증

```
$ python3 -m pytest tests/ -q -p no:randomly
5125 passed, 16 skipped · Total coverage: 72.79%

$ actionlint .github/workflows/guard-falsifiability.yml .github/workflows/security-scan.yml   # OK
$ python3 -m ruff check scripts/ tests/          # All checks passed!
$ python3 -m basedpyright scripts/tools/guard_falsifiability.py  # 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)