### PR TITLE
fix: 액션 SHA 핀 3건의 버전 라벨이 거짓이었다 — 업스트림 대조 가드 추가

### DIFF
--- a/.github/workflows/action-pin-verify.yml
+++ b/.github/workflows/action-pin-verify.yml
@@ -1,0 +1,64 @@
+---
+name: Action Pin Verify
+
+# 액션 핀의 `# vX.Y` 라벨이 **실제 업스트림 태그와 일치하는지** 대조한다.
+#
+# 오프라인 가드 두 개가 이미 있다: `test_workflow_action_pinning_guard.py` 는
+# 모든 외부 `uses:` 가 40-hex SHA 핀임을, `test_workflow_action_version_label_guard.py`
+# 는 라벨이 존재하고 서로 모순되지 않음을 강제한다. 하지만 SHA 가 라벨이 주장하는
+# 버전인지는 업스트림만 안다 — 이 잡이 그 마지막 구간이다.
+#
+# 실제로 3건이 거짓이었다: checkout `# v4`(실제 v6.0.2), github-script `# v7`
+# (실제 v9.0.0), git-auto-commit-action `# v5`(실제 v7.1.0). 라벨은 리뷰어가
+# 참조하는 유일한 버전 신호이므로, 틀리면 잘못된 changelog·CVE 목록을 근거로
+# 판단하게 된다.
+#
+# 스케줄이 필요한 이유: 라벨이 옳아도 업스트림이 태그를 삭제·재지정하면 핀이
+# 가리키는 대상의 정체를 더 이상 확인할 수 없게 된다. PR 트리거만으로는 워크플로우
+# 파일을 건드리지 않는 몇 주 동안 그 상태를 놓친다.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - 'scripts/tools/verify_action_pins.py'
+  schedule:
+    # 매주 월요일 06:00 UTC (KST 15:00). guard-falsifiability(05:00 UTC)와
+    # 겹치지 않게 배치.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: action-pin-verify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify action pins against upstream
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.11'
+
+      # 의존성 설치 단계가 없다 — 도구는 stdlib 전용이다. pip 해석 실패로 공급망
+      # 검증이 "설치 실패라 건너뜀"이 되는 경로를 아예 만들지 않는다.
+      #
+      # `--allow-unverified` 를 쓰지 않는다: 확인 불가한 핀도 실패로 취급한다.
+      # 업스트림이 정말 재지정했다면 로컬에서 그 플래그로 확인한 뒤, 핀을 현재
+      # 태그로 옮기고 라벨을 갱신하는 것이 올바른 대응이다.
+      - name: Verify pins
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/tools/verify_action_pins.py

--- a/.github/workflows/alert-consecutive-failures.yml
+++ b/.github/workflows/alert-consecutive-failures.yml
@@ -94,7 +94,7 @@ jobs:
         if: >-
           steps.check.outputs.alert == 'true' &&
           (steps.slack.outputs.can_post != 'true' || steps.post-slack.outcome == 'failure')
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const title = `[alert-delivery-failed] ${{ inputs.workflow-name }} consecutive failures (Slack notify failed)`;

--- a/.github/workflows/guard-falsifiability.yml
+++ b/.github/workflows/guard-falsifiability.yml
@@ -19,6 +19,8 @@ on:
       - '.github/workflows/code-quality.yml'
       # 공급망/시크릿 가드 — 가드 본체와 감시 대상 설정 양쪽
       - 'tests/test_workflow_action_pinning_guard.py'
+      - 'tests/test_workflow_action_version_label_guard.py'
+      - '.github/workflows/action-pin-verify.yml'
       - 'tests/test_secret_scan_gate_guard.py'
       - 'tests/test_workflow_permission_gate_guard.py'
       # 구분자 정규식 가드 — 가드 본체와 감시 대상 소스
@@ -46,7 +48,7 @@ concurrency:
 jobs:
   falsifiability:
     runs-on: ubuntu-latest
-    # 케이스당 pytest 를 2회(patched/control) 띄우므로 47종 = 94회 프로세스 기동.
+    # 케이스당 pytest 를 2회(patched/control) 띄우므로 55종 = 110회 프로세스 기동.
     # 가드 테스트 자체는 각 1초 미만이고 대부분이 인터프리터 시작 비용이다.
     #
     # 샤딩: 케이스가 **실제 레포 파일**을 변형했다 복원하므로 한 체크아웃 안에서
@@ -56,7 +58,7 @@ jobs:
     # 가드 하나가 검증되지 않은 채 CI 가 그린인 상태를 만든다.
     #
     # 실측 추이: 11케이스 1m44s -> 37케이스 3m49s -> 47케이스 4m09s (약 5s/케이스).
-    # 8샤드면 샤드당 6케이스 안팎으로 ~1분.
+    # 8샤드면 55케이스 기준 샤드당 7케이스 안팎으로 ~1분.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/notify-deploy-status.yml
+++ b/.github/workflows/notify-deploy-status.yml
@@ -73,7 +73,7 @@ jobs:
         if: >-
           steps.slack.outputs.can_post != 'true' ||
           steps.post-slack.outcome == 'failure'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const state = context.payload.deployment_status.state;

--- a/.github/workflows/supply-chain-lock-promotion-reminder.yml
+++ b/.github/workflows/supply-chain-lock-promotion-reminder.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 1
 
       - name: Open promotion reminder issue if due and still non-blocking
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/watchdog-zero-job-runs.yml
+++ b/.github/workflows/watchdog-zero-job-runs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 1
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Commit updated seen-IDs state
         if: steps.scan.outputs.state_changed == 'true'
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v5
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
         with:
           commit_message: "chore(watchdog): startup_failure 감지 상태 업데이트"
           file_pattern: "_state/watchdog_zero_job_seen.json"

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -11,8 +11,8 @@
 | 수집기 (scripts/collect_*.py) | 13 |
 | 생성기 (scripts/generate_*.py) | 6 |
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
-| GitHub Actions 워크플로우 (.github/workflows/*.yml) | 51 |
+| GitHub Actions 워크플로우 (.github/workflows/*.yml) | 52 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 134 |
+| 테스트 파일 (tests/test_*.py) | 135 |
 
 <!-- component-counts:end -->

--- a/docs/devsecops/ci-regression-guards.md
+++ b/docs/devsecops/ci-regression-guards.md
@@ -14,20 +14,41 @@ System Configuration), NIST SSDF(SP 800-218) **PO.3 / PW.4**.
 
 | 가드 테스트 | 케이스 | 불변식 (방향) | 막는 사고 |
 |---|---|---|---|
-| `tests/test_state_path_anchoring.py` | 16 | 모든 `_state` 작성자가 `__file__` 앵커(절대·repo-root 하위)를 쓴다 — bare-relative 금지 | 잘못된 cwd 에서 스크립트 실행 시 stray `scripts/_state/` 생성, dedup 상태 분기 |
+| `tests/test_state_path_anchoring.py` | 18 | 모든 `_state` 작성자가 `__file__` 앵커(절대·repo-root 하위)를 쓴다 — bare-relative 금지 | 잘못된 cwd 에서 스크립트 실행 시 stray `scripts/_state/` 생성, dedup 상태 분기 |
 | `tests/test_pip_audit_ignore_sync.py` | 4 | `code-quality.yml` ↔ `dependency-check.yml` 의 pip-audit `--ignore-vuln` ID 집합 동일(equality), 파일 내 모든 호출이 동일 집합 보유 | 한쪽만 ignore 갱신 → 다른 쪽 보안 게이트 매주 silent red (2026-06 사고) |
 | `tests/test_ruff_version_pin_sync.py` | 3 | ruff 버전 핀 3곳(`.pre-commit-config.yaml` rev, `requirements-dev.txt`, `code-quality.yml`) 동기화(equality) | 핀 불일치 → format 규칙 차이로 코드 변경 없이 main 이 red |
-| `tests/test_workflow_step_if_safety.py` | 48 | step-level `if:` 가 `secrets.*` 컨텍스트를 직접 참조하지 않음(presence) — 전 워크플로우 파라미터화 | actionlint 가 거부하는 expression → 워크플로우 startup_failure |
+| `tests/test_workflow_step_if_safety.py` | 53 | step-level `if:` 가 `secrets.*` 컨텍스트를 직접 참조하지 않음(presence) — 전 워크플로우 파라미터화 | actionlint 가 거부하는 expression → 워크플로우 startup_failure |
 | `tests/test_workflow_permission_lint.py` | 8 | `check_workflow_permissions.py` 도구가 워크플로우 `permissions:` 최소권한 규칙을 검사 | 과대 권한(`contents: write` 남발) GITHUB_TOKEN 노출면 확대 |
 | `tests/test_generated_image_guard.py` | 2 | 레이아웃이 렌더하는 생성 이미지가 404 나지 않음(존재 보장) | 30일 이미지 정리가 참조 살아있는 og/hero 이미지를 삭제 → 깨진 이미지 |
 | `tests/test_encoding_guard.py` | 16 | `encoding_guard` 모듈의 UTF-8/CP949 라벨 교정 동작 불변 | 한국어 텍스트 인코딩 깨짐(mojibake) |
 | `tests/test_requirements_lock_coverage.py` | 6 | `requirements.txt` 직접 의존성 전부가 `requirements.lock` 에 ==핀(부분집합) + 락의 모든 핀이 최소 1개 `--hash` 보유(presence) | 락 staleness(검증 안 되는 새 의존성) / hashless 핀이 `--require-hashes` 무결성 검증을 무력화하는 공급망 변조 창 |
 | `tests/test_workflow_action_pinning_guard.py` | 4 | `.github/workflows/**` · `.github/actions/**` 의 모든 외부 `uses:` 가 40-hex SHA 핀(presence) + 탐지기 양방향 | 가변 태그(`@v4`)/브랜치 참조 → 업스트림 변조가 diff 없이 CI 에서 실행 |
+| `tests/test_workflow_action_version_label_guard.py` | 7 | 모든 핀이 `# vX.Y` 라벨 보유 + 라벨이 버전 형태(presence), 한 SHA 에 모순 라벨 금지 · 한 버전이 두 SHA 로 분기 금지(내부 정합성), 비교기 양방향 | SHA 는 핀됐지만 라벨이 거짓 → 리뷰어·Dependabot 이 잘못된 changelog·CVE 목록을 근거로 판단 (2026-08-07 감사에서 3건: checkout `# v4`→실제 v6.0.2, github-script `# v7`→v9.0.0, git-auto-commit `# v5`→v7.1.0) |
 | `tests/test_secret_scan_gate_guard.py` | 7 | Gitleaks 게이트 무결성: `useDefault=true`(presence), allowlist `targetRules`/`paths` 집합 동일(==), 게이트 차단성(no `continue-on-error`/`\|\| true`), `fetch-depth: 0`(presence) | 잡은 남아있는데 룰셋 해제·allowlist 확대·exit 흡수·히스토리 절단으로 시크릿 스캔이 조용히 무력화 |
 | `tests/test_delimiter_regex_guard.py` | 13 | 출처 구분자 정규식이 구분자 앞 공백을 **요구**한다(`\s+`, presence) — 열린 꼬리 형태만 대상, 고정 alternation·마크다운 불릿·고정 숫자 리터럴은 면제 | `\s*` 는 복합어 내부 하이픈을 구분자로 오인해 뒤를 전부 삭제 (2026-08-06 4회 반복, main 에 13건 피해) |
 | `tests/test_workflow_permission_gate_guard.py` | 4 | `code-quality.yml` 이 `check_workflow_permissions.py` 를 `--workflows-dir .github/workflows` 로 차단 실행(presence) | 도구 단위 테스트는 green 인데 CI 배선만 끊겨 2026-04-23 수집기 장애 클래스가 재무방비 |
 
-총 **131 케이스**.
+총 **145 케이스**.
+
+> 2026-08-07 실측 재집계. 이전 표기(131)는 `test_state_path_anchoring`(16→18)과
+> `test_workflow_step_if_safety`(48→53, 워크플로우 수에 파라미터라이즈됨)가
+> 자라는 동안 갱신되지 않아 stale 했다.
+
+### 오프라인 가드로 끝나지 않는 축: 액션 핀 라벨
+
+`test_workflow_action_version_label_guard.py` 는 네트워크 없이 판정 가능한
+층까지만 강제한다 — 라벨의 존재·형태, 그리고 라벨들 사이의 모순. "이 SHA 가
+정말 `# v6.0.2` 인가"는 업스트림만 답할 수 있고, 스위트는
+`tests/conftest.py` 가 HTTP 를 차단하므로(의도된 설계) 여기서 물을 수 없다.
+
+그 마지막 구간은 `.github/workflows/action-pin-verify.yml` 이 담당한다:
+`scripts/tools/verify_action_pins.py` 가 각 핀을 GitHub API 로 대조하고,
+MISMATCH 면 실패한다. 워크플로우/액션 변경 PR + 주간 스케줄로 돈다(주간이 필요한
+이유는 업스트림 태그 삭제·재지정이 우리 diff 없이 일어나기 때문).
+
+역할 분담이 이렇게 갈린 결과, 2026-08-07 감사에서 나온 3건 중 2건(같은 SHA 에
+`# v4`/`# v6`, `# v7`/`# v9.0.0`)은 오프라인 가드가 잡고, 1건(`# v5` 가 단 한 곳에만
+있어 비교 대상이 없던 v7.1.0 핀)은 온라인 잡만 잡는다.
 
 > 공급망/시크릿 3종(2026-08-06 추가)의 배경: `security-scan.yml` 의
 > `actions-permissions` 잡은 이름과 달리 **build 를 실패시킬 수 없다** — 모든 발견이

--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -410,6 +410,60 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         "      - name: Check reusable workflow permission coverage\n        continue-on-error: true\n",
         "tests/test_workflow_permission_gate_guard.py::test_permission_lint_step_is_blocking",
     ),
+    # ---------------------------------------------------------------------
+    # Part 6 (2026-08-07): 액션 핀 **버전 라벨** 축. Part 4 의 핀닝 가드는 SHA
+    # 형식만 본다 — 40-hex 이기만 하면 `# v4` 라벨이 실제로 v6.0.2 를 가리켜도
+    # green 이다. 감사 시점에 그런 거짓 라벨이 3건 있었다(checkout `# v4`→v6.0.2,
+    # github-script `# v7`→v9.0.0, git-auto-commit `# v5`→v7.1.0).
+    #
+    # 업스트림 대조는 네트워크가 필요해 `.github/workflows/action-pin-verify.yml`
+    # 이 담당하고, 여기서 검증하는 건 네트워크 없이 판정 가능한 오프라인 불변식
+    # 층이다 — 라벨 존재·형태, 그리고 라벨끼리의 모순.
+    # ---------------------------------------------------------------------
+    StaticCase(
+        "액션 핀에서 버전 라벨 제거",
+        ".github/workflows/action-pin-verify.yml",
+        "uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0",
+        "uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
+        "tests/test_workflow_action_version_label_guard.py::test_every_pin_carries_a_version_label",
+    ),
+    StaticCase(
+        "버전 라벨을 비교 불가한 문자열로 (# latest)",
+        ".github/workflows/action-pin-verify.yml",
+        "uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0",
+        "uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # latest",
+        "tests/test_workflow_action_version_label_guard.py::test_version_labels_are_version_shaped",
+    ),
+    StaticCase(
+        "같은 SHA 에 모순 라벨 (# v6 -> # v4, 타 워크플로우는 v6 유지)",
+        ".github/workflows/action-pin-verify.yml",
+        "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6",
+        "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4",
+        "tests/test_workflow_action_version_label_guard.py::test_one_sha_never_carries_contradictory_labels",
+    ),
+    StaticCase(
+        "한 버전이 두 SHA 로 분기 (절반만 적용된 bump)",
+        ".github/workflows/action-pin-verify.yml",
+        "      - name: Setup Python\n",
+        "      - name: Half-applied bump probe\n        uses: actions/checkout@"
+        + "c" * 40
+        + "  # v6\n\n      - name: Setup Python\n",
+        "tests/test_workflow_action_version_label_guard.py::test_one_claimed_version_never_maps_to_two_shas",
+    ),
+    StaticCase(
+        "라벨 비교기 무력화 (모든 라벨을 호환으로 판정)",
+        "tests/test_workflow_action_version_label_guard.py",
+        "    return longer[: len(shorter)] == shorter",
+        "    return True",
+        "tests/test_workflow_action_version_label_guard.py::test_label_comparison_is_bidirectional",
+    ),
+    StaticCase(
+        "라벨 가드 스캐너 붕괴 (핀을 하나도 못 찾음)",
+        "tests/test_workflow_action_version_label_guard.py",
+        "?uses:",
+        "?usez:",
+        "tests/test_workflow_action_version_label_guard.py::test_pin_count_is_plausible",
+    ),
 )
 
 

--- a/scripts/tools/verify_action_pins.py
+++ b/scripts/tools/verify_action_pins.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Verify every SHA-pinned GitHub Action really *is* the version its comment claims.
+
+## The blind spot this closes
+
+`tests/test_workflow_action_pinning_guard.py` proves every external `uses:` is
+pinned to a 40-hex SHA, and `tests/test_workflow_action_version_label_guard.py`
+proves each pin carries a `# vX.Y` label and that two labels for the same SHA
+never contradict each other. Both are **offline** checks: neither can tell
+whether the SHA actually belongs to the claimed version. Only upstream knows.
+
+That gap is not theoretical. When this tool was written it found three pins whose
+labels were false:
+
+| ref | label | actual |
+|---|---|---|
+| `actions/checkout@de0fac2e` | `# v4` | v6.0.2 |
+| `actions/github-script@3a2844b7` | `# v7` | v9.0.0 |
+| `stefanzweifel/git-auto-commit-action@04702edd` | `# v5` | v7.1.0 |
+
+The label is the only human-readable version signal in a workflow — a reviewer
+reading `# v5` on a v7.1.0 pin reasons about the wrong action's behaviour,
+changelog, and CVEs. The SHA pin keeps CI *reproducible*; the label is what keeps
+it *reviewable*.
+
+## Not everything that differs is wrong
+
+A floating major tag moves. `actions/cache/restore@27d5ce7f  # v5` is pinned to
+what `v5` meant when Dependabot last bumped it (v5.0.5); `v5` upstream has since
+advanced. That is normal lag, not a false label — so this tool compares against
+the *immutable* tag the SHA belongs to, not against wherever the floating tag
+currently points, and accepts any tag whose version is a component-wise extension
+of the label (`v5` ⊇ `v5.0.5`).
+
+Two pin forms are both legitimate and both handled:
+
+* **commit SHA** — the usual case. Resolved by scanning immutable tags whose name
+  extends the label (`GET /git/matching-refs/tags/<label>`) and dereferencing
+  each to its commit.
+* **annotated tag-object SHA** — e.g. `github/codeql-action/upload-sarif@256d6340`
+  is the `v4` *tag object*, not a commit. Tag objects are content-addressed, so
+  this is every bit as immutable as a commit pin. `GET /git/tags/<sha>` names it
+  directly, which is why that lookup runs first.
+
+## Usage
+
+    python scripts/tools/verify_action_pins.py
+    python scripts/tools/verify_action_pins.py --allow-unverified
+
+Set `GITHUB_TOKEN` (or `GH_TOKEN`) to lift the 60 req/h anonymous rate limit.
+Exit 0 when every pin verifies, 1 on any MISMATCH (and on UNVERIFIED unless
+`--allow-unverified`).
+
+stdlib-only on purpose: the CI job needs no `pip install` step, so a dependency
+resolution failure can never turn this supply-chain check green-by-skipping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "common"))
+from config import setup_logging  # noqa: E402
+
+logger = setup_logging("verify_action_pins")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+ACTIONS_DIR = REPO_ROOT / ".github" / "actions"
+
+API_ROOT = "https://api.github.com"
+REQUEST_TIMEOUT = 15  # scripts/common/config.py convention
+
+# `uses: owner/repo[/sub/path]@<40-hex>` optionally followed by a `# version`
+# comment. Anchored at the YAML key so prose mentioning `uses:` is not matched.
+_PIN_RE = re.compile(
+    r"^\s*(?:-\s+)?uses:\s*(?P<ref>[^@\s'\"]+)@(?P<sha>[0-9a-f]{40})(?:\s*#\s*(?P<label>\S+))?",
+    re.M,
+)
+
+
+@dataclass(frozen=True)
+class Pin:
+    """One deduplicated `owner/repo[/path]@sha  # label` reference."""
+
+    ref: str  # full path incl. sub-action, e.g. actions/cache/restore
+    sha: str
+    label: str | None
+
+    @property
+    def repo(self) -> str:
+        """`owner/repo` — the API-addressable part of a sub-path action."""
+        return "/".join(self.ref.split("/")[:2])
+
+
+def collect_pins() -> list[Pin]:
+    """Every distinct SHA-pinned external reference across workflows and actions."""
+    sources = sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(ACTIONS_DIR.glob("*/action.yml"))
+    pins: set[Pin] = set()
+    for path in sources:
+        for match in _PIN_RE.finditer(path.read_text(encoding="utf-8")):
+            ref = match.group("ref")
+            if ref.startswith("./"):
+                continue  # local action — checked out with the calling commit
+            pins.add(Pin(ref=ref, sha=match.group("sha"), label=match.group("label")))
+    return sorted(pins, key=lambda p: (p.ref, p.label or "", p.sha))
+
+
+def _api(path: str) -> object | None:
+    """GET a GitHub API path. `None` on 404/422 (absent object), raises otherwise."""
+    request = urllib.request.Request(
+        f"{API_ROOT}{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "investing-verify-action-pins",
+        },
+    )
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:  # noqa: S310 - fixed https host
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code in (404, 422):
+            return None
+        raise
+
+
+def version_parts(label: str) -> tuple[int, ...] | None:
+    """`v5.0.5` -> `(5, 0, 5)`. `None` for tags that are not dotted numerics."""
+    stripped = label[1:] if label.startswith(("v", "V")) else label
+    if not stripped or not re.fullmatch(r"\d+(\.\d+)*", stripped):
+        return None
+    return tuple(int(part) for part in stripped.split("."))
+
+
+def labels_compatible(label: str, actual: str) -> bool:
+    """True when `actual` is the same version as `label`, or a refinement of it.
+
+    `v5` vs `v5.0.5` -> True (a floating major pinned at a concrete patch).
+    `v4` vs `v6.0.2` -> False (different major — the label lies).
+    Non-numeric tags (`codeql-bundle-...`) compare exactly.
+    """
+    if label == actual:
+        return True
+    left, right = version_parts(label), version_parts(actual)
+    if left is None or right is None:
+        return False
+    shorter, longer = sorted((left, right), key=len)
+    return longer[: len(shorter)] == shorter
+
+
+def _deref_to_commit(repo: str, sha: str, obj_type: str) -> str | None:
+    """Resolve a ref target to a commit SHA, unwrapping one annotated-tag layer."""
+    if obj_type == "commit":
+        return sha
+    tag = _api(f"/repos/{repo}/git/tags/{sha}")
+    if isinstance(tag, dict):
+        return (tag.get("object") or {}).get("sha")
+    return None
+
+
+def resolve_tag_names(pin: Pin) -> list[str]:
+    """Immutable tag name(s) the pinned SHA belongs to, best-effort.
+
+    Two lookups, cheapest and most authoritative first:
+
+    1. the SHA *is* an annotated tag object -> that tag's own name;
+    2. the SHA is a commit -> any tag whose name extends the label and
+       dereferences to it. Scoped by `matching-refs` to keep the call count
+       bounded on repos with thousands of tags (`github/codeql-action`).
+    """
+    tag_object = _api(f"/repos/{pin.repo}/git/tags/{pin.sha}")
+    if isinstance(tag_object, dict) and tag_object.get("tag"):
+        return [str(tag_object["tag"])]
+
+    if pin.label is None:
+        return []
+
+    refs = _api(f"/repos/{pin.repo}/git/matching-refs/tags/{pin.label}")
+    if not isinstance(refs, list):
+        return []
+    names: list[str] = []
+    for ref in refs:
+        obj = (ref or {}).get("object") or {}
+        name = str(ref.get("ref", "")).removeprefix("refs/tags/")
+        if not name:
+            continue
+        if obj.get("sha") == pin.sha:  # pinned directly at the tag object
+            names.append(name)
+            continue
+        if _deref_to_commit(pin.repo, str(obj.get("sha")), str(obj.get("type"))) == pin.sha:
+            names.append(name)
+    return names
+
+
+# Reverse lookup scans the most recent tags only. Enough to name a stale label
+# (`v7` on a v9 SHA) without paginating thousands of tags on github/codeql-action.
+_REVERSE_LOOKUP_PAGES = 3
+
+
+def reverse_lookup_tags(pin: Pin) -> list[str]:
+    """Tag name(s) pointing at the pinned SHA, searched *without* the label as a hint.
+
+    `resolve_tag_names` only looks under the claimed version, so a label naming
+    the wrong major finds nothing and would land in the soft UNVERIFIED bucket
+    next to genuine upstream retags. This names what the SHA actually is, which
+    both makes the error actionable and promotes it to a hard MISMATCH.
+    """
+    names: list[str] = []
+    for page in range(1, _REVERSE_LOOKUP_PAGES + 1):
+        tags = _api(f"/repos/{pin.repo}/tags?per_page=100&page={page}")
+        if not isinstance(tags, list) or not tags:
+            break
+        names.extend(
+            str(tag["name"])
+            for tag in tags
+            if ((tag or {}).get("commit") or {}).get("sha") == pin.sha and tag.get("name")
+        )
+    return names
+
+
+def verify(pin: Pin) -> tuple[str, str]:
+    """`(verdict, detail)` where verdict is OK / MISMATCH / UNVERIFIED / NO-LABEL."""
+    if pin.label is None:
+        return "NO-LABEL", "no `# version` comment — nothing to verify against"
+    names = resolve_tag_names(pin)
+    if names and any(labels_compatible(pin.label, name) for name in names):
+        return "OK", ", ".join(names)
+    actual = names or reverse_lookup_tags(pin)
+    if actual:
+        return "MISMATCH", f"SHA is {', '.join(actual)} — label claims {pin.label}"
+    return "UNVERIFIED", f"no tag matching {pin.label} points at this SHA, and no other tag names it either"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--allow-unverified",
+        action="store_true",
+        help="exit 0 when a pin cannot be resolved upstream (still fails on MISMATCH)",
+    )
+    args = parser.parse_args()
+
+    pins = collect_pins()
+    if not pins:
+        logger.error("no SHA-pinned external actions found — the parser is broken, not the repo")
+        return 1
+
+    failures: list[str] = []
+    soft: list[str] = []
+    for pin in pins:
+        verdict, detail = verify(pin)
+        line = f"{verdict:<10} {pin.ref}@{pin.sha[:8]}  # {pin.label or '-'}  ({detail})"
+        if verdict == "MISMATCH":
+            logger.error(line)
+            failures.append(line)
+        elif verdict in ("UNVERIFIED", "NO-LABEL"):
+            logger.warning(line)
+            soft.append(line)
+        else:
+            logger.info(line)
+
+    logger.info("%d pins checked: %d mismatch, %d unverified", len(pins), len(failures), len(soft))
+    if failures:
+        logger.error("version label(s) contradict upstream — correct the `# vX.Y` comment to the actual tag")
+        return 1
+    if soft and not args.allow_unverified:
+        logger.error("unresolved pin(s); re-run with --allow-unverified if upstream retagged")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/verify_action_pins.py
+++ b/scripts/tools/verify_action_pins.py
@@ -63,6 +63,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -114,10 +115,37 @@ def collect_pins() -> list[Pin]:
     return sorted(pins, key=lambda p: (p.ref, p.label or "", p.sha))
 
 
+def _segment(value: str) -> str:
+    """Percent-encode a path segment taken from workflow YAML.
+
+    `repo` and `label` come out of files on disk, so they reach the URL as
+    attacker-influenced-in-principle input. Encoding stops a `?` or `/` in a
+    version comment from splicing on a query string or an extra path segment.
+
+    It does *not* stop `..` — dots are unreserved, so `quote` leaves them
+    untouched. Traversal is rejected in `_api` instead.
+    """
+    return urllib.parse.quote(value, safe="")
+
+
+def _repo_path(repo: str) -> str:
+    """`owner/name` with each half encoded independently, so the `/` survives."""
+    return "/".join(_segment(part) for part in repo.split("/"))
+
+
 def _api(path: str) -> object | None:
     """GET a GitHub API path. `None` on 404/422 (absent object), raises otherwise."""
+    url = f"{API_ROOT}{path}"
+    parsed = urllib.parse.urlparse(url)
+    # `hostname`, not a substring check: `https://api.github.com@evil.example.com`
+    # and `https://api.github.com.evil.com` both contain the literal host.
+    if parsed.scheme != "https" or parsed.hostname != "api.github.com":
+        raise ValueError(f"refusing to fetch off-host URL: {url}")
+    if ".." in parsed.path.split("/"):
+        raise ValueError(f"refusing to fetch traversing path: {url}")
+
     request = urllib.request.Request(
-        f"{API_ROOT}{path}",
+        url,
         headers={
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
@@ -128,7 +156,9 @@ def _api(path: str) -> object | None:
     if token:
         request.add_header("Authorization", f"Bearer {token}")
     try:
-        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:  # noqa: S310 - fixed https host
+        # Scheme and host are asserted above and every interpolated segment is
+        # percent-encoded, so no `file:`/custom-scheme path reaches urlopen.
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:  # noqa: S310  # nosec B310
             return json.load(response)
     except urllib.error.HTTPError as exc:
         if exc.code in (404, 422):
@@ -164,7 +194,7 @@ def _deref_to_commit(repo: str, sha: str, obj_type: str) -> str | None:
     """Resolve a ref target to a commit SHA, unwrapping one annotated-tag layer."""
     if obj_type == "commit":
         return sha
-    tag = _api(f"/repos/{repo}/git/tags/{sha}")
+    tag = _api(f"/repos/{_repo_path(repo)}/git/tags/{_segment(sha)}")
     if isinstance(tag, dict):
         return (tag.get("object") or {}).get("sha")
     return None
@@ -180,14 +210,14 @@ def resolve_tag_names(pin: Pin) -> list[str]:
        dereferences to it. Scoped by `matching-refs` to keep the call count
        bounded on repos with thousands of tags (`github/codeql-action`).
     """
-    tag_object = _api(f"/repos/{pin.repo}/git/tags/{pin.sha}")
+    tag_object = _api(f"/repos/{_repo_path(pin.repo)}/git/tags/{_segment(pin.sha)}")
     if isinstance(tag_object, dict) and tag_object.get("tag"):
         return [str(tag_object["tag"])]
 
     if pin.label is None:
         return []
 
-    refs = _api(f"/repos/{pin.repo}/git/matching-refs/tags/{pin.label}")
+    refs = _api(f"/repos/{_repo_path(pin.repo)}/git/matching-refs/tags/{_segment(pin.label)}")
     if not isinstance(refs, list):
         return []
     names: list[str] = []
@@ -219,7 +249,7 @@ def reverse_lookup_tags(pin: Pin) -> list[str]:
     """
     names: list[str] = []
     for page in range(1, _REVERSE_LOOKUP_PAGES + 1):
-        tags = _api(f"/repos/{pin.repo}/tags?per_page=100&page={page}")
+        tags = _api(f"/repos/{_repo_path(pin.repo)}/tags?per_page=100&page={page}")
         if not isinstance(tags, list) or not tags:
             break
         names.extend(

--- a/tests/test_workflow_action_version_label_guard.py
+++ b/tests/test_workflow_action_version_label_guard.py
@@ -1,0 +1,225 @@
+"""CI config regression guard: every action pin carries a truthful version label.
+
+`test_workflow_action_pinning_guard.py` proves each external `uses:` is pinned to
+a 40-hex SHA. A SHA alone is reproducible but unreadable — the trailing
+`# vX.Y` comment is the only version signal a reviewer, or Dependabot's PR
+description, has to reason about. If it drifts from the SHA, everyone downstream
+reasons about the wrong action: the wrong changelog, the wrong CVE list, the
+wrong breaking changes.
+
+It had drifted. When this guard was written three pins were mislabeled:
+
+| ref | label | actually |
+|---|---|---|
+| `actions/checkout@de0fac2e` | `# v4` | v6.0.2 |
+| `actions/github-script@3a2844b7` | `# v7` | v9.0.0 |
+| `stefanzweifel/git-auto-commit-action@04702edd` | `# v5` | v7.1.0 |
+
+## Division of labour with the online verifier
+
+Proving a label matches upstream needs the network, and `tests/conftest.py`
+blocks outbound HTTP for the whole suite on purpose (see
+`reference_ci_network_not_isolated_http_guard`). So the authoritative comparison
+lives in `scripts/tools/verify_action_pins.py`, run by
+`.github/workflows/action-pin-verify.yml`.
+
+What is left for a *blocking* offline test is everything derivable from the repo
+alone, and that turns out to include two of the three real defects above:
+
+* a label must exist at all, and be version-shaped — otherwise there is nothing
+  for the online verifier to compare against (presence);
+* one SHA must not carry two contradictory labels — `# v4` and `# v6` on the same
+  40 hex characters means at least one is a lie, provable without any network
+  (internal consistency);
+* one claimed version must not map to two different SHAs — that is a half-applied
+  bump, where some workflows moved and others silently did not.
+
+The third defect (`# v5` on a v7.1.0 SHA, appearing exactly once) is only
+detectable upstream; that is precisely why the online job exists too.
+
+Deliberately self-contained: this test does **not** import
+`scripts/tools/verify_action_pins.py`. That module defines `REPO_ROOT`, and
+importing production path anchors into a test trips
+`test_hermetic_test_writes_guard.py`; it would also fold a tool into the coverage
+measurement this guard has no business moving. Text scan only, per
+`docs/devsecops/ci-regression-guards.md`.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+_ACTIONS_DIR = _REPO_ROOT / ".github" / "actions"
+
+# Canary floor: 20+ distinct external pins existed when this guard was written.
+_MIN_PINS = 15
+
+# `uses: owner/repo[/sub/path]@<40-hex>` plus an optional `# label`. The label
+# group stays optional on purpose — a missing label is a finding, not a
+# non-match, so it must reach the assertion rather than be skipped by the regex.
+_PIN_RE = re.compile(
+    r"^\s*(?:-\s+)?uses:\s*(?P<ref>[^@\s'\"]+)@(?P<sha>[0-9a-f]{40})(?P<tail>[^\n]*)",
+    re.M,
+)
+_LABEL_RE = re.compile(r"#\s*(?P<label>\S+)")
+
+# `v1`, `v6.0.2`, `1.302.0`. Anything else (`# latest`, `# pinned`, `# TODO`)
+# would satisfy "a label exists" while carrying no comparable version.
+_VERSION_SHAPED_RE = re.compile(r"^v?\d+(\.\d+)*$")
+
+
+def _yaml_sources() -> list[Path]:
+    return sorted(_WORKFLOWS_DIR.glob("*.yml")) + sorted(_ACTIONS_DIR.glob("*/action.yml"))
+
+
+def _pins() -> list[tuple[Path, str, str, str | None]]:
+    """`(file, ref, sha, label)` for every external SHA-pinned reference."""
+    found: list[tuple[Path, str, str, str | None]] = []
+    for path in _yaml_sources():
+        for match in _PIN_RE.finditer(path.read_text(encoding="utf-8")):
+            ref = match.group("ref")
+            if ref.startswith("./"):
+                continue
+            label_match = _LABEL_RE.search(match.group("tail"))
+            found.append((path, ref, match.group("sha"), label_match.group("label") if label_match else None))
+    return found
+
+
+def _repo_of(ref: str) -> str:
+    """`actions/cache/restore` -> `actions/cache`: sub-path actions share a repo."""
+    return "/".join(ref.split("/")[:2])
+
+
+def _version_parts(label: str) -> tuple[int, ...] | None:
+    stripped = label[1:] if label.startswith(("v", "V")) else label
+    if not re.fullmatch(r"\d+(\.\d+)*", stripped or ""):
+        return None
+    return tuple(int(part) for part in stripped.split("."))
+
+
+def labels_compatible(left: str, right: str) -> bool:
+    """True when one label is the same version as, or a refinement of, the other.
+
+    `v5` / `v5.0.5` -> True: a floating major and a concrete patch inside it can
+    legitimately describe one SHA.
+    `v4` / `v6` -> False: no SHA is both.
+    """
+    if left == right:
+        return True
+    a, b = _version_parts(left), _version_parts(right)
+    if a is None or b is None:
+        return False
+    shorter, longer = sorted((a, b), key=len)
+    return longer[: len(shorter)] == shorter
+
+
+def test_workflow_sources_exist() -> None:
+    """Canary: a moved workflow tree fails loudly instead of vacuously."""
+    assert _WORKFLOWS_DIR.is_dir(), f"{_WORKFLOWS_DIR} not found"
+    assert _yaml_sources(), "no workflow or composite-action YAML found — the glob no longer matches."
+
+
+def test_pin_count_is_plausible() -> None:
+    """Canary: a broken regex must not turn the assertions below into no-ops."""
+    pins = _pins()
+    assert len(pins) >= _MIN_PINS, (
+        f"only {len(pins)} SHA-pinned references found (expected >= {_MIN_PINS}). "
+        "Fix the parser before trusting this guard."
+    )
+
+
+def test_every_pin_carries_a_version_label() -> None:
+    """Presence: a pin with no `# vX.Y` comment has nothing to verify against."""
+    unlabeled = sorted(
+        {f"{path.relative_to(_REPO_ROOT)}: {ref}@{sha[:8]}" for path, ref, sha, label in _pins() if label is None}
+    )
+    assert not unlabeled, (
+        "action pin(s) missing a trailing version comment:\n"
+        + "\n".join(f"  - {entry}" for entry in unlabeled)
+        + "\n\nWrite `uses: owner/repo@<sha>  # vX.Y.Z`. Without the label a reader "
+        "cannot tell which version runs, and scripts/tools/verify_action_pins.py "
+        "has nothing to compare the SHA against."
+    )
+
+
+def test_version_labels_are_version_shaped() -> None:
+    """Presence: `# latest` / `# pinned` would satisfy the label check vacuously."""
+    malformed = sorted(
+        {
+            f"{path.relative_to(_REPO_ROOT)}: {ref} # {label}"
+            for path, ref, _sha, label in _pins()
+            if label is not None and not _VERSION_SHAPED_RE.match(label)
+        }
+    )
+    assert not malformed, (
+        "action pin label(s) are not version-shaped:\n"
+        + "\n".join(f"  - {entry}" for entry in malformed)
+        + "\n\nUse the upstream tag (`v6`, `v6.0.2`). If an action genuinely ships "
+        "non-semver tags, widen _VERSION_SHAPED_RE and say why in this docstring."
+    )
+
+
+def test_one_sha_never_carries_contradictory_labels() -> None:
+    """Internal consistency: `# v4` and `# v6` on one SHA means one of them lies.
+
+    Network-free, and it caught two of the three real mislabels this guard was
+    written for.
+    """
+    by_sha: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for _path, ref, sha, label in _pins():
+        if label is not None:
+            by_sha[(_repo_of(ref), sha)].add(label)
+
+    conflicts = [
+        f"{repo}@{sha[:8]} labeled {sorted(labels)}"
+        for (repo, sha), labels in sorted(by_sha.items())
+        if not all(labels_compatible(a, b) for a in labels for b in labels)
+    ]
+    assert not conflicts, (
+        "the same SHA is labeled with incompatible versions:\n"
+        + "\n".join(f"  - {entry}" for entry in conflicts)
+        + "\n\nOne label is wrong. Resolve the SHA upstream "
+        "(`gh api repos/<owner>/<repo>/tags --jq '.[]|select(.commit.sha==\"<sha>\")|.name'`) "
+        "and correct every occurrence to the real tag."
+    )
+
+
+def test_one_claimed_version_never_maps_to_two_shas() -> None:
+    """Internal consistency: a half-applied bump leaves one version on two SHAs."""
+    by_label: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for _path, ref, sha, label in _pins():
+        if label is not None:
+            by_label[(_repo_of(ref), label)].add(sha)
+
+    split = [
+        f"{repo} # {label} -> {sorted(sha[:8] for sha in shas)}"
+        for (repo, label), shas in sorted(by_label.items())
+        if len(shas) > 1
+    ]
+    assert not split, (
+        "one claimed version maps to multiple SHAs:\n"
+        + "\n".join(f"  - {entry}" for entry in split)
+        + "\n\nA version bump was applied to some workflows but not others. Move "
+        "every occurrence to the same SHA, or label them with the versions they "
+        "actually are."
+    )
+
+
+def test_label_comparison_is_bidirectional() -> None:
+    """The comparator must accept refinements and reject genuine conflicts.
+
+    A `labels_compatible` loosened to `return True` would leave the consistency
+    assertions permanently green, so both directions are pinned here.
+    """
+    for left, right in (("v5", "v5"), ("v5", "v5.0.5"), ("v5.0.5", "v5"), ("v1.302.0", "v1.302.0"), ("v9", "v9.0.0")):
+        assert labels_compatible(left, right), f"comparator rejects compatible pair {left}/{right}"
+
+    for left, right in (("v4", "v6"), ("v7", "v9.0.0"), ("v5", "v7.1.0"), ("v4.6.2", "v4.7.1"), ("v1", "v10")):
+        assert not labels_compatible(left, right), f"comparator accepts contradictory pair {left}/{right}"
+
+    assert _version_parts("latest") is None, "non-numeric label must not parse as a version"
+    assert not labels_compatible("latest", "v1"), "non-numeric label must not match a version"


### PR DESCRIPTION
## 요약

`test_workflow_action_pinning_guard.py` 는 모든 외부 `uses:` 가 40-hex SHA 핀임을 강제한다. 그런데 **SHA 가 `# vX.Y` 주석이 주장하는 버전인지는 보지 않는다.** 그 사각에서 3건이 거짓이었다.

| 참조 | 주석 | 실제 |
|---|---|---|
| `actions/checkout@de0fac2e` | `# v4` | **v6.0.2** |
| `actions/github-script@3a2844b7` | `# v7` | **v9.0.0** |
| `stefanzweifel/git-auto-commit-action@04702edd` | `# v5` | **v7.1.0** |

라벨은 워크플로우에서 사람이 읽는 유일한 버전 신호다. `# v5` 를 보고 v7.1.0 의 동작·changelog·CVE 를 v5 기준으로 판단하게 된다. SHA 핀이 재현성을 지키고 라벨이 리뷰 가능성을 지키는데, 후자가 깨져 있었다.

`stefanzweifel # v5` 는 열려 있는 Dependabot PR #1035("7.1.0 → 7.2.0")와 교차 확인된다.

## 차이가 전부 오류는 아니다

부동 메이저 태그는 이동한다. `actions/cache/restore@27d5ce7f # v5` 는 핀 시점의 v5(=v5.0.5)이고 업스트림 `v5` 는 그 뒤로 전진했다 — 정상 지연이지 거짓 라벨이 아니다. 그래서 "현재 태그가 가리키는 곳"이 아니라 **SHA 가 속한 불변 태그**와 비교하고, 성분별 확장(`v5` ⊇ `v5.0.5`)을 허용한다.

핀 형태 두 가지를 모두 처리한다. `github/codeql-action/upload-sarif@256d6340` 은 커밋이 아니라 `v4` **annotated tag 객체** SHA 였다. 태그 객체도 내용 주소 지정이라 커밋 핀과 동일하게 불변이므로 정상이다 — 커밋 전용 엔드포인트만 쓰면 "존재하지 않는 SHA" 로 오판한다(실제로 조사 중 한 번 오판했다).

## 2계층 구성

| 층 | 무엇 | 어디서 |
|---|---|---|
| 오프라인 | 라벨 존재·버전 형태, 한 SHA 에 모순 라벨 금지, 한 버전이 두 SHA 로 분기 금지, 비교기 양방향 (7케이스) | `tests/test_workflow_action_version_label_guard.py` — blocking pytest 잡 |
| 온라인 | GitHub API 대조 | `scripts/tools/verify_action_pins.py` + `.github/workflows/action-pin-verify.yml` (워크플로우/액션 변경 PR + 주간) |

스위트는 `tests/conftest.py` 가 HTTP 를 차단하므로(의도된 설계) 업스트림 대조는 별도 잡에서만 가능하다. 위 3건 중 **2건은 오프라인이 네트워크 없이** 잡고, 1건(`# v5` 가 한 곳에만 있어 비교 대상이 없던 경우)은 온라인만 잡는다.

주간 스케줄이 필요한 이유: 라벨이 옳아도 업스트림이 태그를 삭제·재지정하면 핀의 정체를 더 이상 확인할 수 없게 되고, 그건 우리 diff 없이 일어난다.

도구는 **stdlib 전용** — pip 설치 단계가 없으므로 의존성 해석 실패로 공급망 검증이 "건너뜀=green" 이 되는 경로가 없다.

## 검증

- 도구: 실제 레포 **21핀 전부 OK / 0 mismatch** (exit 0)
- 도구 falsifiability: 거짓 라벨 2종·라벨 누락·조작된 40-hex → 전부 rc=1 / control 2종(정확 라벨, 부동 태그 이동) → rc=0
- 오프라인 가드 falsifiability: 4개 mutation 전부 **자기 assertion** 으로 red, control green. 수정 전 실제 상태(`v7`+`v9.0.0` 공존)를 재현해 검출 확인
- `guard_falsifiability` STATIC_CASES 6건 등록 → **55/55 guards falsifiable**
- `ruff check` + `ruff format --check` 통과, `actionlint` OK, YAML 6개 파싱 OK
- 권한 감사 OK, 워크플로우 가드 97건 통과
- **전체 스위트 5188 passed, 16 skipped, coverage 72.32%** (게이트 70)
- `basedpyright` 0 errors
- component-counts 재생성 (워크플로우 51→52, 테스트 134→135)
- 카탈로그 총계 실측 재집계 131→**145** (기존 표기는 stale이었다)

## 알려진 트레이드오프

- 신규 도구 `verify_action_pins.py` 는 커버리지 0% (네트워크 도구, `verify_secret_activation.py` 와 동일한 취급). 전체는 72.32% 로 게이트 위.
- 온라인 잡은 `--allow-unverified` 를 쓰지 않는다 — 확인 불가한 핀도 실패로 취급한다. 업스트림이 정말 재지정했다면 로컬에서 그 플래그로 확인한 뒤 핀을 현재 태그로 옮기는 것이 올바른 대응이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)