### PR TITLE
fix: 하이픈 복합어 오절단 수정 + 피해 13건 복구 + 생성 시점 정규화

### DIFF
--- a/_posts/2026-03-05-daily-crypto-news-digest.md
+++ b/_posts/2026-03-05-daily-crypto-news-digest.md
@@ -199,7 +199,7 @@ permalink: "/crypto-news/2026/03/05/daily-crypto-news-digest/"
 <div class="news-card-num">3</div>
 <div class="news-card-body">
 <a href="https://news.google.com/rss/articles/CBMiT0FVX3lxTE9OY1hwcktwa1JpaTBIdzdZRmF4alMxbW1WUDN0azdyVk1TdUhXNGpsdzJHTnB5bDBUaG1VSzg5XzVGXzROZmZGX3VFdmpXaGM?oc=5" class="news-title" target="_blank" rel="noopener noreferrer">비트코인 반등…트럼프 대통령, 암호화폐 법안 공개 지지</a>
-<p class="news-desc">비트코인 반등…트럼프 대통령, 암호화폐 법안 공개 지지</p>
+<p class="news-desc">비트코인 반등…트럼프 대통령, 암호화폐 법안 공개 지지-[美증시 특징주]</p>
 <span class="source-tag" data-source-type="aggregator">Google News KR</span>
 </div>
 </div>

--- a/_posts/2026-03-25-daily-crypto-news-digest.md
+++ b/_posts/2026-03-25-daily-crypto-news-digest.md
@@ -130,7 +130,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-03-25 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-med">MED</span>
 <a href="https://news.google.com/read/CBMimwFBVV95cUxOWWZWY204YmNETXZBRlJJdTQwanZQdEd4TlhDSnJ1d3dkSEFvUUVUdGJPSm9OLXhnLVRjUmNLd00xUUtpQnJBZGF2ZExoWGRNMmhOU2JLd09WUWd1ODJ6UEM3LXBqM19oRGhqc1FlNUFCZTNEQWRHb3RpWVRQYnEwTU9SWUZFb3FxNWkySXNKY25RWkphc0wyWXVFUQ?hl=en-US&gl=US&ceid=US%3Aen" class="news-title" target="_blank" rel="noopener noreferrer">비트코인: 약세장에도 불구하고 실제로 무슨 일이 일어나고 있나요? (암호화폐:BTC-USD)</a>
-<p class="news-desc">비트코인: 하락장에도 불구하고 실제로 무슨 일이 일어나고 있나요(암호화폐:BTC</p>
+<p class="news-desc">비트코인: 하락장에도 불구하고 실제로 무슨 일이 일어나고 있나요(암호화폐:BTC-USD).</p>
 <span class="source-tag" data-source-type="aggregator">Google News</span>
 </div>
 </div>

--- a/_posts/2026-03-26-daily-crypto-news-digest.md
+++ b/_posts/2026-03-26-daily-crypto-news-digest.md
@@ -119,7 +119,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-03-26 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-med">MED</span>
 <a href="https://news.google.com/read/CBMimwFBVV95cUxOWWZWY204YmNETXZBRlJJdTQwanZQdEd4TlhDSnJ1d3dkSEFvUUVUdGJPSm9OLXhnLVRjUmNLd00xUUtpQnJBZGF2ZExoWGRNMmhOU2JLd09WUWd1ODJ6UEM3LXBqM19oRGhqc1FlNUFCZTNEQWRHb3RpWVRQYnEwTU9SWUZFb3FxNWkySXNKY25RWkphc0wyWXVFUQ?hl=en-US&gl=US&ceid=US%3Aen" class="news-title" target="_blank" rel="noopener noreferrer">비트코인: 약세장에도 불구하고 실제로 무슨 일이 일어나고 있나요? (암호화폐:BTC-USD)</a>
-<p class="news-desc">비트코인: 하락장에도 불구하고 실제로 무슨 일이 일어나고 있나요(암호화폐:BTC</p>
+<p class="news-desc">비트코인: 하락장에도 불구하고 실제로 무슨 일이 일어나고 있나요(암호화폐:BTC-USD).</p>
 <span class="source-tag" data-source-type="aggregator">Google News</span>
 </div>
 </div>

--- a/_posts/2026-03-27-daily-stock-news-digest.md
+++ b/_posts/2026-03-27-daily-stock-news-digest.md
@@ -123,7 +123,7 @@ image_alt: "주식 시장 뉴스 종합 - 2026-03-27 - 주식 뉴스 요약 이�
 <div class="news-card-body">
 <span class="news-severity news-severity-high">HIGH</span>
 <a href="https://news.google.com/rss/articles/CBMi1gFBVV95cUxQbDRyWC1UdUhfdG1mNGw1LVhKYTVxUDE1WTZxMDZyRHZrWlJ0QWtidV9STVhPUHZhUnVVVVdNUFQ1M09CZUVLZ3lSNFlXWnZINE9IOGRWdXB5UjJtaWVlbWZhUmpiRzhrSmd3MU42U25oMm1SYXFRcV91OFF6WjlBUWdNaVBJSkhrZ3U0WS1UNTluZUhpNXdNM0tkVHViNWFUWl9hVUs4QTQtU25OME9LdFViQUR4dTM4Tkx2SkxjdDdnNW9rQ0tfdTUzOGozQWZwS0FvOVVB?oc=5" class="news-title" target="_blank" rel="noopener noreferrer">"한은, 유가 108달러·환율 1천500원 진입시 금리 인상" - 한국무역협회</a>
-<p class="news-desc">"한은, 유가 108달러·환율 1천500원 진입시 금리 인상" 한국무역협회</p>
+<p class="news-desc">"한은, 유가 108달러·환율 1천500원 진입시 금리 인상" 한국무역협회-KITA.NET</p>
 <span class="source-tag" data-source-type="default">한국 금리/환율</span>
 </div>
 </div>

--- a/_posts/2026-03-30-daily-crypto-news-digest.md
+++ b/_posts/2026-03-30-daily-crypto-news-digest.md
@@ -147,7 +147,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-03-30 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-med">MED</span>
 <a href="https://news.google.com/read/CBMijgFBVV95cUxPSHJtVnJqVlVmZTdtLVlGd1VRS3U3QWpaR0w2cjVmaldLMi0yTkxrQXQyMjZ1RWxjM3RzX1Q0R3BJV243bUMyTkx1MTVvaUVZSTlXV2hLVU5tSlN1dTFMcThlb1IwUm1UVWFfZTRxQlgzbnR4WEVTaUFad0FZUE5jU202QlBmeTFRekJ0ZjVB?hl=en-US&gl=US&ceid=US%3Aen" class="news-title" target="_blank" rel="noopener noreferrer">비트코인의 끝은 새로운 시작이 될 것입니다 (암호화폐: BTC-USD)</a>
-<p class="news-desc">비트코인은 더 이상 희소성 기반 모델에 의해 구동되지 않습니다. 이제 가격은 수요 역학을 추적하고 베타 기술 지수와 상관관계가 있습니다. 여기에서 BTC</p>
+<p class="news-desc">비트코인은 더 이상 희소성 기반 모델에 의해 구동되지 않습니다. 이제 가격은 수요 역학을 추적하고 베타 기술 지수와 상관관계가 있습니다. 여기에서 BTC-USD에 대해 자세히 알아보세요.</p>
 <span class="source-tag" data-source-type="aggregator">Google News</span>
 </div>
 </div>

--- a/_posts/2026-03-31-daily-crypto-news-digest.md
+++ b/_posts/2026-03-31-daily-crypto-news-digest.md
@@ -124,7 +124,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-03-31 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-med">MED</span>
 <a href="https://news.google.com/read/CBMijgFBVV95cUxPSHJtVnJqVlVmZTdtLVlGd1VRS3U3QWpaR0w2cjVmaldLMi0yTkxrQXQyMjZ1RWxjM3RzX1Q0R3BJV243bUMyTkx1MTVvaUVZSTlXV2hLVU5tSlN1dTFMcThlb1IwUm1UVWFfZTRxQlgzbnR4WEVTaUFad0FZUE5jU202QlBmeTFRekJ0ZjVB?hl=en-US&gl=US&ceid=US%3Aen" class="news-title" target="_blank" rel="noopener noreferrer">비트코인의 끝은 새로운 시작이 될 것입니다 (암호화폐: BTC-USD)</a>
-<p class="news-desc">비트코인은 더 이상 희소성 기반 모델에 의해 구동되지 않습니다. 이제 가격은 수요 역학을 추적하고 베타 기술 지수와 상관관계가 있습니다. 여기에서 BTC</p>
+<p class="news-desc">비트코인은 더 이상 희소성 기반 모델에 의해 구동되지 않습니다. 이제 가격은 수요 역학을 추적하고 베타 기술 지수와 상관관계가 있습니다. 여기에서 BTC-USD에 대해 자세히 알아보세요.</p>
 <span class="source-tag" data-source-type="aggregator">Google News</span>
 </div>
 </div>

--- a/_posts/2026-05-12-daily-stock-news-digest.md
+++ b/_posts/2026-05-12-daily-stock-news-digest.md
@@ -248,7 +248,7 @@ image_alt: "주식 시장 뉴스 종합 - 2026-05-12 - 주식 뉴스 요약 이�
 <div class="news-card-body">
 <span class="news-severity news-severity-med">MED</span>
 <a href="https://www.cnbc.com/2026/05/11/trump-iran-war-ceasefire-life-support.html" class="news-title" target="_blank" rel="noopener noreferrer">트럼프는 이란의 반대 제안을 거부한 후 이란 휴전은 '생명 유지'에 관한 것이라고 말했습니다.</a>
-<p class="news-desc">트럼프가 아무런 협상도 타결되지 않으면 이란의 "전체 문명"을 파괴하겠다고 위협한 이후 4월 중순에 미국</p>
+<p class="news-desc">트럼프가 아무런 협상도 타결되지 않으면 이란의 "전체 문명"을 파괴하겠다고 위협한 이후 4월 중순에 미국-이란의 화끈한 휴전이 시작되었습니다.</p>
 <span class="source-tag" data-source-type="finance-media">CNBC Top News</span>
 </div>
 </div>

--- a/_posts/2026-05-25-daily-crypto-news-digest.md
+++ b/_posts/2026-05-25-daily-crypto-news-digest.md
@@ -181,7 +181,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-05-25 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-high">HIGH</span>
 <a href="https://news.google.com/rss/articles/CBMic0FVX3lxTFA4RmZKV0hjY21vWDYtYnBfcm0ybHM2VVVVNzJyanR6VEstYzJ5QVlEYXR1ci1EbGsxMVAxclVEb0pFOUdoZldwYVp0Z25lSFhpTjRFWmNJQjRXeGJWRl9PWFNXSGFVSWtyMHAzVXV2Wi00ekU?oc=5" class="news-title" target="_blank" rel="noopener noreferrer">비트코인 7만 4천 5백 달러대 하락, 지정학적 불확실성에 주간 손실 전망 - Investing.com 한국어</a>
-<p class="news-desc">비트코인 7만 4천 5백 달러대 하락, 지정학적 불확실성에 주간 손실 전망 Investing.com 한국어 전쟁 땐 위험자산 떨어진다더니…비트코인 가격에 무슨 일 [레버리지셰어즈 인사이트] v.daum.net 비트코인 6만달러대 추락?…2026년 저점 재시험하나 네이트 미국-이란 평화협정 급물살…비트코인·알트코인 급반등 글로벌이코노믹 비트코인 무관심 구간 재진입하나…온체인 지표서 바닥 신호 디지털투데이 비트코인 핵심 지지선 붕괴… 6만 달러 하방 압력 속 단기 반등 시험대 gukjenews.com 비트코인 반등…미국</p>
+<p class="news-desc">비트코인 7만 4천 5백 달러대 하락, 지정학적 불확실성에 주간 손실 전망 Investing.com 한국어 전쟁 땐 위험자산 떨어진다더니…비트코인 가격에 무슨 일 [레버리지셰어즈 인사이트] v.daum.net 비트코인 6만달러대 추락?…2026년 저점 재시험하나 네이트 미국-이란 평화협정 급물살…비트코인·알트코인 급반등 글로벌이코노믹 비트코인 무관심 구간 재진입하나…온체인 지표서 바닥 신호 디지털투데이 비트코인 핵심 지지선 붕괴… 6만 달러 하방 압력 속 단기 반등 시험대 gukjenews.com 비트코인 반등…미국-이란 협정.</p>
 <span class="source-tag" data-source-type="aggregator">Google News KR</span>
 </div>
 </div>

--- a/_posts/2026-06-14-daily-crypto-news-digest.md
+++ b/_posts/2026-06-14-daily-crypto-news-digest.md
@@ -74,7 +74,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-06-14 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-med">MED</span>
 <a href="https://news.google.com/read/CBMi1wFBVV95cUxQSk5BbUJWN2d2aFdfWlF2V2hqYzFaZnk3bV9oTi1hZHlqbGpaQVhOX05zQWJPUW90SEdhNjNOSmc1dzVNWWNiZTZReG5XN3dhb3Q0UWx1MUZmN0Njdm1QUXA2MDZXclZHWVlmeDJLU19yQm9CUmlycnJxX2k5Rjh3SGVrWFFhNmhZazJ1RFppSEhYeXRzUm9oRUxRZk14d3pMaE5mVzhLcFRKa3E5Qm9sVHRmTURRUW15VXBtN3JXSFBLWl9jVVB6bV9jaXEzN1R6ampMeTVNWQ?hl=en-US&gl=US&ceid=US%3Aen" class="news-title" target="_blank" rel="noopener noreferrer">비트코인은 암호화폐 겨울이 끝나며 59,000달러로 바닥을 쳤다고 Standard Chartered 분석가는 말합니다.</a>
-<p class="news-desc">수석 시장 분석가인 Geoffrey Kendrick은 최근 암호화폐 매각을 종식시키는 이중 촉매제로 SpaceX IPO과 잠재적인 미국</p>
+<p class="news-desc">수석 시장 분석가인 Geoffrey Kendrick은 최근 암호화폐 매각을 종식시키는 이중 촉매제로 SpaceX IPO과 잠재적인 미국-이란 평화 협정을 지적했습니다.</p>
 <span class="source-tag" data-source-type="aggregator">Google News</span>
 </div>
 </div>

--- a/_posts/2026-06-15-daily-crypto-news-digest.md
+++ b/_posts/2026-06-15-daily-crypto-news-digest.md
@@ -141,7 +141,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-06-15 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-med">MED</span>
 <a href="https://news.google.com/read/CBMi1wFBVV95cUxQSk5BbUJWN2d2aFdfWlF2V2hqYzFaZnk3bV9oTi1hZHlqbGpaQVhOX05zQWJPUW90SEdhNjNOSmc1dzVNWWNiZTZReG5XN3dhb3Q0UWx1MUZmN0Njdm1QUXA2MDZXclZHWVlmeDJLU19yQm9CUmlycnJxX2k5Rjh3SGVrWFFhNmhZazJ1RFppSEhYeXRzUm9oRUxRZk14d3pMaE5mVzhLcFRKa3E5Qm9sVHRmTURRUW15VXBtN3JXSFBLWl9jVVB6bV9jaXEzN1R6ampMeTVNWQ?hl=en-US&gl=US&ceid=US%3Aen" class="news-title" target="_blank" rel="noopener noreferrer">비트코인은 암호화폐 겨울이 끝나며 59,000달러로 바닥을 쳤다고 Standard Chartered 분석가는 말합니다.</a>
-<p class="news-desc">수석 시장 분석가인 Geoffrey Kendrick은 최근 암호화폐 매각을 종식시키는 이중 촉매제로 SpaceX IPO과 잠재적인 미국</p>
+<p class="news-desc">수석 시장 분석가인 Geoffrey Kendrick은 최근 암호화폐 매각을 종식시키는 이중 촉매제로 SpaceX IPO과 잠재적인 미국-이란 평화 협정을 지적했습니다.</p>
 <span class="source-tag" data-source-type="aggregator">Google News</span>
 </div>
 </div>

--- a/_posts/2026-06-20-daily-crypto-news-digest.md
+++ b/_posts/2026-06-20-daily-crypto-news-digest.md
@@ -300,7 +300,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-06-20 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-high">HIGH</span>
 <a href="https://cointelegraph.com/news/crypto-biz-ai-exit-strategy-bitcoin-miners?utm_source=rss&utm_medium=rss&utm_campaign=rss" class="news-title" target="_blank" rel="noopener noreferrer">Crypto Biz: AI은 채굴자들을 위한 출구 전략일까?</a>
-<p class="news-desc">비트코인 채굴자는 AI에 두 배로 감소하고 RWA를 토큰화하여 상위 430억 달러를 기록했으며 리플은 아프리카 결제 네트워크를 강화했으며 Sam Bankman</p>
+<p class="news-desc">비트코인 채굴자는 AI에 두 배로 감소하고 RWA를 토큰화하여 상위 430억 달러를 기록했으며 리플은 아프리카 결제 네트워크를 강화했으며 Sam Bankman-Fried는 매력을 잃었습니다.</p>
 <span class="source-tag" data-source-type="crypto-media">Cointelegraph</span>
 </div>
 </div>

--- a/_posts/2026-06-24-daily-crypto-news-digest.md
+++ b/_posts/2026-06-24-daily-crypto-news-digest.md
@@ -117,7 +117,7 @@ image_alt: "암호화폐 뉴스 브리핑 - 2026-06-24 - 암호화폐 뉴스 요
 <div class="news-card-body">
 <span class="news-severity news-severity-med">MED</span>
 <a href="https://news.google.com/read/CBMibEFVX3lxTE1pajVac2ZqTkJRbE15VE9ydkJiVFFmX1QtZ0REZEIwN0dVMEVfc3o1dDBrem85enlRTkpIazVSTVM1ajJlaExmZDE0Rm5zcERIeXdCYW5Jb3ByQ3d3cnJ0MC1qTWtYT24wWlJreg?hl=en-US&gl=US&ceid=US%3Aen" class="news-title" target="_blank" rel="noopener noreferrer">암호화폐 범죄자의 미국 미래는 규제 당국이 그들을 어떻게 부르기로 결정했는지에 따라 정의됩니다</a>
-<p class="news-desc">암호화폐 무기한 선물 규정은 이제 범인, 이벤트 계약 및 규정 준수 경로에 대한 SEC</p>
+<p class="news-desc">암호화폐 무기한 선물 규정은 이제 범인, 이벤트 계약 및 규정 준수 경로에 대한 SEC-CFTC 정의에 따라 달라집니다.</p>
 <span class="source-tag" data-source-type="aggregator">Google News</span>
 </div>
 </div>

--- a/_posts/2026-07-28-daily-stock-news-digest.md
+++ b/_posts/2026-07-28-daily-stock-news-digest.md
@@ -242,7 +242,7 @@ image_alt: "주식 시장 뉴스 종합 - 2026-07-28 - 주식 뉴스 요약 이�
 <div class="news-card-body">
 <span class="news-severity news-severity-high">HIGH</span>
 <a href="https://news.google.com/rss/articles/CBMihwFBVV95cUxPclQyWlJCa3dHSl9QUjFadm9xRS1ZS09BRzdhSXBGUk9WaWtVeElOeVo0MUNqUEJKZ1Q1MkdIcFJCcU9ZNlVzUDJqbXlsTE1FTFJuYTN0QXctblJOYk8yb2ZWRmZVVmVzaHk0NDRKZTV5UV9YTlptRTNlWnZDbWxBUUJQQmRuY2s?oc=5" class="news-title" target="_blank" rel="noopener noreferrer">오늘의 주식 시장: 엔비디아, 마이크론, 인텔 주식 하락; 트럼프-이란 일시 정지로 인한 석유 하락 — 실시간 업데이트</a>
-<p class="news-desc">오늘의 주식 시장: 엔비디아, 마이크론, 인텔 주식 하락; 트럼프</p>
+<p class="news-desc">오늘의 주식 시장: 엔비디아, 마이크론, 인텔 주식 하락; 트럼프-이란 일시 정지로 유가 폭락</p>
 <span class="source-tag" data-source-type="aggregator">Google News Stocks EN</span>
 </div>
 </div>

--- a/scripts/common/enrichment_synthetic.py
+++ b/scripts/common/enrichment_synthetic.py
@@ -480,7 +480,14 @@ _KOREAN_TITLE_KW_SETS: list = [(frozenset(k.split("|")), v) for k, v in _KOREAN_
 # Outlet suffix: `… - The Hill`, `… | 공감신문`. Bounded and digit-free so an
 # informative subtitle ("삼성전자 - 2분기 영업이익 14조 원") is left alone; the
 # previous single-token pattern (`\S+$`) stripped 프리진경제 but not "The Hill".
-_SOURCE_SUFFIX_RE = re.compile(r"\s*[-–—|]\s*(?![^-–—|]*\d)[^-–—|]{2,20}$")
+#
+# **Whitespace before the delimiter is required.** With `\s*` (zero allowed) the
+# hyphen inside a compound matched: "…net inflows to a multi-month high." lost
+# its tail to "…a multi", and "미국-이란 평화 협정을 지적했습니다." became "…미국".
+# A false positive here destroys a sentence, while a false negative only leaves
+# an outlet name behind — so the rule errs toward keeping text. Cost: an outlet
+# written without a leading space ("…지지-[美증시 특징주]") is no longer stripped.
+_SOURCE_SUFFIX_RE = re.compile(r"\s+[-–—|]\s*(?![^-–—|]*\d)[^-–—|]{2,20}$")
 
 # Grammatical particles that ride along when Hangul runs are taken verbatim,
 # turning "러시아" into the non-word "러시아에서".

--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -46,6 +46,7 @@ from .text_utils import (  # noqa: F401  (_best_favicon_link, _favicon_url re-ex
     _fix_mistranslations,
     _strip_trailing_artifacts,
     _truncate_sentence,
+    normalize_blurb,
 )
 from .theme_briefing import ThemeBriefingGenerator
 from .theme_index import ThemeIndex
@@ -1030,7 +1031,7 @@ class ThemeSummarizer:
                     # Skip descriptions that are mostly English (non-Korean)
                     korean_chars = sum(1 for c in desc if "\uac00" <= c <= "\ud7a3")
                     if korean_chars >= len(desc) * 0.3:
-                        desc = _strip_trailing_artifacts(desc)
+                        desc = normalize_blurb(_strip_trailing_artifacts(desc))
                         desc_short = desc[:100] + "..." if len(desc) > 100 else desc
                         desc_part = f' <span class="p0-desc">{desc_short}</span>'
                 if link:

--- a/scripts/common/text_utils.py
+++ b/scripts/common/text_utils.py
@@ -5,6 +5,7 @@ Pure helpers extracted from summarizer.py — no module-level side effects.
 
 import re
 
+from .enrichment_synthetic import _strip_source_suffix
 from .post_generator import _MISTRANSLATION_FIXES
 from .utils import truncate_sentence as _truncate_sentence_util
 
@@ -132,3 +133,37 @@ def _best_favicon_link(item: dict) -> str:
     if link and "news.google.com" not in link:
         return link
     return original or link
+
+
+# ---------------------------------------------------------------------------
+# Per-URL blurb normalisation (2026-08-06).
+#
+# The card already renders the outlet in its own `source-tag` span, so a copy
+# trailing the summary is duplication. A corpus sweep found 97 such blurbs plus
+# 4 with a doubled terminator; both classes are cheap to prevent at render time
+# rather than backfilling forever.
+#
+# Single source of truth: `themed_news_renderer` (news-desc), `summarizer`
+# (p0-desc) and `fix_post_url_summaries` (backfill) all route through here, so
+# the "outlet name or informative subtitle?" rule lives in one place.
+# ---------------------------------------------------------------------------
+
+# Exactly two periods. `...` is deliberate Korean punctuation and must survive.
+_DOUBLED_PERIOD_RE = re.compile(r"(?<!\.)\.\.(?!\.)")
+
+# Stripping must not leave less than a sentence behind.
+BLURB_MIN_LEN = 30
+
+
+def normalize_blurb(text: str) -> str:
+    """Return ``text`` with a trailing outlet name and doubled periods removed.
+
+    Idempotent, and a no-op when stripping would gut the blurb.
+    """
+    if not text:
+        return text
+    cleaned = _DOUBLED_PERIOD_RE.sub(".", text).strip()
+    stripped = _strip_source_suffix(cleaned)
+    if stripped != cleaned and len(stripped) >= BLURB_MIN_LEN:
+        cleaned = stripped
+    return cleaned

--- a/scripts/common/themed_news_renderer.py
+++ b/scripts/common/themed_news_renderer.py
@@ -14,6 +14,7 @@ from .text_utils import (
     _fix_mistranslations,
     _strip_trailing_artifacts,
     _truncate_sentence,
+    normalize_blurb,
 )
 from .themes import ARTICLES_PER_THEME, OVERFLOW_PREVIEW_LIMIT
 
@@ -112,7 +113,7 @@ class ThemedNewsRenderer:
         if description and description != title and not sumr_module._is_generic_desc(description):
             # Additional boilerplate check for translated descriptions
             if not sumr_module._is_boilerplate_desc(description):
-                desc_text = _strip_trailing_artifacts(_truncate_sentence(description, max_len=300))
+                desc_text = normalize_blurb(_strip_trailing_artifacts(_truncate_sentence(description, max_len=300)))
                 if desc_text:
                     card_parts.append(f'<p class="news-desc">{_esc(desc_text, quote=True)}</p>')
         else:

--- a/scripts/fix_post_url_summaries.py
+++ b/scripts/fix_post_url_summaries.py
@@ -66,11 +66,10 @@ from common.enrichment_network import (  # noqa: E402
 )
 from common.enrichment_synthetic import (  # noqa: E402
     _is_title_related_description,
-    _strip_source_suffix,
     generate_synthetic_description,
 )
 from common.summary_quality import is_boilerplate  # noqa: E402
-from common.text_utils import _strip_trailing_artifacts  # noqa: E402
+from common.text_utils import _strip_trailing_artifacts, normalize_blurb  # noqa: E402
 from common.translator import translate_to_korean  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -188,15 +187,7 @@ def clean_text(text: str) -> str:
     Returning ``""`` for a clean blurb is load-bearing — callers use it to skip
     the rewrite entirely rather than writing the same bytes back.
     """
-    cleaned = _DOUBLED_PERIOD_RE.sub(".", text).strip()
-
-    # The card renders the outlet in its own `source-tag` span, so a trailing
-    # copy in the summary is duplication. Reuses the synthesiser's stripper so
-    # the "is this an outlet or a subtitle?" rule lives in one place.
-    stripped = _strip_source_suffix(cleaned)
-    if stripped != cleaned and len(stripped) >= _MIN_DESC_LEN:
-        cleaned = stripped
-
+    cleaned = normalize_blurb(text)
     return cleaned if cleaned != text.strip() else ""
 
 

--- a/tests/test_enrichment_synthetic_quality.py
+++ b/tests/test_enrichment_synthetic_quality.py
@@ -164,3 +164,25 @@ def test_numeric_context_is_preferred_over_a_keyword_bag() -> None:
     result = _synth("국내 관광객 수 3.2% 늘어난 것으로 집계")
     assert "3.2%" in result
     assert "주요 키워드" not in result
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        # A hyphen inside a compound is not a delimiter. Allowing zero spaces
+        # before it truncated real text: "…to a multi-month high." lost its tail
+        # to "…a multi", and "미국-이란 평화 협정을 지적했습니다." became "…미국".
+        "Daily creation activity pushes weekly net inflows to a multi-month high.",
+        "최근 암호화폐 매각을 종식시키는 촉매제로 SpaceX IPO과 미국-이란 평화 협정을 지적했습니다.",
+        "비트코인: 하락장에도 무슨 일이 일어나고 있나요(암호화폐:BTC-USD).",
+        "오늘의 주식 시장: 엔비디아, 인텔 주식 하락; 트럼프-이란 일시 정지로 유가 폭락",
+    ],
+)
+def test_hyphen_compound_is_not_a_source_delimiter(title: str) -> None:
+    """A false positive destroys a sentence; a false negative leaves a name.
+
+    The rule therefore requires whitespace before the delimiter and errs toward
+    keeping text. Found by a golden-master failure after the first version
+    shipped, which had already truncated 13 published blurbs.
+    """
+    assert _synth(title).startswith(title.rstrip("."))

--- a/tests/test_themed_news_renderer.py
+++ b/tests/test_themed_news_renderer.py
@@ -618,3 +618,46 @@ class TestDeterminism:
         assert "<details>" in out
         assert "Overflow without link" in out
         assert "<span>Overflow without link</span>" in out
+
+
+class TestBlurbNormalization:
+    """The rendered blurb must not repeat the outlet name (2026-08-06).
+
+    The card already prints the source in its own `source-tag` span, so a copy
+    trailing the summary is duplication. A corpus sweep found 97 such blurbs;
+    catching them here stops the backfill from being a permanent chore.
+    """
+
+    def test_source_suffix_is_stripped_from_rendered_blurb(self, mock_summarizer: MagicMock) -> None:
+        articles = [
+            _make_article(
+                "코스피 급등",
+                link="https://example.com/kospi",
+                description="S&P500·나스닥 급락; 원유·가스·금·은 급등; 비트코인 $67K 근처로 후퇴 - The Sunday Guardian",
+            ),
+        ]
+        items = articles + [{"title": f"pad{i}"} for i in range(4)]
+        mock_summarizer._theme_articles = {"k": articles}
+        mock_summarizer.get_top_themes.return_value = [("Name", "k", "*", 1)]
+
+        out = ThemedNewsRenderer(items, mock_summarizer).render()
+
+        assert "The Sunday Guardian" not in out
+        assert "비트코인 $67K 근처로 후퇴" in out
+
+    def test_informative_tail_survives_rendering(self, mock_summarizer: MagicMock) -> None:
+        """A tail carrying figures is the story, not an outlet name."""
+        articles = [
+            _make_article(
+                "삼성전자 실적",
+                link="https://example.com/sec",
+                description="삼성전자 2분기 실적 발표 - 영업이익 14조 원으로 전년 대비 32% 증가했습니다",
+            ),
+        ]
+        items = articles + [{"title": f"pad{i}"} for i in range(4)]
+        mock_summarizer._theme_articles = {"k": articles}
+        mock_summarizer.get_top_themes.return_value = [("Name", "k", "*", 1)]
+
+        out = ThemedNewsRenderer(items, mock_summarizer).render()
+
+        assert "14조 원" in out and "32% 증가" in out


### PR DESCRIPTION
> **먼저 읽어주세요**: 이 PR 은 #1084(머지됨)가 main 에 남긴 **실제 피해 13건을 복구**합니다.

## 1. 회귀 — 하이픈 복합어를 구분자로 오인

#1084 의 출처 접미사 제거가 정규식에서 구분자 앞 공백을 `\s*`(0개 허용)로 뒀습니다. 그래서 **복합어 안의 하이픈**에 걸려 실제 문장을 잘랐습니다:

```
"…net inflows to a multi-month high."  →  "…to a multi"
"…미국-이란 평화 협정을 지적했습니다."   →  "…미국"
"…(암호화폐:BTC-USD)."                 →  "…(암호화폐:BTC"
```

한국어 코퍼스로만 감사해서 놓쳤습니다 — 한국어는 하이픈 복합어가 드물지만 영어 설명문과 `미국-이란` 같은 표기에는 흔합니다.

**골든마스터(`test_summarizer_themed_news_golden`)가 잡아냈습니다.** 스냅샷이 없었다면 이 절단은 조용히 남았을 겁니다.

### 복구

main 에 반영된 119건을 전수 감사해 **13건의 피해를 확인하고 원문으로 되돌렸습니다**:

| 되돌린 꼬리 |
|---|
| `-이란 평화 협정을 지적했습니다.` (2건) |
| `-USD에 대해 자세히 알아보세요.` (2건) |
| `-USD).` (2건) |
| `-이란의 화끈한 휴전이 시작되었습니다.` |
| `-이란 일시 정지로 유가 폭락 — Live Updates WSJ` |
| `-Fried는 매력을 잃었습니다.` / `-CFTC 정의에 따라 달라집니다.` / `-이란 협정.` / `-[美증시 특징주]` / `-KITA.NET` |

### 수정

구분자 앞에 **공백을 요구**합니다(`\s+`).

방향을 명시하면: **오탐은 문장을 파괴하지만 미탐은 매체명이 남을 뿐**입니다. 그래서 규칙은 텍스트를 보존하는 쪽으로 기울입니다. 대가는 공백 없이 붙은 매체명(`…지지-[美증시 특징주]`)이 더 이상 제거되지 않는 것이고, 이는 받아들일 만합니다.

마지막 케이스가 이 균형을 잘 보여줍니다:

```
before: …트럼프-이란 일시 정지로 유가 폭락 — Live Updates WSJ
after : …트럼프-이란 일시 정지로 유가 폭락
```

`트럼프-이란`(공백 없음)은 보존하고 ` — Live Updates WSJ`(공백 있음)만 제거합니다.

## 2. 생성 시점 정규화 (원래 목적)

과거 데이터를 영원히 백필하는 대신 **렌더 시점에 막습니다**. `text_utils.normalize_blurb` 를 SSoT 로 두고 세 소비자가 같은 규칙을 씁니다:

| 소비자 | 대상 |
|---|---|
| `themed_news_renderer` | `news-desc` 카드 |
| `summarizer` | `p0-desc` 알림 |
| `fix_post_url_summaries.clean_text` | 백필 (공유 함수에 위임) |

`enrichment_synthetic` 은 sibling import 가 없는 leaf 라 순환이 생기지 않습니다.

## 검증

```
$ python3 -m pytest tests/ -q -p no:randomly
5138 passed, 16 skipped · Total coverage: 72.76%

$ python3 -m ruff check scripts/ tests/          # All checks passed!
$ python3 -m basedpyright <변경 3파일>            # 0 errors
```

신규 회귀 테스트: 하이픈 복합어 4종(영어 `multi-month`, `미국-이란`, `BTC-USD`, `트럼프-이란`)이 절단되지 않음 + 렌더러에서 출처 접미사가 제거되고 수치 부제는 보존됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)