### PR TITLE
fix: 하이픈 오절단 전수 감사(2곳 추가 발견) + 골든 커버리지 보강

### DIFF
--- a/scripts/common/enrichment_synthetic.py
+++ b/scripts/common/enrichment_synthetic.py
@@ -871,7 +871,11 @@ def generate_synthetic_description(
 
     # Build a title-condensed description instead of boilerplate
     # Clean trailing source names from the title
-    clean_title = re.sub(r"\s*[-–—|]\s*\S+$", "", title).strip()
+    # `\s+` (not `\s*`): a hyphen inside a compound is not a delimiter. With zero
+    # spaces allowed this cut "(BTC-USD:Cryptocurrency)" down to "(BTC" — 21 such
+    # titles in the corpus. Cost of the stricter rule is an outlet glued on
+    # without a space, which is the cheaper failure.
+    clean_title = re.sub(r"\s+[-–—|]\s*\S+$", "", title).strip()
     # For Korean titles, extract a condensed version
     kr_chars = len(re.findall(r"[가-힣]", clean_title))
     if kr_chars > len(clean_title) * 0.3:

--- a/scripts/common/summarizer.py
+++ b/scripts/common/summarizer.py
@@ -141,7 +141,11 @@ def _generate_title_based_desc(title: str, theme_key: str) -> str:
     has_korean = bool(re.search(r"[가-힣]", title))
     if has_korean:
         # Korean title: condense and add entity-specific context
-        clean = re.sub(r"\s*[-–—|]\s*\S+$", "", title).strip()
+        # `\s+` (not `\s*`): a hyphen inside a compound is not a delimiter. With zero
+        # spaces allowed this cut "(BTC-USD:Cryptocurrency)" down to "(BTC" — 21 such
+        # titles in the corpus. Cost of the stricter rule is an outlet glued on
+        # without a space, which is the cheaper failure.
+        clean = re.sub(r"\s+[-–—|]\s*\S+$", "", title).strip()
         ctx = _THEME_CONTEXT.get(theme_key, "")
         if len(clean) > 80:
             clean = clean[:77] + "..."

--- a/scripts/common/themed_news_renderer.py
+++ b/scripts/common/themed_news_renderer.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List
 from .enrichment import is_logo_like_url
 from .markdown_utils import html_source_tag
 from .severity import _SEV_BADGE_HTML, _classify_news_severity
+from .summary_quality import _NAV_LINK_LIST_RE
 from .text_utils import (
     _fix_mistranslations,
     _strip_trailing_artifacts,
@@ -110,7 +111,20 @@ class ThemedNewsRenderer:
         else:
             card_parts.append(f'<span class="news-title">{safe_title}</span>')
 
-        if description and description != title and not sumr_module._is_generic_desc(description):
+        # The pipe-delimited navigation strip ("콜로 | 8 뉴스 지금 | 리노, 네바다")
+        # is site chrome, not a summary, and neither existing check saw it.
+        # Only this one detector is added: routing the whole `is_boilerplate`
+        # facade through here was measured and rejected — its "<35 chars without
+        # a number" rule discarded legitimate short Korean summaries, and its
+        # phrase list matched real headlines that merely carry a source name
+        # ("…암호화폐 시장, 전쟁에서 새로운 관심 끌다 Bloomberg.com"). The nav
+        # detector alone flags 29 blurbs corpus-wide, all genuine chrome.
+        if (
+            description
+            and description != title
+            and not sumr_module._is_generic_desc(description)
+            and not _NAV_LINK_LIST_RE.search(description)
+        ):
             # Additional boilerplate check for translated descriptions
             if not sumr_module._is_boilerplate_desc(description):
                 desc_text = normalize_blurb(_strip_trailing_artifacts(_truncate_sentence(description, max_len=300)))

--- a/tests/_golden.py
+++ b/tests/_golden.py
@@ -40,8 +40,21 @@ def assert_golden(name: str, actual: str) -> None:
     actual_norm = _normalize(actual)
 
     if os.environ.get("UPDATE_GOLDEN") == "1":
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(actual_norm, encoding="utf-8")
+        # The runtime tree-write detector refuses writes into the committed
+        # tree, which is what a snapshot *is*. Regenerating a golden is the one
+        # deliberate exception: the operator asked for it by name via the env
+        # var, so suspend the guard for exactly this write rather than
+        # exempting `tests/snapshots/` wholesale (which would also let an
+        # accidental write through).
+        # Imported bare, matching how `conftest.py` loads it. `tests.` -prefixed
+        # and bare imports resolve to *different module objects* with separate
+        # `_INSTALLED` registries, so the prefixed one would suspend a guard
+        # nobody installed.
+        from _tree_write_guard import suspended
+
+        with suspended():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(actual_norm, encoding="utf-8")
         return
 
     if not path.exists():

--- a/tests/fixtures/themed_news/punctuation_edge_cases.py
+++ b/tests/fixtures/themed_news/punctuation_edge_cases.py
@@ -1,0 +1,90 @@
+"""Punctuation edge cases: the text-mangling classes the other 8 fixtures miss.
+
+The 2026-08-06 hyphen regression reached `main` and truncated 13 published
+blurbs before a golden caught it — and the golden that caught it
+(``image_variants``) did so *by accident*, because one of its descriptions
+happened to contain "multi-month". No fixture targeted the punctuation rules
+on purpose, so the safety net had a hole exactly where the edit was risky.
+
+Each article below pins one rule, in both directions where that applies:
+
+1. Hyphen compound in the description — must survive. A delimiter needs
+   whitespace in front of it; `multi-month` does not have any.
+2. Hyphen compound in the *title* — the two title-cleaning paths had the same
+   bug ("(BTC-USD:Cryptocurrency)" → "(BTC").
+3. Source suffix with a leading space — must be stripped, since the card
+   already renders the outlet in its own `source-tag` span.
+4. Source suffix glued on without a space — must be kept. This is the
+   deliberate cost of rule 1: a false positive destroys a sentence, a false
+   negative leaves a name behind.
+5. Ellipsis `...` — deliberate Korean punctuation, must survive the
+   doubled-period collapse that targets `..`.
+6. Pipe-delimited navigation strip — site chrome, must not reach the card as
+   an article summary.
+
+All articles target ``bitcoin`` so theme classification stays deterministic
+and every row goes through the same rendering branch.
+"""
+
+ITEMS: list[dict] = [
+    # 1) Hyphen compound in the description — tail must survive.
+    {
+        "title": "비트코인 현물 ETF 자금 유입 가속",
+        "title_ko": None,
+        "description": "Daily creation activity pushes weekly net inflows to a multi-month high.",
+        "description_ko": None,
+        "link": "https://example.com/btc/etf-inflows",
+        "image": "https://example.com/img/etf.jpg",
+        "source": "Example Crypto",
+    },
+    # 2) Hyphen compound in the title — "(BTC-USD:Cryptocurrency)" must stay whole.
+    {
+        "title": "금리 인하 기대 약화로 암호화폐 주가 급락 (BTC-USD:Cryptocurrency)",
+        "title_ko": None,
+        "description": "선물 미결제약정이 줄면서 변동성이 확대됐다고 거래소가 밝혔습니다.",
+        "description_ko": None,
+        "link": "https://example.com/btc/rate-cut",
+        "image": "https://example.com/img/rates.jpg",
+        "source": "Example Crypto",
+    },
+    # 3) Source suffix with a leading space — stripped.
+    {
+        "title": "비트코인 채굴 난이도 사상 최고치 경신",
+        "title_ko": None,
+        "description": "S&P500·나스닥 급락; 원유·가스 급등; 비트코인이 $67K 근처로 후퇴했습니다 - The Sunday Guardian",
+        "description_ko": None,
+        "link": "https://example.com/btc/difficulty",
+        "image": "https://example.com/img/mining.jpg",
+        "source": "Example Crypto",
+    },
+    # 4) Source glued on without a space — kept, by design.
+    {
+        "title": "비트코인 반등에 알트코인 동반 상승",
+        "title_ko": None,
+        "description": "트럼프 대통령이 암호화폐 법안을 공개 지지하면서 시장이 반등했다고 전해집니다-[美증시 특징주]",
+        "description_ko": None,
+        "link": "https://example.com/btc/altcoin-rally",
+        "image": "https://example.com/img/altcoin.jpg",
+        "source": "Example Crypto",
+    },
+    # 5) Ellipsis — survives the `..` collapse.
+    {
+        "title": "비트코인 장중 급락 후 낙폭 축소",
+        "title_ko": None,
+        "description": "비트코인·알트코인 '장중 급락'...주요 변수는 금리와 환율이라는 분석이 나왔습니다.",
+        "description_ko": None,
+        "link": "https://example.com/btc/intraday",
+        "image": "https://example.com/img/intraday.jpg",
+        "source": "Example Crypto",
+    },
+    # 6) Navigation strip — site chrome, must not render as a summary.
+    {
+        "title": "비트코인 규제 논의 지역 의회로 확산",
+        "title_ko": None,
+        "description": "KCRG | 시더 래피즈, 아이오와 시티, 워털루, 더뷰크 | 뉴스, 스포츠, 날씨",
+        "description_ko": None,
+        "link": "https://example.com/btc/local-regulation",
+        "image": "https://example.com/img/local.jpg",
+        "source": "Example Crypto",
+    },
+]

--- a/tests/snapshots/generate_themed_news_sections/punctuation_edge_cases.txt
+++ b/tests/snapshots/generate_themed_news_sections/punctuation_edge_cases.txt
@@ -1,0 +1,114 @@
+## 테마별 주요 뉴스
+
+### 🟠 비트코인 (6건)
+
+*Daily creation activity pushes weekly net inflows to a multi-month high.*
+
+
+<div class="news-card-item news-sev-medium">
+<div class="news-card-num">1</div>
+<div class="news-card-thumb"><img src="https://example.com/img/etf.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div>
+<div class="news-card-body">
+<span class="news-severity news-severity-med">MED</span>
+<a href="https://example.com/btc/etf-inflows" class="news-title" target="_blank" rel="noopener noreferrer">비트코인 현물 ETF 자금 유입 가속</a>
+<p class="news-desc">Daily creation activity pushes weekly net inflows to a multi-month high.</p>
+<span class="source-tag" data-source-type="default">Example Crypto</span>
+</div>
+</div>
+
+
+<div class="news-card-item news-sev-high">
+<div class="news-card-num">2</div>
+<div class="news-card-thumb"><img src="https://example.com/img/rates.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div>
+<div class="news-card-body">
+<span class="news-severity news-severity-high">HIGH</span>
+<a href="https://example.com/btc/rate-cut" class="news-title" target="_blank" rel="noopener noreferrer">금리 인하 기대 약화로 암호화폐 주가 급락 (BTC-USD:Cryptocurrency)</a>
+<p class="news-desc">선물 미결제약정이 줄면서 변동성이 확대됐다고 거래소가 밝혔습니다.</p>
+<span class="source-tag" data-source-type="default">Example Crypto</span>
+</div>
+</div>
+
+
+<div class="news-card-item news-sev-high">
+<div class="news-card-num">3</div>
+<div class="news-card-thumb"><img src="https://example.com/img/mining.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div>
+<div class="news-card-body">
+<span class="news-severity news-severity-high">HIGH</span>
+<a href="https://example.com/btc/difficulty" class="news-title" target="_blank" rel="noopener noreferrer">비트코인 채굴 난이도 사상 최고치 경신</a>
+<p class="news-desc">S&amp;P500·나스닥 급락; 원유·가스 급등; 비트코인이 $67K 근처로 후퇴했습니다</p>
+<span class="source-tag" data-source-type="default">Example Crypto</span>
+</div>
+</div>
+
+<details><summary>그 외 3건 보기</summary><div class="details-content"><ol class="news-overflow-list">
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/altcoin.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/altcoin-rally" target="_blank" rel="noopener noreferrer">비트코인 반등에 알트코인 동반 상승</a><span class="overflow-source">Example Crypto</span></span></li>
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/intraday.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/intraday" target="_blank" rel="noopener noreferrer">비트코인 장중 급락 후 낙폭 축소</a><span class="overflow-source">Example Crypto</span></span></li>
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/local.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/local-regulation" target="_blank" rel="noopener noreferrer">비트코인 규제 논의 지역 의회로 확산</a><span class="overflow-source">Example Crypto</span></span></li>
+</ol></div></details>
+
+
+### 📈 가격/시장 (5건)
+
+*Daily creation activity pushes weekly net inflows to a multi-month high.*
+
+
+<div class="news-card-item news-sev-medium">
+<div class="news-card-num">1</div>
+<div class="news-card-thumb"><img src="https://example.com/img/altcoin.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div>
+<div class="news-card-body">
+<span class="news-severity news-severity-med">MED</span>
+<a href="https://example.com/btc/altcoin-rally" class="news-title" target="_blank" rel="noopener noreferrer">비트코인 반등에 알트코인 동반 상승</a>
+<p class="news-desc">트럼프 대통령이 암호화폐 법안을 공개 지지하면서 시장이 반등했다고 전해집니다-[美증시 특징주]</p>
+<span class="source-tag" data-source-type="default">Example Crypto</span>
+</div>
+</div>
+
+
+<div class="news-card-item news-sev-high">
+<div class="news-card-num">2</div>
+<div class="news-card-thumb"><img src="https://example.com/img/intraday.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div>
+<div class="news-card-body">
+<span class="news-severity news-severity-high">HIGH</span>
+<a href="https://example.com/btc/intraday" class="news-title" target="_blank" rel="noopener noreferrer">비트코인 장중 급락 후 낙폭 축소</a>
+<p class="news-desc">비트코인·알트코인 &#x27;장중 급락&#x27;...주요 변수는 금리와 환율이라는 분석이 나왔습니다.</p>
+<span class="source-tag" data-source-type="default">Example Crypto</span>
+</div>
+</div>
+
+<details><summary>그 외 3건 보기</summary><div class="details-content"><ol class="news-overflow-list">
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/etf.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/etf-inflows" target="_blank" rel="noopener noreferrer">비트코인 현물 ETF 자금 유입 가속</a><span class="overflow-source">Example Crypto</span></span></li>
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/rates.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/rate-cut" target="_blank" rel="noopener noreferrer">금리 인하 기대 약화로 암호화폐 주가 급락 (BTC-USD:Cryptocurrency)</a><span class="overflow-source">Example Crypto</span></span></li>
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/mining.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/difficulty" target="_blank" rel="noopener noreferrer">비트코인 채굴 난이도 사상 최고치 경신</a><span class="overflow-source">Example Crypto</span></span></li>
+</ol></div></details>
+
+
+### 🔵 규제/정책 (2건)
+
+*트럼프 대통령이 암호화폐 법안을 공개 지지하면서 시장이 반등했다고 전해집니다-[美증시 특징주]*
+
+
+<div class="news-card-item news-sev-medium">
+<div class="news-card-num">1</div>
+<div class="news-card-thumb"><img src="https://example.com/img/local.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div>
+<div class="news-card-body">
+<span class="news-severity news-severity-med">MED</span>
+<a href="https://example.com/btc/local-regulation" class="news-title" target="_blank" rel="noopener noreferrer">비트코인 규제 논의 지역 의회로 확산</a>
+<p class="news-desc">비트코인 규제 논의 지역 의회로 확산. 규제 방향이 시장 구조를 바꿀 수 있습니다.</p>
+<span class="source-tag" data-source-type="default">Example Crypto</span>
+</div>
+</div>
+
+<details><summary>그 외 1건 보기</summary><div class="details-content"><ol class="news-overflow-list">
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/altcoin.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/altcoin-rally" target="_blank" rel="noopener noreferrer">비트코인 반등에 알트코인 동반 상승</a><span class="overflow-source">Example Crypto</span></span></li>
+</ol></div></details>
+
+
+### 📊 매크로/금리 (2건)
+
+*선물 미결제약정이 줄면서 변동성이 확대됐다고 거래소가 밝혔습니다.*
+
+<details><summary>그 외 2건 보기</summary><div class="details-content"><ol class="news-overflow-list">
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/rates.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/rate-cut" target="_blank" rel="noopener noreferrer">금리 인하 기대 약화로 암호화폐 주가 급락 (BTC-USD:Cryptocurrency)</a><span class="overflow-source">Example Crypto</span></span></li>
+<li class="overflow-preview"><span class="overflow-thumb"><img src="https://example.com/img/intraday.jpg" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></span><span class="overflow-body"><a href="https://example.com/btc/intraday" target="_blank" rel="noopener noreferrer">비트코인 장중 급락 후 낙폭 축소</a><span class="overflow-source">Example Crypto</span></span></li>
+</ol></div></details>
+

--- a/tests/test_enrichment_synthetic_quality.py
+++ b/tests/test_enrichment_synthetic_quality.py
@@ -186,3 +186,20 @@ def test_hyphen_compound_is_not_a_source_delimiter(title: str) -> None:
     shipped, which had already truncated 13 published blurbs.
     """
     assert _synth(title).startswith(title.rstrip("."))
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        # Title-cleaning paths had the same `\s*` hazard as the description one.
+        # Measured on 4605 corpus titles: 21 were cut inside a compound.
+        "금리 인하 희망이 약화되면서 암호화폐 주가 급락 (BTC-USD:Cryptocurrency)",
+        "비트코인: 약세장에도 무슨 일이 일어나고 있나요? (암호화폐:BTC-USD)",
+        "Bitcoin falls amid prolonged U.S.-Israel-Iran conflict (BTC-USD:Cryptocurrency)",
+    ],
+)
+def test_title_cleaning_keeps_hyphen_compounds(title: str) -> None:
+    """The ticker pair is the subject; cutting at its hyphen loses the subject."""
+    result = _synth(title)
+    tail = title.rsplit("-", 1)[-1].rstrip(").")
+    assert tail in result, f"compound tail {tail!r} was truncated out of {result!r}"

--- a/tests/test_summarizer_themed_news_golden.py
+++ b/tests/test_summarizer_themed_news_golden.py
@@ -4,7 +4,9 @@ This is the PR4 safety net. See .omc/plans/golden-snapshot-themed-news-sections.
 for the full plan. The fixtures cover the 8 cases from the plan's matrix:
 ``tiny_below_threshold``, ``small``, ``medium``, ``large``,
 ``cross_theme_dedup_heavy``, ``korean_only_titles``,
-``mixed_lang_with_synthetic_desc``, and ``image_variants``.
+``mixed_lang_with_synthetic_desc``, and ``image_variants``, plus
+``punctuation_edge_cases`` added 2026-08-06 after a hyphen-truncation
+regression reached main — the golden that caught it did so by accident.
 
 To regenerate the golden after an intentional output change:
     UPDATE_GOLDEN=1 pytest tests/test_summarizer_themed_news_golden.py -q
@@ -29,6 +31,7 @@ from tests.fixtures.themed_news import (  # noqa: E402
     large,
     medium,
     mixed_lang_with_synthetic_desc,
+    punctuation_edge_cases,
     small,
     tiny_below_threshold,
 )
@@ -45,6 +48,7 @@ _CASES = [
     ("korean_only_titles", korean_only_titles),
     ("mixed_lang_with_synthetic_desc", mixed_lang_with_synthetic_desc),
     ("image_variants", image_variants),
+    ("punctuation_edge_cases", punctuation_edge_cases),
 ]
 
 


### PR DESCRIPTION
## 1. 하이픈 오절단 전수 감사 — 2곳 더 있었다

#1087 에서 설명문의 출처 접미사 제거가 하이픈 복합어를 잘랐습니다. 같은 결함이 다른 경로에도 있는지 감사했습니다.

**감사 범위**: 절단 함수 6개(`_truncate_sentence`, `_strip_trailing_artifacts`, `_trim_sentence`, `truncate_sentence`, `_trim_to_sentence`, `_truncate`) + 구분자 정규식 11개.

**실제 위험 2곳** — 둘 다 `\s*[-–—|]\s*\S+$` 로 구분자 앞 공백 0개를 허용:

| 위치 | 용도 |
|---|---|
| `enrichment_synthetic.py` `clean_title` | 제목 끝 매체명 제거 |
| `summarizer.py` `clean` | 동일 |

**실측(코퍼스 제목 4605건)**: 적중 834건 중 **21건이 복합어 절단**.

```
"금리 인하 희망이 약화되면서 암호화폐 주가 급락 (BTC-USD:Cryptocurrency)"
                                          → "…급락 (BTC"
```

수정 후 위험 **0건**, 정상 적중은 813건으로 유지.

### 위험 없음으로 판정한 것들 (근거 포함)

- `_truncate_sentence` / `truncate_sentence` / `_trim_to_sentence` — 문장 종결부호 기준, 하이픈 무관
- `_strip_trailing_artifacts` — 광고 문구 고정 패턴, 구분자 미사용
- `utils.SOURCE_SUFFIX_RE` — 매체명 **고정 목록**. `\s*` 이지만 복합어가 매체명과 일치할 일이 없고, 코퍼스 실측 절단 **0건**이라 그대로 둡니다
- `backfill_post_summaries.py:127`, `collect_crypto_news.py:314` — 이미 `\s+`

## 2. 골든 커버리지 — 왜 우연이었는지

하이픈 회귀를 잡아준 건 `image_variants` 였지만 **우연이었습니다**. 그 설명문에 "multi-month" 가 우연히 들어 있었을 뿐, 구두점 규칙을 겨냥한 시나리오는 8개 중 하나도 없었습니다. 편집이 가장 위험한 지점에 안전망 구멍이 있었던 셈입니다.

`punctuation_edge_cases` 6종으로 각 규칙을 **양방향** 고정:

| # | 규칙 | 기대 |
|---|---|---|
| 1 | 설명문 하이픈 복합어 (`multi-month`) | 보존 |
| 2 | 제목 하이픈 복합어 (`(BTC-USD:Cryptocurrency)`) | 보존 |
| 3 | 공백 있는 출처 접미사 (`- The Sunday Guardian`) | 제거 |
| 4 | 공백 없는 출처 (`-[美증시 특징주]`) | 보존 (규칙 1의 의도된 대가) |
| 5 | 말줄임표 (`...`) | `..` 축약에서 생존 |
| 6 | 파이프 내비 스트립 | 요약으로 렌더 안 됨 |

## 3. `UPDATE_GOLDEN=1` 이 동작하지 않았다

문서화된 골든 재생성 절차가 **런타임 트리-쓰기 탐지기에 막혀** 있었습니다 — 스냅샷은 정의상 커밋된 트리이기 때문입니다.

의도적 재생성만 가드를 일시 해제합니다. 환경변수로 명시적으로 요청한 경우이므로, `tests/snapshots/` 를 통째로 면제 목록에 넣는 것(사고성 쓰기까지 허용)보다 좁은 처리입니다.

> 이때 `tests._tree_write_guard` 와 `_tree_write_guard` 가 **서로 다른 모듈 객체**라 `_INSTALLED` 레지스트리가 갈리는 함정을 만났습니다. conftest 와 동일하게 bare 로 import 합니다.

## 4. 내비 탐지기 — facade 통째 연결은 실측 후 기각

골든이 갭을 드러냈습니다: 렌더러는 `_is_generic_desc` + `_is_boilerplate_desc` 만 호출해, 수집 경로용으로 강화한 사이트 크롬 탐지기가 렌더 시점엔 적용되지 않았습니다.

**`is_boilerplate` facade 를 통째로 연결해 봤고, 실측 후 되돌렸습니다**:

- "35자 미만 + 숫자 없음" 규칙이 **정상적인 짧은 한국어 요약**을 버림
  → `"위원회가 미등록 거래소에 대한 집행 절차를 개시했습니다."` 가 제목 기반 대체로 교체
- 구문 목록이 **출처명만 달린 실제 헤드라인**에 substring 매치
  → `"…암호화폐 시장, 전쟁에서 새로운 관심 끌다 Bloomberg.com"`
- 코퍼스 추가 거부 644건 중 표본 다수가 오탐

대신 정밀한 `_NAV_LINK_LIST_RE` **하나만** 넣습니다. 코퍼스 추가 거부 **29건**, 표본 전부가 진짜 내비/링크목록(`"콜로 | 8 뉴스 지금 | 리노, 네바다"`, `"W베이 | 홈페이지 | 그린베이, 위스콘신"`). **기존 골든 8개는 전부 무변경**입니다.

## 검증

```
$ python3 -m pytest tests/ -q -p no:randomly
5146 passed, 16 skipped · Total coverage: 72.76%

$ python3 -m ruff check scripts/ tests/          # All checks passed!
$ python3 -m ruff format --check scripts/ tests/ # 273 files already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)