### PR TITLE
fix: 액션 버전 라벨을 전체 버전으로 정규화 (Dependabot 이 그때만 갱신한다)

### DIFF
--- a/.github/actions/python-collect/action.yml
+++ b/.github/actions/python-collect/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Cache Playwright browsers
       if: inputs.install-playwright == 'true'
       id: playwright-cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ hashFiles('scripts/requirements.txt') }}

--- a/.github/workflows/action-pin-verify.yml
+++ b/.github/workflows/action-pin-verify.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/alert-consecutive-failures.yml
+++ b/.github/workflows/alert-consecutive-failures.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/backfill-post-summaries.yml
+++ b/.github/workflows/backfill-post-summaries.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/backfill-url-summaries.yml
+++ b/.github/workflows/backfill-url-summaries.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/check-post-images.yml
+++ b/.github/workflows/check-post-images.yml
@@ -39,7 +39,7 @@ jobs:
       R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/check-post-summary.yml
+++ b/.github/workflows/check-post-summary.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/classify-workflow-failures.yml
+++ b/.github/workflows/classify-workflow-failures.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Classify failure type
         id: classify

--- a/.github/workflows/cleanup-old-images.yml
+++ b/.github/workflows/cleanup-old-images.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-html
           path: coverage-html/
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload coverage data for comment
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-data
           path: coverage.json
@@ -108,7 +108,7 @@ jobs:
 
       - name: Coverage comment on push
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: py-cov-action/python-coverage-comment-action@63f52f4fbbffada6e8dee8ec432de7e01df9ba79  # v3
+        uses: py-cov-action/python-coverage-comment-action@63f52f4fbbffada6e8dee8ec432de7e01df9ba79  # v3.41
         with:
           GITHUB_TOKEN: ${{ github.token }}
           MINIMUM_GREEN: 50

--- a/.github/workflows/collect-blockchain.yml
+++ b/.github/workflows/collect-blockchain.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-coinmarketcap.yml
+++ b/.github/workflows/collect-coinmarketcap.yml
@@ -22,7 +22,7 @@ jobs:
       CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-crypto-news.yml
+++ b/.github/workflows/collect-crypto-news.yml
@@ -22,7 +22,7 @@ jobs:
       CRYPTOPANIC_API_KEY: ${{ secrets.CRYPTOPANIC_API_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-defi-llama.yml
+++ b/.github/workflows/collect-defi-llama.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-defi-yields.yml
+++ b/.github/workflows/collect-defi-yields.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-fmp-calendar.yml
+++ b/.github/workflows/collect-fmp-calendar.yml
@@ -23,7 +23,7 @@ jobs:
       FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-geopolitical.yml
+++ b/.github/workflows/collect-geopolitical.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-market-indicators.yml
+++ b/.github/workflows/collect-market-indicators.yml
@@ -22,7 +22,7 @@ jobs:
       FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-political-trades.yml
+++ b/.github/workflows/collect-political-trades.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-regulatory.yml
+++ b/.github/workflows/collect-regulatory.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-social-media.yml
+++ b/.github/workflows/collect-social-media.yml
@@ -22,7 +22,7 @@ jobs:
       TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-stock-news.yml
+++ b/.github/workflows/collect-stock-news.yml
@@ -22,7 +22,7 @@ jobs:
       ALPHA_VANTAGE_API_KEY: ${{ secrets.ALPHA_VANTAGE_API_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collect-worldmonitor-news.yml
+++ b/.github/workflows/collect-worldmonitor-news.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/collector-heartbeat.yml
+++ b/.github/workflows/collector-heartbeat.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Collect health report
         id: report

--- a/.github/workflows/continuous-improvement-loop.yml
+++ b/.github/workflows/continuous-improvement-loop.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download coverage data
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.11'
 
       - name: Post coverage comment
-        uses: py-cov-action/python-coverage-comment-action@63f52f4fbbffada6e8dee8ec432de7e01df9ba79  # v3
+        uses: py-cov-action/python-coverage-comment-action@63f52f4fbbffada6e8dee8ec432de7e01df9ba79  # v3.41
         with:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Review dependency changes
         uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9  # v4.7.1

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
@@ -94,7 +94,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && success()
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/description-quality-check.yml
+++ b/.github/workflows/description-quality-check.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/generate-daily-summary.yml
+++ b/.github/workflows/generate-daily-summary.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/generate-journal-og-images.yml
+++ b/.github/workflows/generate-journal-og-images.yml
@@ -29,7 +29,7 @@ jobs:
       R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/generate-weekly-report.yml
+++ b/.github/workflows/generate-weekly-report.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/gsc-index-audit.yml
+++ b/.github/workflows/gsc-index-audit.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload audit result
         if: env.HAS_GSC_KEY == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: gsc-audit-${{ github.run_id }}
           path: gsc-audit-output.txt

--- a/.github/workflows/gsc-sitemap-submit.yml
+++ b/.github/workflows/gsc-sitemap-submit.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/guard-falsifiability.yml
+++ b/.github/workflows/guard-falsifiability.yml
@@ -45,7 +45,7 @@ jobs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 
@@ -102,7 +102,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/i18n-e2e.yml
+++ b/.github/workflows/i18n-e2e.yml
@@ -41,7 +41,7 @@ jobs:
       I18N_E2E_BASE_URL: http://127.0.0.1:4000
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload Playwright artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-artifacts-${{ github.run_id }}
           path: playwright-artifacts/

--- a/.github/workflows/indexnow-submit.yml
+++ b/.github/workflows/indexnow-submit.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integrated-quality-report.yml
+++ b/.github/workflows/integrated-quality-report.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0

--- a/.github/workflows/notify-deploy-status.yml
+++ b/.github/workflows/notify-deploy-status.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (for local resolve-slack-config action)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ops-10am-digest.yml
+++ b/.github/workflows/ops-10am-digest.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -34,7 +34,7 @@ jobs:
         run: npm install -g vercel
 
       - name: Restore digest state cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: _state/ops-10am-digest-state.json
           key: ops-10am-digest-state-${{ github.run_id }}
@@ -87,7 +87,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save digest state cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         if: always()
         with:
           path: _state/ops-10am-digest-state.json

--- a/.github/workflows/post-quality.yml
+++ b/.github/workflows/post-quality.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/push-folder-info-to-slack.yml
+++ b/.github/workflows/push-folder-info-to-slack.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout investing
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/reports-e2e.yml
+++ b/.github/workflows/reports-e2e.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0

--- a/.github/workflows/respond-ai-mentions.yml
+++ b/.github/workflows/respond-ai-mentions.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout investing
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -107,7 +107,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -134,7 +134,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # 이 잡은 2026-08-06 감사 전까지 **build 를 실패시킬 수 없었다**:
       #   - 모든 발견이 `::warning::` 이고 어떤 경로로도 exit 하지 않았다.

--- a/.github/workflows/site-health-check.yml
+++ b/.github/workflows/site-health-check.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Check site availability
         id: site_check

--- a/.github/workflows/supply-chain-lock-promotion-reminder.yml
+++ b/.github/workflows/supply-chain-lock-promotion-reminder.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/supply-chain-lock.yml
+++ b/.github/workflows/supply-chain-lock.yml
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/watchdog-zero-job-runs.yml
+++ b/.github/workflows/watchdog-zero-job-runs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/docs/devsecops/branch-protection.md
+++ b/docs/devsecops/branch-protection.md
@@ -41,6 +41,16 @@
 > 검증 하네스 주의: `if git push ... \| tail` 은 `tail` 의 종료코드를 평가하므로
 > 거부를 "통과"로 오판한다. `out=$(cmd 2>&1); rc=$?` 로 캡처할 것.
 
+**main 실측 확인.** 프로브 브랜치 결과는 같은 룰셋·같은 규칙 타입이지만 main 자체는
+아니었다. 룰셋 활성(05:07:18Z) 이후 `github-actions[bot]` 이 main 에 실제로
+푸시한 것을 확인했다:
+
+- `05:48:49Z` `chore: collect social media`
+- `05:53:12Z` `chore: collect stock news`
+
+두 건 모두 `python-collect` 공유 액션 경유다. 즉 23개 자동 푸시 경로 중 가장 많이
+쓰이는 것이 Phase 1 아래서 정상 동작한다.
+
 ## Phase 2 — PR 필수 + 상태 체크 필수 (미적용)
 
 ### 막고 있던 제약: 경로 필터와 required check 는 공존하지 않는다

--- a/docs/devsecops/branch-protection.md
+++ b/docs/devsecops/branch-protection.md
@@ -115,6 +115,9 @@ changes (항상 실행, 변경 파일 판정)
   장애가 머지를 막는 대가가 이득보다 크다. 주간 스케줄 + 워크플로우 변경 PR 로
   충분하다.
 - `lighthouse-ci` / `coverage-comment` — `pull_request` 트리거가 없다.
+- `Vercel` — 무료 티어 빌드 쿼터로 실패한다. PR #1119 에서 코드와 무관하게
+  `upgradeToPro=build-rate-limit` 로 FAILURE 였다. required 로 걸면 쿼터 소진이
+  머지 차단이 된다.
 
 ### 남은 미검증 항목
 

--- a/docs/devsecops/ci-regression-guards.md
+++ b/docs/devsecops/ci-regression-guards.md
@@ -51,6 +51,29 @@ MISMATCH 면 실패한다. 워크플로우/액션 변경 PR + 주간 스케줄�
 `# v4`/`# v6`, `# v7`/`# v9.0.0`)은 오프라인 가드가 잡고, 1건(`# v5` 가 단 한 곳에만
 있어 비교 대상이 없던 v7.1.0 핀)은 온라인 잡만 잡는다.
 
+#### 라벨은 전체 버전으로 쓴다 — Dependabot 이 그때만 갱신한다
+
+Dependabot 은 SHA 를 교체할 때 **버전 주석이 기존 버전 문자열과 정확히 일치할
+때만** 함께 갱신한다. 열려 있던 PR 들에서 실측한 결과:
+
+| PR | 라벨 변화 | 결과 |
+|---|---|---|
+| #1029 `ruby/setup-ruby` | `# v1.302.0` → `# v1.314.0` | 자동 갱신 |
+| #1030 `actions/checkout` | `# v6` → `# v6` (SHA 는 v7.0.0) | **거짓 라벨 도입** |
+| #1035 `git-auto-commit-action` | `# v5` → `# v5` (SHA 는 v7.2.0) | **거짓 라벨 도입** |
+
+즉 메이저-only 라벨(`# v6`)은 bump 마다 조용히 거짓이 된다. 그래서 2026-08-07 에
+정규화 가능한 라벨 전부를 실측 최다-구체 태그로 바꿨다(64곳): `checkout # v6`
+→`# v6.0.2`, `cache # v4`→`# v4.3.0`, `cache/{restore,save} # v5`→`# v5.0.5`,
+`upload-artifact # v7`→`# v7.0.1`, `py-cov-action # v3`→`# v3.41`.
+
+예외 2건은 메이저 라벨이 **유일하게 참인** 경우라 그대로 둔다 —
+`github/codeql-action/upload-sarif` 는 핀이 `v4` **태그 객체** 자체이고,
+`treosh/lighthouse-ci-action` 은 `v12` 만 그 SHA 를 가리킨다. 이 둘은 Dependabot
+자동 갱신 대상이 아니므로 온라인 잡의 주간 실행에 의존한다.
+
+**새 액션을 추가할 때 라벨은 `# vX.Y.Z` 로 쓸 것.** `# vX` 는 첫 bump 에서 거짓이 된다.
+
 > 공급망/시크릿 3종(2026-08-06 추가)의 배경: `security-scan.yml` 의
 > `actions-permissions` 잡은 이름과 달리 **build 를 실패시킬 수 없다** — 모든 발견이
 > `::warning::` 이고 exit 하지 않으며, 핀닝 체크의 `has_issues=true` 는

--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -435,9 +435,9 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         "tests/test_workflow_action_version_label_guard.py::test_version_labels_are_version_shaped",
     ),
     StaticCase(
-        "같은 SHA 에 모순 라벨 (# v6 -> # v4, 타 워크플로우는 v6 유지)",
+        "같은 SHA 에 모순 라벨 (# v6.0.2 -> # v4, 타 워크플로우는 v6.0.2 유지)",
         ".github/workflows/action-pin-verify.yml",
-        "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6",
+        "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2",
         "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4",
         "tests/test_workflow_action_version_label_guard.py::test_one_sha_never_carries_contradictory_labels",
     ),
@@ -447,7 +447,7 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         "      - name: Setup Python\n",
         "      - name: Half-applied bump probe\n        uses: actions/checkout@"
         + "c" * 40
-        + "  # v6\n\n      - name: Setup Python\n",
+        + "  # v6.0.2\n\n      - name: Setup Python\n",
         "tests/test_workflow_action_version_label_guard.py::test_one_claimed_version_never_maps_to_two_shas",
     ),
     StaticCase(


### PR DESCRIPTION
## 왜 지금

Dependabot 은 SHA 를 교체할 때 **버전 주석이 기존 버전 문자열과 정확히 일치할 때만** 함께 갱신한다. 열려 있는 PR 3건에서 실측했다:

| PR | 라벨 변화 | 결과 |
|---|---|---|
| #1029 `ruby/setup-ruby` | `# v1.302.0` → `# v1.314.0` | ✅ 자동 갱신 |
| #1030 `actions/checkout` | `# v6` → `# v6` (SHA 는 v7.0.0) | ❌ **거짓 라벨 도입** |
| #1035 `git-auto-commit-action` | `# v5` → `# v5` (SHA 는 v7.2.0) | ❌ **거짓 라벨 도입** |

즉 메이저-only 라벨은 bump 마다 조용히 거짓이 된다. **이 3건을 그대로 머지하면 #1116 에서 도입한 `action-pin-verify` 가 main 에서 red 가 된다.** 라벨을 전체 버전으로 바꿔 두면 Dependabot 이 스스로 유지한다 — setup-ruby 가 그 증거다.

## 무엇

업스트림 실측 최다-구체 태그로 **64곳** 치환:

| 참조 | 이전 | 이후 | 곳 |
|---|---|---|---|
| `actions/checkout` | `# v6` | `# v6.0.2` | 52 |
| `actions/cache` | `# v4` | `# v4.3.0` | 1 |
| `actions/cache/{restore,save}` | `# v5` | `# v5.0.5` | 2 |
| `actions/upload-artifact` | `# v7` | `# v7.0.1` | 1 |
| `py-cov-action/python-coverage-comment-action` | `# v3` | `# v3.41` | 1 |

예외 2건은 메이저 라벨이 **유일하게 참인** 경우라 그대로 둔다: `github/codeql-action/upload-sarif` 는 핀이 `v4` **태그 객체** 자체이고, `treosh/lighthouse-ci-action` 은 `v12` 만 그 SHA 를 가리킨다. 이 둘은 Dependabot 자동 갱신 대상이 아니므로 온라인 잡의 주간 실행에 의존한다.

`guard_falsifiability.py` 의 STATIC_CASES 앵커 2건도 함께 갱신했다 — `# v6` 리터럴을 앵커로 쓰고 있어 정규화 후 "앵커를 찾을 수 없음"으로 하네스가 죽는다.

## 검증

- `verify_action_pins.py`: **21핀 전부 OK / 0 mismatch** (exit 0)
- 하네스 전수 **59/59 guards falsifiable**, 실행 후 워킹 트리 복원 확인
- 전체 스위트 **5193 passed**, 16 skipped, coverage 72.26% (게이트 70)
- actionlint 전 워크플로우 OK, ruff check + format 통과

## 부수 문서화

`Vercel` 을 required check 후보에서 제외로 명시했다 — PR #1119 에서 코드와 무관하게 무료 티어 `upgradeToPro=build-rate-limit` 로 FAILURE 였다.

`docs/devsecops/ci-regression-guards.md` 규약 추가: **새 액션의 라벨은 `# vX.Y.Z` 로 쓸 것.** `# vX` 는 첫 bump 에서 거짓이 된다.