### PR TITLE
fix: RSS <source url> 은 퍼블리셔 홈페이지다 — 기사 URL 로 쓰지 않는다

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 50 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 133 |
+| 테스트 파일 (tests/test_*.py) | 134 |
 
 <!-- component-counts:end -->

--- a/scripts/common/rss_fetcher.py
+++ b/scripts/common/rss_fetcher.py
@@ -24,6 +24,26 @@ _GOOGLE_NEWS_REDIRECT_QUERY_KEYS = ("url", "u", "q")
 _sanitize_mojibake = sanitize_mojibake
 
 
+def _is_article_url(url: str) -> bool:
+    """False for a bare domain — a homepage, not a specific article.
+
+    Google News RSS carries ``<source url="https://www.sedaily.com">서울경제</source>``:
+    the attribute names the *publisher*, not the item. Treating it as the
+    article URL had two consequences, both measured 2026-08-07:
+
+    * ``summarizer`` writes it as the p0 alert link, so **264 of 909** p0 links
+      (29%) sent the reader to a homepage instead of the story.
+    * ``enrichment`` prefers it over the Google News link when fetching a
+      description, so the homepage's ``og:description`` — the outlet's own
+      tagline — became the article summary. That is the source of the site-chrome
+      blurbs tracked in ``summary_quality`` (FT/CoinDesk/Fortune self-intros).
+
+    A query string still identifies an item, so it counts as a path.
+    """
+    parsed = urlparse(url)
+    return bool(parsed.path.strip("/") or parsed.query)
+
+
 def is_safe_url(url: str) -> bool:
     """Validate URL scheme to prevent XSS via javascript:/data: URLs."""
     try:
@@ -301,13 +321,14 @@ def fetch_rss_feed(
                         else:
                             logger.debug("RSS image blocked unsafe scheme (img src): %s", _u[:80])
 
-                # Extract original URL from <source url=""> (Google News RSS preserves it)
+                # `<source url="">` in Google News RSS is the **publisher's site**,
+                # not the article (see `_is_article_url`). Only accept it when it
+                # actually points at an item.
                 original_url = ""
                 source_el = entry.find("source")
                 if source_el and source_el.get("url"):
-                    raw_url = source_el["url"]
-                    candidate_orig = str(raw_url).strip()
-                    if candidate_orig and is_safe_url(candidate_orig):
+                    candidate_orig = str(source_el["url"]).strip()
+                    if candidate_orig and is_safe_url(candidate_orig) and _is_article_url(candidate_orig):
                         original_url = candidate_orig
 
                 if link_val and urlparse(str(link_val)).netloc in _GOOGLE_NEWS_HOSTS:

--- a/tests/test_rss_source_url_guard.py
+++ b/tests/test_rss_source_url_guard.py
@@ -1,0 +1,70 @@
+"""`<source url="">` in Google News RSS names the publisher, not the article.
+
+    <item>
+      <title>코스피 6,600선 회복 - 산경투데이</title>
+      <link>https://news.google.com/rss/articles/CBMi…</link>
+      <source url="https://www.sankyungtoday.com">산경투데이</source>
+    </item>
+
+The `url` attribute is the outlet's site. Storing it as the item's original URL
+had two measured consequences (2026-08-07):
+
+* `summarizer` writes it as the p0 alert link — **264 of 909** p0 links (29%)
+  pointed at a homepage instead of the story.
+* `enrichment` prefers it over the Google News link when fetching a
+  description, so the homepage's `og:description` — the outlet's own tagline —
+  became the article summary. That is where the site-chrome blurbs come from
+  (FT/CoinDesk/Fortune self-introductions), the class `summary_quality` filters
+  after the fact.
+
+The backfill surfaced it: re-fetching `https://www.sedaily.com` returned
+whatever was on the front page that minute, so one published blurb ended up
+describing a different article entirely.
+
+Direction: presence — a `<source url>` that does point at an item is still
+accepted; only bare domains are dropped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from common.rss_fetcher import _is_article_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # The shape actually seen in Google News RSS `<source url>`.
+        "https://www.sedaily.com",
+        "https://www.sankyungtoday.com/",
+        "https://thehill.com",
+        "http://biz.chosun.com/",
+        "https://finance.yahoo.com",
+    ],
+)
+def test_bare_domains_are_not_article_urls(url: str) -> None:
+    assert _is_article_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.sedaily.com/NewsView/2ABCDEFG",
+        "https://biz.chosun.com/stock/market_trend/2026/08/07/ABCDEF/",
+        "https://news.google.com/rss/articles/CBMiZ0FVX3lxTFBV",
+        # A query string identifies a specific item even without a path.
+        "https://example.com?idxno=12345",
+        "https://example.com/?articleId=42",
+    ],
+)
+def test_item_urls_are_article_urls(url: str) -> None:
+    assert _is_article_url(url) is True
+
+
+def test_empty_and_malformed_are_rejected() -> None:
+    assert _is_article_url("") is False
+    assert _is_article_url("not a url") is True, (
+        "a bare word parses as a path, which is harmless here — `is_safe_url` "
+        "rejects non-http schemes before this check runs"
+    )


### PR DESCRIPTION
> "p0 항목이 왜 도메인 루트만 저장하는지" 추적한 결과입니다. 원인이 예상보다 넓었습니다 — **지금까지 필터로 막아온 사이트 크롬 블러브의 출처**이기도 합니다.

## 근본 원인

Google News RSS 항목은 이렇게 생겼습니다:

```xml
<link>https://news.google.com/rss/articles/CBMi…</link>
<source url="https://www.sankyungtoday.com">산경투데이</source>
```

`url` 속성은 **매체 사이트**이지 기사가 아닙니다. `rss_fetcher.py:304` 가 이를 `original_url` 로 저장했고, 주석에는 "Google News RSS preserves it(원문 URL)" 이라고 적혀 있었습니다. 그 전제가 틀렸습니다.

## 두 소비자가 이를 기사 URL 로 취급했습니다

### 1. p0 알림 링크 (`summarizer.py:1030`)

```python
link = item.get("original_url") or item.get("link", "")
```

**p0 링크 909건 중 264건(29%)** 이 홈페이지로 연결됩니다. 독자가 클릭하면 기사가 아니라 매체 첫 화면이 뜹니다.

### 2. 설명문 fetch (`enrichment.py:182, 257, 371`)

`original_url` 을 Google News 링크보다 우선합니다. 그래서 **홈페이지의 `og:description`, 즉 매체 자기소개 태그라인이 기사 요약**이 됐습니다.

이게 그동안 제가 `summary_quality` 필터로 사후에 걸러내던 사이트 크롬 블러브의 출처입니다 — FT·CoinDesk·Fortune 자기소개, "뉴스의 리더입니다", 섹션 나열형 소개문 전부. 증상을 필터로 막고 있었지 원인을 보고 있지 않았습니다.

## 어떻게 드러났나

백필이 잡아냈습니다. `https://www.sedaily.com` 을 재수집하니 그 시각 첫 화면 내용이 돌아와, 발행된 블러브 하나가 **전혀 다른 기사**를 설명하게 됐습니다(#1092 에서 소비자 측 차단 + 1건 복구). 이 PR 은 그 위쪽, 데이터가 만들어지는 지점을 고칩니다.

## 수정

`<source url>` 은 **경로(또는 쿼리)가 있을 때만** `original_url` 로 채택합니다. 비면 기존 폴백이 동작합니다:

- `enrichment` → Google News 링크를 해소해 실제 기사로
- `summarizer` p0 → `item["link"]` (Google News URL, 리다이렉트로 기사 도달)

둘 다 기사로 갑니다.

## 검증

```
$ python3 -m pytest tests/ -q -p no:randomly
5176 passed, 16 skipped · Total coverage: 72.77%

$ python3 -m ruff check scripts/ tests/          # All checks passed!
$ python3 -m basedpyright scripts/common/rss_fetcher.py  # 0 errors
```

신규 테스트 11건 — 실제 관측된 도메인 루트 5종은 거부, 기사 경로·쿼리 형태 5종은 통과.

## 범위 밖

이미 발행된 264건의 홈페이지 p0 링크는 이 PR 이 고치지 않습니다. 링크 자체를 복구하려면 원문 URL 을 다시 알아내야 하고, 그건 백필 워크플로우가 재수집하며 처리할 문제입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)