### PR TITLE
feat: 필수 체크용 집계 잡 + needs 완결성 가드 (트리거 드리프트 7건 발견)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,16 +5,15 @@ name: Dependency Review
 # 이미 설치된 전체 트리를 주기적으로 훑는 반면, 이쪽은 diff 에서 추가된 것만
 # 보고 머지 전에 막는다 — 취약 의존성이 들어온 뒤 다음 주 스캔에서 발견되는
 # 대신, 들어오는 순간 차단된다.
+#
+# 경로 필터를 두지 않는다. `dependency-review-action` 은 PR 의 의존성 diff 를
+# 보므로 매니페스트가 바뀌지 않은 PR 에서는 검사할 것이 없어 즉시 통과한다 —
+# 필터로 아끼는 시간(~30s)보다, required status check 로 지정할 수 있게 되는
+# 값이 크다. 워크플로우 수준 `paths:` 가 걸리면 그 경로를 건드리지 않은 PR 에서
+# 체크가 생성되지 않아 required 지정 시 영구 대기한다.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'scripts/requirements.txt'
-      - 'requirements-dev.txt'
-      - 'requirements.lock'
-      - 'Gemfile'
-      - 'Gemfile.lock'
-      - '.github/workflows/**'
 
 permissions:
   contents: read

--- a/.github/workflows/guard-falsifiability.yml
+++ b/.github/workflows/guard-falsifiability.yml
@@ -4,34 +4,23 @@ name: Guard Falsifiability
 # 가드 자체는 code-quality 스위트에서 매 PR 돌지만, "통과한다"만으로는 가드가
 # 실제로 fixture 부재를 잡아내는지 알 수 없다. 이 잡은 fixture 를 하나씩 실제로
 # 비활성화해 대응 가드가 red 가 되는지 확인한다. 규약: docs/test-isolation.md
+# `paths:` 필터가 없는 것은 의도다. 두 가지 이유:
+#
+# 1. **필수 체크 적격성.** 워크플로우 수준 `paths:` 가 걸리면 그 경로를 건드리지
+#    않은 PR 에서 워크플로우가 아예 돌지 않고, 체크가 생성되지 않는다. 그 체크를
+#    branch ruleset 의 required 로 지정하면 그런 PR 은 **영구 대기**한다. 반대로
+#    워크플로우는 항상 돌고 잡만 `if:` 로 skip 하면 체크는 skipped 로 나타나며,
+#    GitHub 은 skipped required check 를 통과로 취급한다.
+# 2. **목록 드리프트.** 손으로 유지한 19개 경로 목록은 이미 7개를 놓치고 있었다 —
+#    `tests/_tree_write_guard.py`(STATIC_CASES 5건의 변형 대상), `common/dedup.py`,
+#    `common/image_rejection_metrics.py`, `fix_defi_tvl_history.py`,
+#    `check_description_quality.py`, `test_tree_write_guard.py`,
+#    `test_encoding_guard.py`. 즉 그 파일들을 편집해도 하네스가 돌지 않았다.
+#    이제 `--list-targets` 로 케이스 정의에서 **파생**하므로 드리프트가 구조적으로
+#    불가능하다.
 on:
   pull_request:
     branches: [main]
-    paths:
-      # 격리 fixture 가드
-      - 'tests/conftest.py'
-      - 'tests/test_suite_isolation_guard.py'
-      # 정적/설정 가드 — 가드 본체와 그 가드가 감시하는 설정 양쪽
-      - 'tests/test_state_path_anchoring.py'
-      - 'tests/test_hermetic_test_writes_guard.py'
-      - 'tests/test_coverage_floor_guard.py'
-      - 'pyproject.toml'
-      - '.github/workflows/code-quality.yml'
-      # 공급망/시크릿 가드 — 가드 본체와 감시 대상 설정 양쪽
-      - 'tests/test_workflow_action_pinning_guard.py'
-      - 'tests/test_workflow_action_version_label_guard.py'
-      - '.github/workflows/action-pin-verify.yml'
-      - 'tests/test_secret_scan_gate_guard.py'
-      - 'tests/test_workflow_permission_gate_guard.py'
-      # 구분자 정규식 가드 — 가드 본체와 감시 대상 소스
-      - 'tests/test_delimiter_regex_guard.py'
-      - 'scripts/common/summarizer.py'
-      - '.gitleaks.toml'
-      - '.github/workflows/security-scan.yml'
-      - '.github/workflows/lighthouse-ci.yml'
-      # 하네스 자신
-      - 'scripts/tools/guard_falsifiability.py'
-      - '.github/workflows/guard-falsifiability.yml'
   schedule:
     # 매주 월요일 05:00 UTC (KST 14:00). code-quality 주간 잡(일요일 04:00 UTC)과
     # 겹치지 않게 배치.
@@ -40,15 +29,58 @@ on:
 
 permissions:
   contents: read
+  # PR 의 변경 파일 목록 조회용 (fetch-depth: 0 체크아웃 회피).
+  pull-requests: read
 
 concurrency:
   group: guard-falsifiability-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  falsifiability:
+  changes:
+    name: Detect falsifiability-relevant changes
     runs-on: ubuntu-latest
-    # 케이스당 pytest 를 2회(patched/control) 띄우므로 55종 = 110회 프로세스 기동.
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 1
+
+      - name: Detect
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # schedule / workflow_dispatch: 판정 대상이 없으므로 전수 실행.
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "PR 컨텍스트 아님 → 전수 실행"
+            exit 0
+          fi
+          # 트리거 경로는 STATIC_CASES 에서 파생된다 — 손으로 유지하지 않는다.
+          python3 scripts/tools/guard_falsifiability.py --list-targets > targets.txt
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' > changed.txt
+          # -x: 부분일치 금지(경로 전체가 일치해야 한다), -F: 정규식 아님.
+          matched=$(grep -Fxf targets.txt changed.txt || true)
+          if [ -n "${matched}" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "해당 변경:"; echo "${matched}"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "falsifiability 관련 파일 변경 없음 → skip"
+          fi
+
+  falsifiability:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    # 케이스당 pytest 를 2회(patched/control) 띄우므로 59종 = 118회 프로세스 기동.
     # 가드 테스트 자체는 각 1초 미만이고 대부분이 인터프리터 시작 비용이다.
     #
     # 샤딩: 케이스가 **실제 레포 파일**을 변형했다 복원하므로 한 체크아웃 안에서
@@ -58,7 +90,7 @@ jobs:
     # 가드 하나가 검증되지 않은 채 CI 가 그린인 상태를 만든다.
     #
     # 실측 추이: 11케이스 1m44s -> 37케이스 3m49s -> 47케이스 4m09s (약 5s/케이스).
-    # 8샤드면 55케이스 기준 샤드당 7케이스 안팎으로 ~1분.
+    # 8샤드면 59케이스 기준 샤드당 7~8케이스로 ~1분.
     strategy:
       fail-fast: false
       matrix:
@@ -101,3 +133,52 @@ jobs:
             git status --porcelain
             exit 1
           fi
+
+  # 집계(aggregator) 잡 — 이 워크플로우에서 **required status check 로 지정할 대상**.
+  #
+  # 왜 샤드 8개를 직접 required 로 걸지 않는가: 체크 이름이
+  # `falsifiability (3/8)` 처럼 매트릭스 크기를 포함한다. 샤드 수를 바꾸면 등록된
+  # required 컨텍스트가 존재하지 않는 이름이 되어 모든 PR 이 영구 대기한다.
+  # 이 잡의 이름은 고정이므로 그 결합이 없다.
+  #
+  # `if: always()` 가 핵심이다. 이것이 없으면 upstream 이 skip 될 때 이 잡도
+  # skip 되는 게 아니라 아예 실행되지 않아, 결국 required 체크 미생성 문제로
+  # 되돌아간다.
+  #
+  # 판정: skipped 는 통과다(관련 변경이 없어 돌 필요가 없었다는 뜻). failure 와
+  # cancelled 만 실패로 본다 — `success` 만 통과로 두면 skip 경로가 전부 red 가 된다.
+  gate:
+    name: Falsifiability gate
+    if: always()
+    needs: [changes, falsifiability]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Evaluate upstream results
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          FALSIFIABILITY_RESULT: ${{ needs.falsifiability.result }}
+        run: |
+          set -euo pipefail
+          echo "changes=${CHANGES_RESULT} falsifiability=${FALSIFIABILITY_RESULT}"
+          # 탐지 잡이 실패하면 "관련 변경 없음" 을 신뢰할 수 없다 — fail closed.
+          if [ "${CHANGES_RESULT}" != "success" ]; then
+            echo "::error::변경 탐지 잡이 ${CHANGES_RESULT} — 하네스 실행 여부를 판정할 수 없다"
+            exit 1
+          fi
+          case "${FALSIFIABILITY_RESULT}" in
+            failure|cancelled)
+              echo "::error::falsifiability 하네스가 ${FALSIFIABILITY_RESULT}"
+              exit 1
+              ;;
+            skipped)
+              echo "관련 변경 없음 — 하네스 skip (통과)"
+              ;;
+            success)
+              echo "하네스 통과"
+              ;;
+            *)
+              echo "::error::예상하지 못한 결과 '${FALSIFIABILITY_RESULT}'"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,15 +8,22 @@ on:
       - 'scripts/**'
       - '.github/workflows/**'
       - '.gitleaks.toml'
+  # PR 에서는 **경로 필터를 두지 않는다.** 두 가지 이유:
+  #
+  # 1. 시크릿은 어느 경로에든 커밋된다. 이전 필터(`scripts/**`,
+  #    `.github/workflows/**`, `.gitleaks.toml`)는 `_posts/`·`_data/`·`docs/`·
+  #    `assets/`·루트 설정에 들어간 자격증명을 그 PR 에서 **스캔하지 않았다**.
+  #    주간 스케줄이 나중에 잡더라도 그때는 이미 히스토리에 남는다.
+  # 2. required status check 적격성: 워크플로우 수준 `paths:` 가 걸리면 해당 경로를
+  #    건드리지 않은 PR 에서 체크가 생성되지 않아, required 로 지정하면 영구 대기한다.
+  #
+  # 비용은 실측 약 3 job-minute (Bandit ~50s, Secret Detection ~100s, 권한 감사
+  # ~25s). 보안 게이트를 조건부로 두는 값보다 싸다.
+  #
+  # `push` 트리거의 필터는 유지한다 — main 푸시는 자동 커밋이 하루 수십 건이고,
+  # 그쪽은 required check 대상이 아니며 주간 스케줄이 전수를 덮는다.
   pull_request:
     branches: [main]
-    paths:
-      - 'scripts/**'
-      # 권한 감사가 의미를 가지려면 워크플로우 변경에서 돌아야 한다. 이전 필터는
-      # `scripts/**` 와 `.gitleaks.toml` 뿐이어서, 새 워크플로우를 permissions
-      # 블록 없이 추가해도 이 잡이 실행조차 되지 않았다.
-      - '.github/workflows/**'
-      - '.gitleaks.toml'
   schedule:
     - cron: '0 3 * * 1'  # Every Monday 03:00 UTC
   workflow_dispatch:

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 52 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 135 |
+| 테스트 파일 (tests/test_*.py) | 136 |
 
 <!-- component-counts:end -->

--- a/docs/devsecops/branch-protection.md
+++ b/docs/devsecops/branch-protection.md
@@ -1,0 +1,132 @@
+# main 브랜치 보호 — 단계별 적용 기록
+
+이 저장소는 **main 에 직접 푸시하는 워크플로우가 23개**다. 그래서 브랜치 보호를
+한 번에 켜면 수집 파이프라인이 멈춘다. 단계를 나눈 이유와 각 단계의 제약을 여기
+기록한다.
+
+매핑: OWASP **CICD-SEC-1**(Insufficient Flow Control), NIST SSDF(SP 800-218)
+**PO.3 / PS.1**.
+
+## 자동 푸시 인벤토리
+
+| 경로 | 개수 | 비고 |
+|---|---|---|
+| `.github/actions/python-collect/action.yml:197` 의 `git push origin main` | 17 워크플로우 | 공유 composite action. rebase 재시도 루프 포함 |
+| 워크플로우 내 직접 푸시 | 6 | `backfill-url-summaries`, `check-post-images`, `cleanup-old-images`, `generate-journal-og-images`, `generate-weekly-report`, `watchdog-zero-job-runs`(git-auto-commit-action) |
+
+소유자가 User 계정이므로 classic branch protection 의 push allowlist(조직 전용)를
+쓸 수 없다. **ruleset** 으로 구성한다.
+
+## Phase 1 — force-push · 브랜치 삭제 차단 (적용됨)
+
+- 룰셋 **id 20539046** `main: block force-push and deletion (phase 1)`
+- 대상 `refs/heads/main`, rules `deletion` + `non_fast_forward`
+- `bypass_actors: []` — 예외 없음
+- enforcement `active`, 적용 2026-08-07T05:07:18Z
+
+**bypass 가 필요 없는 이유:** 두 규칙은 fast-forward 푸시를 건드리지 않는다.
+자동 푸시 23개는 전부 fast-forward(또는 rebase 후 fast-forward)이므로 영향이 없다.
+
+### 실측 검증
+
+프로브 브랜치를 같은 룰셋 범위에 임시 편입해 세 경로를 확인한 뒤 범위를 main
+전용으로 복원했다. main 자체를 실험 대상으로 삼지 않았다.
+
+| 케이스 | 결과 | rc |
+|---|---|---|
+| fast-forward 푸시 | 허용 | 0 |
+| force-push 되감기 | 거부 (`GH013: Repository rule violations found`) | 1 |
+| 브랜치 삭제 | 거부 (`GH013`) | 1 |
+
+> 검증 하네스 주의: `if git push ... \| tail` 은 `tail` 의 종료코드를 평가하므로
+> 거부를 "통과"로 오판한다. `out=$(cmd 2>&1); rc=$?` 로 캡처할 것.
+
+## Phase 2 — PR 필수 + 상태 체크 필수 (미적용)
+
+### 막고 있던 제약: 경로 필터와 required check 는 공존하지 않는다
+
+required status check 는 **이름으로 매칭**된다. 워크플로우 수준 `paths:` 필터가
+걸려 있으면 그 경로를 건드리지 않은 PR 에서 워크플로우가 아예 돌지 않고, 체크가
+생성되지 않는다. 그 이름을 required 로 등록하면 그런 PR 은 **영구 대기**한다.
+
+반대로 워크플로우는 항상 돌고 **잡만** `if:` 로 skip 하면 체크가 `skipped` 로
+보고되고, GitHub 은 skipped required check 를 통과로 취급한다. 이것이 아래 두
+가지 조치의 근거다.
+
+### 조치 A — 저렴한 게이트는 필터를 걷었다
+
+| 워크플로우 | 조치 | 근거 |
+|---|---|---|
+| `security-scan.yml` | PR 트리거의 `paths:` 제거 | **보안 갭이었다.** 필터가 `scripts/**`·`.github/workflows/**`·`.gitleaks.toml` 뿐이어서 `_posts/`·`_data/`·`docs/`·`assets/`·루트 설정에 커밋된 시크릿은 그 PR 에서 스캔되지 않았다. 비용 실측 ~3 job-minute |
+| `dependency-review.yml` | PR 트리거의 `paths:` 제거 | 액션이 의존성 diff 를 보므로 매니페스트 무변경 PR 은 즉시 통과(~30s) |
+
+`security-scan.yml` 의 `push` 트리거 필터는 유지했다 — main 푸시는 자동 커밋이
+하루 수십 건이고 required check 대상이 아니며 주간 스케줄이 전수를 덮는다.
+
+### 조치 B — 비싼 게이트는 집계(aggregator) 잡으로
+
+`guard-falsifiability.yml` 은 8샤드 ~4분이라 매 PR 전수 실행이 낭비다. 구조를
+바꿨다:
+
+```
+changes (항상 실행, 변경 파일 판정)
+  └─ falsifiability (if: needs.changes.outputs.relevant == 'true', 8샤드)
+       └─ gate (if: always(), needs: [changes, falsifiability])   ← required check 대상
+```
+
+- `gate` 는 `skipped` 를 **통과**로, `failure`/`cancelled` 를 실패로 본다.
+  `success` 만 통과로 두면 skip 경로가 전부 red 가 된다.
+- `changes` 가 실패하면 "관련 변경 없음"을 신뢰할 수 없으므로 fail closed.
+- **샤드를 직접 required 로 걸지 않는다.** 체크 이름이 `falsifiability (3/8)`
+  처럼 매트릭스 크기를 포함하므로, 샤드 수를 바꾸면 등록된 컨텍스트가 존재하지
+  않는 이름이 되어 모든 PR 이 영구 대기한다. `gate` 는 이름이 고정이다.
+
+#### 트리거 경로를 손으로 유지하지 않는다
+
+`changes` 잡은 `guard_falsifiability.py --list-targets` 가 **케이스 정의에서
+파생한** 경로 목록을 쓴다. 손으로 유지하던 19개 목록은 이미 7개를 놓치고
+있었다 — `tests/_tree_write_guard.py`(STATIC_CASES 5건의 변형 대상),
+`scripts/common/dedup.py`, `scripts/common/image_rejection_metrics.py`,
+`scripts/fix_defi_tvl_history.py`, `scripts/check_description_quality.py`,
+`tests/test_tree_write_guard.py`, `tests/test_encoding_guard.py`. 즉 그 파일들을
+편집해도 하네스가 돌지 않았다. 파생으로 바꿔 드리프트를 구조적으로 없앴다.
+
+이 배선은 `tests/test_required_check_aggregator_guard.py` 가 강제한다(5케이스:
+`needs:` 완결성, `always()` 존재, `paths:` 부재, 스캐너 양방향).
+
+### required check 후보 (Phase 2 적용 시)
+
+전 PR 무조건 생성되는 체크만 등록할 수 있다.
+
+| 체크 이름 | 출처 | 적격 |
+|---|---|---|
+| `quality` | `code-quality.yml` | ✅ 필터 없음 |
+| `Analyze (actions)` / `(javascript-typescript)` / `(python)` / `(ruby)` | CodeQL default setup(워크플로우 파일 없음) | ✅ |
+| `Python SAST (Bandit)` · `Secret Detection` · `Workflow Permissions Audit` | `security-scan.yml` | ✅ 조치 A 이후 |
+| `Dependency Review` | `dependency-review.yml` | ✅ 조치 A 이후 |
+| `Falsifiability gate` | `guard-falsifiability.yml` | ✅ 조치 B 이후 |
+
+**등록하지 않을 것:**
+
+- `i18n-e2e` / `reports-e2e` — Playwright 기반이고 기능 한정. 두 워크플로우의 잡
+  id 가 **둘 다 `e2e`** 여서 required 컨텍스트로 모호하다(이름을 먼저 구분해야
+  한다).
+- `Verify action pins against upstream` — 업스트림 API 의존. 네트워크/rate limit
+  장애가 머지를 막는 대가가 이득보다 크다. 주간 스케줄 + 워크플로우 변경 PR 로
+  충분하다.
+- `lighthouse-ci` / `coverage-comment` — `pull_request` 트리거가 없다.
+
+### 남은 미검증 항목
+
+- Phase 2 는 PR 필수화가 자동 푸시를 막으므로 **bypass actor 가 필요**하다.
+  `github-actions[bot]`(Integration) 을 bypass 로 넣는 것이 후보이며, 룰셋을 실제로
+  만들어봐야 API 형태가 확정된다. Phase 1 은 bypass 가 없어 이 불확실성이 없다.
+- bypass 를 넣으면 "어떤 워크플로우든 main 에 푸시 가능"이 된다. 워크플로우 파일
+  자체는 Phase 2 로 보호되므로 사람이 몰래 바꿀 수는 없지만, 권한 축소가 아니라
+  **권한 이전**임을 인식할 것.
+
+## Phase 3 — 자동 푸시를 PR + auto-merge 로 (권장하지 않음)
+
+수집기가 하루 여러 번 도는 구조라 PR 이 하루 수십 건 생긴다. bypass 제거의
+이득보다 노이즈·API 사용량·머지 큐 지연 비용이 크다고 판단했다. 판단을 바꿀
+근거가 생기면 이 절을 갱신할 것.

--- a/docs/devsecops/ci-regression-guards.md
+++ b/docs/devsecops/ci-regression-guards.md
@@ -23,12 +23,13 @@ System Configuration), NIST SSDF(SP 800-218) **PO.3 / PW.4**.
 | `tests/test_encoding_guard.py` | 16 | `encoding_guard` 모듈의 UTF-8/CP949 라벨 교정 동작 불변 | 한국어 텍스트 인코딩 깨짐(mojibake) |
 | `tests/test_requirements_lock_coverage.py` | 6 | `requirements.txt` 직접 의존성 전부가 `requirements.lock` 에 ==핀(부분집합) + 락의 모든 핀이 최소 1개 `--hash` 보유(presence) | 락 staleness(검증 안 되는 새 의존성) / hashless 핀이 `--require-hashes` 무결성 검증을 무력화하는 공급망 변조 창 |
 | `tests/test_workflow_action_pinning_guard.py` | 4 | `.github/workflows/**` · `.github/actions/**` 의 모든 외부 `uses:` 가 40-hex SHA 핀(presence) + 탐지기 양방향 | 가변 태그(`@v4`)/브랜치 참조 → 업스트림 변조가 diff 없이 CI 에서 실행 |
+| `tests/test_required_check_aggregator_guard.py` | 5 | 집계 잡의 `needs:` 가 나머지 전 잡을 덮음(집합 동일) + `if: always()` 보유 + 대상 워크플로우의 PR 트리거에 `paths:` 없음(presence) + 잡 id 스캐너 양방향 | ①`needs:` 밖의 잡이 실패해도 required 체크는 green ②`always()` 없으면 upstream skip 시 체크 미생성 → PR 영구 대기 ③`paths:` 재도입도 같은 영구 대기 |
 | `tests/test_workflow_action_version_label_guard.py` | 7 | 모든 핀이 `# vX.Y` 라벨 보유 + 라벨이 버전 형태(presence), 한 SHA 에 모순 라벨 금지 · 한 버전이 두 SHA 로 분기 금지(내부 정합성), 비교기 양방향 | SHA 는 핀됐지만 라벨이 거짓 → 리뷰어·Dependabot 이 잘못된 changelog·CVE 목록을 근거로 판단 (2026-08-07 감사에서 3건: checkout `# v4`→실제 v6.0.2, github-script `# v7`→v9.0.0, git-auto-commit `# v5`→v7.1.0) |
 | `tests/test_secret_scan_gate_guard.py` | 7 | Gitleaks 게이트 무결성: `useDefault=true`(presence), allowlist `targetRules`/`paths` 집합 동일(==), 게이트 차단성(no `continue-on-error`/`\|\| true`), `fetch-depth: 0`(presence) | 잡은 남아있는데 룰셋 해제·allowlist 확대·exit 흡수·히스토리 절단으로 시크릿 스캔이 조용히 무력화 |
 | `tests/test_delimiter_regex_guard.py` | 13 | 출처 구분자 정규식이 구분자 앞 공백을 **요구**한다(`\s+`, presence) — 열린 꼬리 형태만 대상, 고정 alternation·마크다운 불릿·고정 숫자 리터럴은 면제 | `\s*` 는 복합어 내부 하이픈을 구분자로 오인해 뒤를 전부 삭제 (2026-08-06 4회 반복, main 에 13건 피해) |
 | `tests/test_workflow_permission_gate_guard.py` | 4 | `code-quality.yml` 이 `check_workflow_permissions.py` 를 `--workflows-dir .github/workflows` 로 차단 실행(presence) | 도구 단위 테스트는 green 인데 CI 배선만 끊겨 2026-04-23 수집기 장애 클래스가 재무방비 |
 
-총 **145 케이스**.
+총 **150 케이스**.
 
 > 2026-08-07 실측 재집계. 이전 표기(131)는 `test_state_path_anchoring`(16→18)과
 > `test_workflow_step_if_safety`(48→53, 워크플로우 수에 파라미터라이즈됨)가

--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -464,6 +464,41 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         "?usez:",
         "tests/test_workflow_action_version_label_guard.py::test_pin_count_is_plausible",
     ),
+    # ---------------------------------------------------------------------
+    # Part 7 (2026-08-07): required status check 집계(aggregator) 층. 룰셋의
+    # required check 는 이름으로 매칭되므로, 경로 필터가 걸린 워크플로우의 체크를
+    # required 로 걸면 그 경로를 건드리지 않은 PR 이 영구 대기한다. 그래서 필터를
+    # 걷고 잡을 `if:` 로 게이팅하며 항상 도는 집계 잡을 둔다 — 그 집계 잡이
+    # 조용히 무력화되는 세 경로(needs 누락, always() 제거, 필터 재도입)를 검증한다.
+    # ---------------------------------------------------------------------
+    StaticCase(
+        "집계 잡 needs 축소 (falsifiability 가 게이트 밖으로)",
+        ".github/workflows/guard-falsifiability.yml",
+        "    needs: [changes, falsifiability]",
+        "    needs: [changes]",
+        "tests/test_required_check_aggregator_guard.py::test_aggregator_needs_every_other_job[guard-falsifiability.yml]",
+    ),
+    StaticCase(
+        "집계 잡 if: always() 제거 (upstream skip 시 체크 미생성)",
+        ".github/workflows/guard-falsifiability.yml",
+        "    name: Falsifiability gate\n    if: always()\n",
+        "    name: Falsifiability gate\n",
+        "tests/test_required_check_aggregator_guard.py::test_aggregator_runs_unconditionally[guard-falsifiability.yml]",
+    ),
+    StaticCase(
+        "PR 트리거에 paths 필터 재도입 (required check 영구 대기)",
+        ".github/workflows/guard-falsifiability.yml",
+        "  pull_request:\n    branches: [main]\n",
+        "  pull_request:\n    branches: [main]\n    paths:\n      - 'tests/conftest.py'\n",
+        "tests/test_required_check_aggregator_guard.py::test_aggregated_workflow_has_no_pull_request_path_filter[guard-falsifiability.yml]",
+    ),
+    StaticCase(
+        "잡 id 스캐너 완화 (중첩 키를 잡으로 오인)",
+        "tests/test_required_check_aggregator_guard.py",
+        r'_JOB_ID_RE = re.compile(r"^  (?P<job>[A-Za-z_][A-Za-z0-9_-]*):\s*$", re.M)',
+        r'_JOB_ID_RE = re.compile(r"^\s*(?P<job>[A-Za-z_][A-Za-z0-9_-]*):\s*$", re.M)',
+        "tests/test_required_check_aggregator_guard.py::test_job_id_scanner_rejects_nested_keys",
+    ),
 )
 
 
@@ -517,6 +552,29 @@ def apply_static_mutation(source: str, case: StaticCase) -> str:
 def discover_autouse_fixtures(src: str) -> list[str]:
     """conftest 소스에서 autouse fixture 이름을 전수 수집한다."""
     return _AUTOUSE_RE.findall(src)
+
+
+def trigger_paths() -> list[str]:
+    """저장소-상대 경로 중 **변경 시 이 하네스를 돌려야 하는** 것 전부.
+
+    워크플로우가 `on.pull_request.paths` 에 같은 목록을 손으로 유지하면 반드시
+    드리프트한다 — 새 STATIC_CASES 가 새 파일을 겨냥해도 트리거는 모르므로,
+    그 가드는 falsifiability 검증 없이 머지된다. 그래서 목록을 케이스 정의에서
+    **파생**시키고, 워크플로우는 `--list-targets` 로 이걸 읽는다.
+
+    포함 대상:
+
+    * 하네스가 덮어썼다 복원하는 파일(`_mutated_files`) — 변형 대상이 바뀌면
+      앵커가 어긋날 수 있다;
+    * 각 케이스가 돌리는 가드 테스트 파일(node id 의 파일 부분) — 가드 본체가
+      바뀌면 여전히 falsifiable 한지 다시 봐야 한다;
+    * 하네스 자신과 그 워크플로우.
+    """
+    paths = {str(p.relative_to(REPO_ROOT)) for p in _mutated_files()}
+    paths.update(case.node_id.split("::", 1)[0] for case in STATIC_CASES)
+    paths.add(str(Path(__file__).resolve().relative_to(REPO_ROOT)))
+    paths.add(".github/workflows/guard-falsifiability.yml")
+    return sorted(paths)
 
 
 def _purge_pycache() -> None:
@@ -749,8 +807,17 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--json", action="store_true", help="JSON 출력")
     mode.add_argument("--check", action="store_true", help="vacuous/미등록 시 exit 1 (CI)")
+    mode.add_argument(
+        "--list-targets",
+        action="store_true",
+        help="변경 시 이 하네스를 돌려야 하는 저장소-상대 경로를 한 줄씩 출력 (워크플로우 트리거 판정용)",
+    )
     parser.add_argument("--shard", metavar="N/M", help="N번째/M개 샤드만 실행 (CI 매트릭스용)")
     args = parser.parse_args()
+
+    if args.list_targets:
+        print("\n".join(trigger_paths()))
+        return 0
 
     results = run_all(parse_shard(args.shard) if args.shard else None)
 

--- a/tests/test_required_check_aggregator_guard.py
+++ b/tests/test_required_check_aggregator_guard.py
@@ -1,0 +1,174 @@
+"""CI config regression guard: the required-check aggregator covers every job.
+
+## Why an aggregator exists at all
+
+A branch ruleset's *required status check* is matched by check name. If the
+workflow that produces that check has a workflow-level `paths:` filter, then on a
+PR that touches none of those paths the workflow never runs, the check is never
+created, and the PR waits forever. The fix is to drop the `paths:` filter, gate
+the expensive job with a job-level `if:`, and add an aggregator job that runs
+unconditionally (`if: always()`) and reports one stable check name.
+
+Two properties make that aggregator load-bearing, and both fail silently:
+
+* **`needs:` completeness.** A new job added to the workflow but not wired into
+  `needs:` is invisible to the gate: it can fail while the required check stays
+  green. That is the same class of hole as a coverage gate that omits a module.
+* **`if: always()`.** Without it the gate is skipped whenever an upstream job is
+  skipped — which is the common case — and a skipped job that never *ran* is not
+  the same as one GitHub reports as skipped. Drop it and the required check goes
+  missing exactly on the PRs the aggregator was introduced to serve.
+
+## Why the shard matrix is not required directly
+
+`guard-falsifiability` fans out over 8 shards and names each check
+`falsifiability (3/8)`. Registering those as required contexts couples branch
+protection to the matrix size: change the shard count and every registered name
+stops existing, so every PR waits forever. The aggregator's name is fixed.
+
+Direction: presence (`needs:` must equal the full job set, `if: always()` must be
+there). Text scan only, no PyYAML, per `docs/devsecops/ci-regression-guards.md`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+
+# workflow file -> aggregator job id that branch protection should require.
+_AGGREGATORS: dict[str, str] = {
+    "guard-falsifiability.yml": "gate",
+}
+
+# A job id at the canonical two-space indent under `jobs:`. Anchored so that
+# nested mapping keys (`with:`, `env:`, matrix entries) cannot be mistaken for
+# job ids.
+_JOB_ID_RE = re.compile(r"^  (?P<job>[A-Za-z_][A-Za-z0-9_-]*):\s*$", re.M)
+
+
+def _text(workflow: str) -> str:
+    return (_WORKFLOWS_DIR / workflow).read_text(encoding="utf-8")
+
+
+def _job_ids(text: str) -> list[str]:
+    """Every job id in the workflow, in file order."""
+    jobs_start = re.search(r"^jobs:\s*$", text, re.M)
+    assert jobs_start, "no top-level `jobs:` mapping found"
+    return [m.group("job") for m in _JOB_ID_RE.finditer(text[jobs_start.end() :])]
+
+
+def _job_block(text: str, job_id: str) -> str:
+    """The lines belonging to one job: from its id to the next id or EOF."""
+    start = re.search(rf"^  {re.escape(job_id)}:\s*$", text, re.M)
+    assert start, f"job `{job_id}` not found"
+    rest = text[start.end() :]
+    following = _JOB_ID_RE.search(rest)
+    return rest[: following.start()] if following else rest
+
+
+def _needs_of(block: str) -> set[str]:
+    """`needs:` entries, accepting both inline `[a, b]` and block-list form."""
+    inline = re.search(r"^\s{4}needs:\s*\[(?P<items>[^\]]*)\]\s*$", block, re.M)
+    if inline:
+        return {item.strip().strip("'\"") for item in inline.group("items").split(",") if item.strip()}
+
+    scalar = re.search(r"^\s{4}needs:\s*(?P<one>[A-Za-z_][A-Za-z0-9_-]*)\s*$", block, re.M)
+    if scalar:
+        return {scalar.group("one")}
+
+    header = re.search(r"^\s{4}needs:\s*$", block, re.M)
+    if not header:
+        return set()
+    items: set[str] = set()
+    # `\s*$` stops before the newline, so the remainder starts mid-line; without
+    # lstrip the first splitlines() element is "" and the loop breaks at once.
+    for line in block[header.end() :].lstrip("\n").splitlines():
+        entry = re.match(r"^\s{6}-\s*(?P<item>[A-Za-z_][A-Za-z0-9_-]*)\s*$", line)
+        if not entry:
+            break
+        items.add(entry.group("item"))
+    return items
+
+
+@pytest.mark.parametrize("workflow", sorted(_AGGREGATORS))
+def test_workflow_and_aggregator_job_exist(workflow: str) -> None:
+    """Canary: a renamed workflow or job fails loudly, not vacuously."""
+    path = _WORKFLOWS_DIR / workflow
+    assert path.is_file(), f"{path} not found"
+    assert _AGGREGATORS[workflow] in _job_ids(_text(workflow)), (
+        f"aggregator job `{_AGGREGATORS[workflow]}` missing from {workflow}. If it was "
+        "renamed, update _AGGREGATORS *and* the required status check in the branch ruleset."
+    )
+
+
+@pytest.mark.parametrize("workflow", sorted(_AGGREGATORS))
+def test_aggregator_needs_every_other_job(workflow: str) -> None:
+    """A job outside `needs:` can fail while the required check stays green."""
+    text = _text(workflow)
+    aggregator = _AGGREGATORS[workflow]
+    expected = set(_job_ids(text)) - {aggregator}
+    actual = _needs_of(_job_block(text, aggregator))
+
+    missing = sorted(expected - actual)
+    assert not missing, (
+        f"{workflow}: job(s) {missing} are not in `{aggregator}.needs`. They can fail "
+        f"while the `{aggregator}` required check reports success. Add them to `needs:` "
+        "and handle their result in the gate step."
+    )
+    unknown = sorted(actual - expected)
+    assert not unknown, f"{workflow}: `{aggregator}.needs` names non-existent job(s) {unknown}"
+
+
+@pytest.mark.parametrize("workflow", sorted(_AGGREGATORS))
+def test_aggregator_runs_unconditionally(workflow: str) -> None:
+    """Without `if: always()` the gate vanishes whenever an upstream job skips."""
+    block = _job_block(_text(workflow), _AGGREGATORS[workflow])
+    assert re.search(r"^\s{4}if:\s*always\(\)\s*$", block, re.M), (
+        f"{workflow}: aggregator `{_AGGREGATORS[workflow]}` must declare `if: always()`. "
+        "Otherwise it is skipped when an upstream job is skipped, the required check is "
+        "never reported, and every such PR blocks."
+    )
+
+
+@pytest.mark.parametrize("workflow", sorted(_AGGREGATORS))
+def test_aggregated_workflow_has_no_pull_request_path_filter(workflow: str) -> None:
+    """A `paths:` filter on the PR trigger defeats the whole arrangement.
+
+    With one, the workflow does not run on unrelated PRs, so the aggregator's
+    check is never created — the exact failure the aggregator exists to avoid.
+    """
+    text = _text(workflow)
+    pr_trigger = re.search(r"^  pull_request:\s*$", text, re.M)
+    assert pr_trigger, f"{workflow}: no `pull_request:` trigger — it cannot gate PRs at all"
+
+    for line in text[pr_trigger.end() :].splitlines():
+        if re.match(r"^  \S", line):  # next top-level trigger
+            break
+        assert not re.match(r"^\s{4}paths(-ignore)?:\s*$", line), (
+            f"{workflow}: the `pull_request` trigger has a `paths:` filter. The aggregator "
+            f"check `{_AGGREGATORS[workflow]}` then goes missing on PRs that touch none of "
+            "those paths, blocking them forever. Gate the expensive job with a job-level "
+            "`if:` instead."
+        )
+
+
+def test_job_id_scanner_rejects_nested_keys() -> None:
+    """The scanner must not mistake nested mapping keys for job ids.
+
+    If `_JOB_ID_RE` loosened to any `key:` line, `_job_ids` would return `with`,
+    `env`, `steps`... and `test_aggregator_needs_every_other_job` would demand
+    they appear in `needs:` — failing for the wrong reason, or, if the comparison
+    were inverted, passing vacuously.
+    """
+    sample = "jobs:\n  build:\n    steps:\n      - uses: x\n        with:\n          k: v\n  gate:\n    if: always()\n"
+    assert _job_ids(sample) == ["build", "gate"]
+
+    assert _needs_of("    needs: [a, b]\n") == {"a", "b"}
+    assert _needs_of("    needs: solo\n") == {"solo"}
+    assert _needs_of("    needs:\n      - a\n      - b\n") == {"a", "b"}
+    assert _needs_of("    runs-on: ubuntu-latest\n") == set()


### PR DESCRIPTION
## 배경 — 경로 필터와 required check 는 공존하지 않는다

required status check 는 **이름으로 매칭**된다. 워크플로우 수준 `paths:` 필터가 걸려 있으면 그 경로를 건드리지 않은 PR 에서 워크플로우가 아예 돌지 않아 체크가 생성되지 않고, 그 이름을 required 로 등록하면 그런 PR 은 **영구 대기**한다. 반대로 워크플로우는 항상 돌고 **잡만** `if:` 로 skip 하면 체크가 `skipped` 로 보고되며 GitHub 은 그것을 통과로 취급한다.

`needs:` 는 워크플로우 내부에서만 동작하므로 **워크플로우 간 집계는 불가능**하다. 그래서 워크플로우별로 구성을 달리했다.

## 조치 A — 저렴한 게이트는 필터 제거

| 워크플로우 | 근거 |
|---|---|
| `security-scan.yml` | **실제 보안 갭이었다.** PR 필터가 `scripts/**`·`.github/workflows/**`·`.gitleaks.toml` 뿐이어서 `_posts/`·`_data/`·`docs/`·`assets/`·루트 설정에 커밋된 시크릿은 그 PR 에서 스캔되지 않았다. 주간 스케줄이 나중에 잡더라도 그때는 이미 히스토리에 남는다. 비용 실측 ~3 job-minute |
| `dependency-review.yml` | 액션이 의존성 diff 를 보므로 매니페스트 무변경 PR 은 즉시 통과(~30s) |

`security-scan.yml` 의 `push` 트리거 필터는 유지했다 — main 푸시는 자동 커밋이 하루 수십 건이고 required 대상이 아니며 주간 스케줄이 전수를 덮는다.

## 조치 B — 비싼 게이트는 집계 잡 (guard-falsifiability, 8샤드 ~4분)

```
changes (항상 실행, 변경 파일 판정)
  └─ falsifiability (if: needs.changes.outputs.relevant == 'true', 8샤드)
       └─ gate (if: always(), needs: [changes, falsifiability])   ← required 대상
```

- `gate` 는 `skipped` 를 **통과**로, `failure`/`cancelled` 를 실패로 본다. `success` 만 통과로 두면 skip 경로가 전부 red 가 된다.
- `changes` 실패 시 "관련 변경 없음"을 신뢰할 수 없으므로 **fail closed**.
- 샤드를 직접 required 로 걸지 않는 이유: 체크 이름이 `falsifiability (3/8)` 처럼 매트릭스 크기를 포함해, 샤드 수를 바꾸면 등록된 컨텍스트가 존재하지 않는 이름이 되어 모든 PR 이 영구 대기한다. `gate` 는 이름이 고정이다.

## 부수 발견 — 트리거 경로가 이미 7건 드리프트했다

`--list-targets` 를 추가해 트리거 경로를 STATIC_CASES 에서 **파생**시킨다. 손으로 유지한 19개 목록은 이미 7개를 놓치고 있었다:

- **`tests/_tree_write_guard.py` — STATIC_CASES 5건의 변형 대상**
- `scripts/common/dedup.py`, `scripts/common/image_rejection_metrics.py`
- `scripts/fix_defi_tvl_history.py`, `scripts/check_description_quality.py`
- `tests/test_tree_write_guard.py`, `tests/test_encoding_guard.py`

즉 그 파일들을 편집해도 falsifiability 하네스가 돌지 않았다. 이제 드리프트가 구조적으로 불가능하다(파생 27개).

## 가드

`tests/test_required_check_aggregator_guard.py` (5케이스) — `needs:` 완결성(집합 동일), `if: always()` 존재, 대상 워크플로우 PR 트리거에 `paths:` 부재, 잡 id 스캐너 양방향.

가드 자신의 양방향 테스트가 작성 중 **제 파서 버그를 잡았습니다** — 블록 리스트 `needs:` 파싱에서 개행이 남아 첫 항목이 빈 문자열이 되어 전부 놓치고 있었습니다.

## 검증

- 집계 가드 falsifiability 4종(needs 축소 · `always()` 제거 · `paths:` 재도입 · **새 잡 미배선**) → 전부 자기 assertion 으로 red, control 3속성 전부 green
- 하네스 전수 **59/59 guards falsifiable**, 실행 후 워킹 트리 복원 확인
- 전체 스위트 **5193 passed**, 16 skipped, coverage 72.26% (게이트 70)
- ruff check + format, basedpyright 0 errors, actionlint 전 워크플로우 OK
- 권한 감사 OK, 워크플로우 가드 101건 통과
- 카탈로그 총계 실측 145→150, component-counts 재생성

## 이 PR 이 검증하지 않는 것

이 PR 은 falsifiability 관련 파일을 건드리므로 `changes` 가 `relevant=true` 로 판정해 **8샤드가 실제로 도는 경로**를 확인한다. `skipped` 경로(관련 변경 없는 PR 에서 `gate` 가 통과로 보고되는지)는 이 PR 로 확인할 수 없다 — 열려 있는 Dependabot PR 들이 그 경로를 자연스럽게 검증한다.

문서: `docs/devsecops/branch-protection.md` (Phase 1 적용 기록 + Phase 2 잔여 작업 + required check 적격성 표)

🤖 Generated with [Claude Code](https://claude.com/claude-code)