### PR TITLE
feat: 구분자 정규식 회귀 가드 + 4번째 오절단 수정 (하네스 47 → 49)

### DIFF
--- a/.github/workflows/guard-falsifiability.yml
+++ b/.github/workflows/guard-falsifiability.yml
@@ -21,6 +21,9 @@ on:
       - 'tests/test_workflow_action_pinning_guard.py'
       - 'tests/test_secret_scan_gate_guard.py'
       - 'tests/test_workflow_permission_gate_guard.py'
+      # 구분자 정규식 가드 — 가드 본체와 감시 대상 소스
+      - 'tests/test_delimiter_regex_guard.py'
+      - 'scripts/common/summarizer.py'
       - '.gitleaks.toml'
       - '.github/workflows/security-scan.yml'
       - '.github/workflows/lighthouse-ci.yml'

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 49 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 132 |
+| 테스트 파일 (tests/test_*.py) | 133 |
 
 <!-- component-counts:end -->

--- a/scripts/collect_crypto_news.py
+++ b/scripts/collect_crypto_news.py
@@ -743,7 +743,11 @@ def _extract_security_summary_from_title(title: str) -> str:
     # 제목 자체가 충분히 설명적이면 그대로 사용
     summary = title.strip()
     # 출처 태그 제거 (e.g., "- CoinDesk", "| The Block")
-    summary = re.sub(r"\s*[-|]\s*[A-Z][\w\s.]+$", "", summary).strip()
+    # `\s+` (not `\s*`): 구분자 앞 공백을 요구한다. 0개를 허용하면 하이픈 복합어를
+    # 잘라 문장을 통째로 날린다 — "…U.S.-Iran conflict drags on for months. 지정학적
+    # 리스크가…" 가 "…U.S." 로, "Sam Bankman-Fried 인터뷰를…" 이 "Sam Bankman" 으로
+    # 줄었다(코퍼스 실측 43건).
+    summary = re.sub(r"\s+[-|]\s*[A-Z][\w\s.]+$", "", summary).strip()
     if len(summary) > 10:
         return summary
     return ""

--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -385,6 +385,24 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         "run: python3 scripts/tools/check_workflow_permissions.py --workflows-dir tests/fixtures",
         "tests/test_workflow_permission_gate_guard.py::test_permission_lint_scans_the_real_workflow_tree",
     ),
+    # Part 5 (2026-08-06): 구분자 정규식 회귀 가드. 같은 결함이 네 번 반복돼
+    # 패턴 자체를 금지했다 — 가드가 실제 위반을 잡는지 여기서 증명한다.
+    StaticCase(
+        "구분자 정규식에 \\s* 재도입 (하이픈 복합어 절단)",
+        "scripts/common/summarizer.py",
+        'clean = re.sub(r"\\s+[-–—|]\\s*\\S+$", "", title).strip()',
+        'clean = re.sub(r"\\s*[-–—|]\\s*\\S+$", "", title).strip()',
+        "tests/test_delimiter_regex_guard.py::test_no_open_ended_delimiter_strip_without_leading_space",
+    ),
+    StaticCase(
+        "구분자 탐지기 무력화 (델리미터 클래스 비움)",
+        "tests/test_delimiter_regex_guard.py",
+        '_DELIM_CLASS = r"\\[[^\\]]*[–—|][^\\]]*\\]"',
+        '_DELIM_CLASS = r"(?!x)x"',
+        # 파라미터라이즈 id 는 유니코드/백슬래시가 이스케이프돼 취약하다. 카나리는
+        # _DELIM_CLASS 를 공유하므로 같은 변형에 red 가 된다.
+        "tests/test_delimiter_regex_guard.py::test_safe_spelling_is_actually_present_in_the_repo",
+    ),
     StaticCase(
         "permission lint 비차단화 (continue-on-error)",
         ".github/workflows/code-quality.yml",

--- a/tests/_golden.py
+++ b/tests/_golden.py
@@ -40,6 +40,17 @@ def assert_golden(name: str, actual: str) -> None:
     actual_norm = _normalize(actual)
 
     if os.environ.get("UPDATE_GOLDEN") == "1":
+        # Regeneration is a local operation. If this ever ran in CI — a repo-level
+        # env var, a copy-pasted step — every snapshot would rewrite itself and
+        # pass, so the whole golden suite would prove nothing while staying
+        # green. That is the failure mode goldens exist to prevent, so refuse
+        # loudly rather than silently rewrite.
+        if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
+            raise AssertionError(
+                "UPDATE_GOLDEN=1 is set in CI. Regenerating snapshots there makes "
+                "every golden test vacuous — it would rewrite the expected output "
+                "and pass. Regenerate locally, review the diff, and commit it."
+            )
         # The runtime tree-write detector refuses writes into the committed
         # tree, which is what a snapshot *is*. Regenerating a golden is the one
         # deliberate exception: the operator asked for it by name via the env

--- a/tests/test_delimiter_regex_guard.py
+++ b/tests/test_delimiter_regex_guard.py
@@ -1,0 +1,161 @@
+"""CI config regression guard: source-delimiter regexes must require a leading space.
+
+A regex that strips a trailing outlet name looks like this:
+
+    re.sub(r"\\s*[-–—|]\\s*\\S+$", "", title)
+
+The `\\s*` allows **zero** spaces before the delimiter, so the hyphen inside a
+compound word matches. The tail after it is then deleted:
+
+    "…net inflows to a multi-month high."       -> "…to a multi"
+    "…미국-이란 평화 협정을 지적했습니다."          -> "…미국"
+    "…(BTC-USD:Cryptocurrency)"                 -> "…(BTC"
+    "…U.S.-Iran conflict drags on for months."  -> "…U.S."
+
+This shipped **four separate times** in this repo (2026-08-06):
+`enrichment_synthetic._strip_source_suffix`, `enrichment_synthetic.clean_title`,
+`summarizer.clean`, and `collect_crypto_news`'s security-summary cleaner. The
+first reached `main` and truncated 13 published blurbs before a golden snapshot
+caught it. Each fix was the same one-character edit, so the pattern is worth
+banning outright rather than re-auditing after the fifth.
+
+Direction: presence — the check is on the *shape of the regex source*, so a new
+delimiter regex written with `\\s+` stays green and only the `\\s*` spelling
+trips.
+
+## What is allowed
+
+* **Fixed alternations** — `\\s*[-–—|]\\s*(?:Reuters|Bloomberg|…)` is safe: a
+  compound word does not match an outlet name. Measured on 4605 corpus titles:
+  zero truncations. These are the majority of the repo's delimiter regexes.
+* **Markdown bullet classes** — `[-*]` is a list marker, not a delimiter. The
+  discriminator is that a delimiter class contains an en dash, em dash, or pipe.
+* **Anchored literals** — `\\s*[-–]\\s*\\d{4}-\\d{2}-\\d{2}$` matches a date, not
+  arbitrary text.
+
+The ban targets exactly the dangerous shape: zero-or-more whitespace, a
+delimiter class, then an *open-ended* tail (`\\S+`, `.{n,m}`, `[A-Z]…`).
+
+Text scan of the source files (no import of the scanned modules, so the guard
+cannot move the coverage gate) per the conventions in
+`docs/devsecops/ci-regression-guards.md`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+
+# Canary: the repo had 100+ Python files under scripts/ when this was written.
+_MIN_SCANNED_FILES = 50
+
+# A character class that acts as a source delimiter carries an en dash, em dash
+# or pipe. `[-*]` (markdown bullet) deliberately does not match.
+_DELIM_CLASS = r"\[[^\]]*[–—|][^\]]*\]"
+
+# The dangerous shape: `\s*` + delimiter class + an **open-ended** tail.
+#
+# Two tail forms are bounded and therefore safe, and both are excluded:
+#   `(?:Reuters|Bloomberg|…)` — a fixed alternation of outlet names
+#   `\d{4}-\d{2}-\d{2}`       — a fixed numeric literal (a trailing date)
+# Everything else (`\S+$`, `.{2,20}$`, `[A-Z][\w\s.]+$`) can swallow arbitrary
+# text once the delimiter matches inside a compound word.
+_UNSAFE_RE = re.compile(r"\\s\*" + _DELIM_CLASS + r"\\s\*(?!\(\?:|\\d)")
+
+# Same shape but with the required leading space — what a fix looks like.
+_SAFE_RE = re.compile(r"\\s\+" + _DELIM_CLASS)
+
+
+def _python_sources() -> list[Path]:
+    return sorted(_SCRIPTS_DIR.rglob("*.py"))
+
+
+def _offenders() -> list[str]:
+    hits: list[str] = []
+    for path in _python_sources():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if _UNSAFE_RE.search(line):
+                rel = path.relative_to(_REPO_ROOT)
+                hits.append(f"{rel}:{lineno}: {line.strip()[:100]}")
+    return hits
+
+
+def test_scripts_tree_exists() -> None:
+    """Canary: a moved tree fails loudly instead of scanning nothing."""
+    assert _SCRIPTS_DIR.is_dir(), f"{_SCRIPTS_DIR} not found"
+    assert len(_python_sources()) >= _MIN_SCANNED_FILES, (
+        f"only {len(_python_sources())} Python files found under scripts/ "
+        f"(expected >= {_MIN_SCANNED_FILES}); the scanner is likely broken."
+    )
+
+
+def test_no_open_ended_delimiter_strip_without_leading_space() -> None:
+    """`\\s*[-–—|]\\s*<open tail>` truncates hyphen compounds. Use `\\s+`."""
+    offenders = _offenders()
+    assert not offenders, (
+        "source-delimiter regex allows zero spaces before the delimiter, so a "
+        "hyphen inside a compound word ('multi-month', 'BTC-USD', '미국-이란') "
+        "is treated as a delimiter and everything after it is deleted:\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+        + "\n\nUse `\\\\s+` instead of `\\\\s*`. A false positive here destroys a "
+        "sentence; a false negative only leaves an outlet name behind, so the "
+        "rule errs toward keeping text. If the tail is a fixed alternation "
+        "`(?:Reuters|Bloomberg|…)` it is already exempt."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detector correctness — both directions, so the guard cannot rot into a no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # The four shapes that actually shipped.
+        r'clean = re.sub(r"\s*[-–—|]\s*\S+$", "", title)',
+        r'_SOURCE_SUFFIX_RE = re.compile(r"\s*[-–—|]\s*(?![^-–—|]*\d)[^-–—|]{2,20}$")',
+        r'summary = re.sub(r"\s*[-|]\s*[A-Z][\w\s.]+$", "", summary)',
+        r'x = re.compile(r"\s*[—]\s*.+$")',
+    ],
+)
+def test_detector_flags_the_dangerous_shape(source: str) -> None:
+    assert _UNSAFE_RE.search(source), f"detector missed a known-dangerous form: {source}"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # Fixed outlet alternation — a compound cannot match an outlet name.
+        r'SOURCE_SUFFIX_RE = re.compile(r"\s*[-–—|]\s*(?:Reuters|Bloomberg|CNBC")',
+        r'(r"\s*[-–—]\s*(?:나스닥|알파 추구|야후 파이낸스)\s*$", "")',
+        # Markdown bullet class — not a delimiter at all.
+        r'content = re.sub(r"(^\s*[-*])\s+-\s+", r"\1 ", content)',
+        r'r"(^\s*[-*]\s+)\[([^\]\n]+)\]"',
+        # Already fixed.
+        r'clean = re.sub(r"\s+[-–—|]\s*\S+$", "", title)',
+        # Fixed numeric literal tail — a trailing date, not arbitrary text.
+        r'clean_title = re.sub(r"\s*[-–]\s*\d{4}-\d{2}-\d{2}\s*$", "", clean_title)',
+    ],
+)
+def test_detector_spares_the_safe_forms(source: str) -> None:
+    assert not _UNSAFE_RE.search(source), f"detector flagged a safe form: {source}"
+
+
+def test_safe_spelling_is_actually_present_in_the_repo() -> None:
+    """Canary: the fixed spelling exists, so the ban is achievable, not aspirational.
+
+    If every call site were rewritten away, this guard would pass vacuously
+    while protecting nothing.
+    """
+    found = any(_SAFE_RE.search(p.read_text(encoding="utf-8")) for p in _python_sources())
+    assert found, (
+        "no `\\\\s+[-–—|]` delimiter regex found anywhere in scripts/. Either the "
+        "call sites moved or the scanner broke — this guard is no longer "
+        "watching what it claims to."
+    )

--- a/tests/test_summarizer_themed_news_golden.py
+++ b/tests/test_summarizer_themed_news_golden.py
@@ -77,3 +77,32 @@ def test_generate_themed_news_sections_golden(
     summarizer = ThemeSummarizer(fixture_mod.ITEMS)
     output = summarizer.generate_themed_news_sections(max_articles=5, featured_count=3)
     assert_golden(f"generate_themed_news_sections/{name}", output)
+
+
+def test_update_golden_is_refused_in_ci(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`UPDATE_GOLDEN=1` in CI would make every golden rewrite itself and pass.
+
+    Goldens exist to fail when output changes unexpectedly; a CI run that
+    regenerates them proves nothing while staying green. CI never sets the var
+    today — this pins that it cannot start doing so silently.
+    """
+    from tests._golden import assert_golden
+
+    monkeypatch.setenv("UPDATE_GOLDEN", "1")
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    with pytest.raises(AssertionError, match="vacuous"):
+        assert_golden("generate_themed_news_sections/small", "anything")
+
+
+def test_update_golden_still_works_locally(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The documented local workflow must keep working — the guard is CI-only."""
+    from tests import _golden
+
+    monkeypatch.setenv("UPDATE_GOLDEN", "1")
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.setattr(_golden, "_SNAPSHOT_ROOT", tmp_path)
+
+    _golden.assert_golden("scratch/case", "recorded output")
+    assert (tmp_path / "scratch" / "case.txt").read_text(encoding="utf-8") == "recorded output"


### PR DESCRIPTION
## 같은 결함이 네 번 반복됐습니다

`\s*[-–—|]\s*<열린 꼬리>` — 구분자 앞 공백을 0개 허용해 **하이픈 복합어**를 구분자로 오인하고 그 뒤를 전부 지웁니다.

| # | 위치 | 발견 경위 |
|---|---|---|
| 1 | `enrichment_synthetic._strip_source_suffix` | 골든마스터 (#1087) — main 에서 13건 피해 |
| 2 | `enrichment_synthetic.clean_title` | 전수 감사 (#1088) |
| 3 | `summarizer.clean` | 전수 감사 (#1088) |
| 4 | **`collect_crypto_news` 보안 요약** | **이 PR** |

매번 고친 건 한 글자였습니다. 다섯 번째를 기다리지 않고 패턴 자체를 금지합니다.

## 4번째 사례 — 피해가 가장 큽니다

```python
re.sub(r"\s*[-|]\s*[A-Z][\w\s.]+$", "", summary)
```

꼬리가 열려 있어 문장을 통째로 날립니다:

```
"…U.S.-Iran conflict drags on for months. 지정학적 리스크가…"  →  "…U.S."
"…Sam Bankman-Fried 인터뷰를 포함하며 4월 17일 극장 개봉…"      →  "…Sam Bankman"
```

**실측(텍스트 9109건)**: 적중 635 중 위험 **43**. 수정 후 적중 592 / 위험 **0**.

## 가드 — `tests/test_delimiter_regex_guard.py`

`scripts/` 전체를 텍스트 스캔해 위험한 형태를 금지합니다. 방향은 presence — `\s+` 로 쓴 새 정규식은 그린이고 `\s*` 철자만 트립합니다.

### 허용 (각각 근거 있음)

| 형태 | 왜 안전한가 |
|---|---|
| `(?:Reuters\|Bloomberg\|…)` 고정 alternation | 복합어가 매체명과 일치할 수 없음. 코퍼스 제목 4605건 실측 절단 **0건** |
| `[-*]` 마크다운 불릿 | 구분자가 아님. 판별 기준은 클래스에 en/em 대시나 파이프가 있는지 |
| `\d{4}-\d{2}-\d{2}$` 고정 숫자 리터럴 | 날짜이지 임의 텍스트가 아님 |

### 탐지기 자체를 지키는 장치

- **양방향 고정** — 실제 출하됐던 4가지 형태는 잡고, 안전한 6가지는 통과
- **카나리** — 고쳐진 `\s+` 철자가 레포에 실제로 존재하는지 확인합니다. 호출부가 전부 사라지면 가드가 아무것도 지키지 않으면서 통과하기 때문입니다

작성 후 실제 위반(summarizer 에 `\s*` 재도입)을 주입해 red 가 되는 것을 확인했습니다.

## 하네스 편입 (47 → 49)

- summarizer 에 `\s*` 재도입 → 가드 red
- 가드의 델리미터 클래스 비우기 → 카나리 red

**49/49 FALSIFIABLE** 확인.

> 처음엔 파라미터라이즈된 node id 를 썼는데 유니코드/백슬래시가 이스케이프돼 `CONTROL-FAIL` 이 났습니다(변형 없이도 실패 = 존재하지 않는 노드). 비-파라미터라이즈 카나리 노드로 바꿨습니다.

## `UPDATE_GOLDEN` CI 경로 검증

CI 는 골든을 **비교만** 하고 `UPDATE_GOLDEN` 을 설정하지 않습니다. 다만 실질적 위험이 있습니다 — 그 변수가 CI 에서 켜지면(레포 레벨 env, 복사된 스텝) **모든 스냅샷이 자기 자신을 재기록하고 통과**해, 골든 스위트 전체가 아무것도 증명하지 않으면서 green 이 됩니다. 골든이 막으려는 실패 모드 그 자체입니다.

CI 감지 시 명시적으로 실패시킵니다. 로컬 재생성 경로는 그대로 동작하며, 양쪽 다 테스트로 고정했습니다.

## 검증

```
$ python3 scripts/tools/guard_falsifiability.py
49/49 guards falsifiable

$ python3 -m pytest tests/ -q -p no:randomly
5161 passed, 16 skipped · Total coverage: 72.76%

$ python3 -m ruff check scripts/ tests/          # All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)