### PR TITLE
fix: Vercel 배포 트리거 축소 + 사이트에 공개되던 개발 파일 제외

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -13,6 +13,7 @@ _state/
 .env
 .env.example
 docs/
+tests/
 *.pyc
 __pycache__/
 .ruff_cache/

--- a/_config.yml
+++ b/_config.yml
@@ -76,3 +76,15 @@ exclude:
   - README.md
   - docs/
   - _config_ghpages.yml
+  # 아래는 2026-08-07 실측으로 **라이브 사이트에 공개되고 있던** 경로들이다.
+  # `curl https://investing.2twodragon.com/tests/conftest.py` -> 200,
+  # `content-type: application/octet-stream` 으로 테스트 원본이 그대로 서빙됐다.
+  # 저장소가 공개이므로 기밀 문제는 아니지만 크롤 표면·배포 용량 낭비이고,
+  # vercel.json 의 경로 기반 빌드 생략 전제(= 이 경로들은 _site 에 영향 없음)를
+  # 깨뜨린다. Jekyll 은 dot-디렉토리(.github/, .claude/)는 기본 무시하므로 제외
+  # 목록에 넣지 않는다.
+  - tests/
+  - AGENTS.md
+  - CLAUDE.md
+  - pyproject.toml
+  - requirements-dev.txt

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "outputDirectory": "_site",
   "regions": ["icn1"],
   "trailingSlash": true,
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]; then exit 0; fi; exit 1",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]; then exit 0; fi; if git rev-parse --verify --quiet HEAD^2 >/dev/null; then exit 1; fi; if ! git rev-parse --verify --quiet HEAD^ >/dev/null; then exit 1; fi; if ! git diff --quiet HEAD^ HEAD -- scripts/tools/postbuild_fix_feed_enclosures.py; then exit 1; fi; if git diff --quiet HEAD^ HEAD -- . ':(exclude)_state' ':(exclude).github' ':(exclude)tests' ':(exclude)docs' ':(exclude)scripts'; then exit 0; fi; exit 1",
   "redirects": [
     {
       "source": "/investing/:path*",


### PR DESCRIPTION
## 실태 — 프로덕션 배포가 멈춰 있다

```
Vercel: failure — "Deployment rate limited — retry in 24 hours"
```

`7d0e08c7`(06:54Z) 이후 main 커밋 5건 전부 배포 실패. 마지막 성공은 `3d2dc7dc4`(06:27Z). **그 이후 수집된 포스트는 사이트에 반영되지 않았다.** 독립 증거: `/tests/test_gsc_api.py` 가 404 (#1064 는 머지됨).

**소비 경로**: 오늘 main 커밋 40건 중 **18건(45%)이 사이트 산출물에 영향 없는 푸시**였다 — 수집기가 신규 항목을 못 찾아 `_state/` 만 갱신한 경우, 워크플로우·테스트·문서 전용 PR, 의존성 bump. 기존 `ignoreCommand` 는 브랜치만 필터하고(`main` 아니면 skip) 경로는 보지 않아 이 18건이 모두 풀 빌드를 돌렸다.

## 별개 발견 — 개발 파일이 라이브 사이트에 공개되고 있었다

```
$ curl -I https://investing.2twodragon.com/tests/conftest.py
200, content-type: application/octet-stream, x-vercel-cache: HIT
```

`/pyproject.toml`, `/requirements-dev.txt`, `/AGENTS.md`, `/CLAUDE.md` 도 200. Jekyll `exclude` 에 `tests/` 등이 없어 `_site` 로 복사됐다. (`.github/`·`.claude/` 는 dot-디렉토리라 Jekyll 이 기본 무시해 무사했다.)

저장소가 공개이므로 **기밀 문제는 아니다.** 다만 크롤 표면·배포 용량 낭비이고, 더 중요하게는 아래 경로 기반 빌드 생략의 전제("이 경로들은 `_site` 에 영향 없음")를 깨뜨린다 — 그래서 같은 PR 에서 함께 고친다.

## 변경

- `_config.yml` exclude += `tests/`, `AGENTS.md`, `CLAUDE.md`, `pyproject.toml`, `requirements-dev.txt`
- `.vercelignore` += `tests/`
- `vercel.json` `ignoreCommand` 경로 기반 판정 (전부 **fail-open** — 불확실하면 빌드)

| 순서 | 조건 | 결과 |
|---|---|---|
| 1 | `main` 아님 | skip (기존 동작) |
| 2 | **병합 커밋** | build — 1-parent diff 는 머지로 들어온 변경을 놓친다 |
| 3 | **부모 없음** | build — shallow clone 대비 |
| 4 | **`postbuild_fix_feed_enclosures.py` 변경** | build — buildCommand 가 빌드 후 `_site` 를 수정하므로 `scripts/` 일괄 제외에 넣을 수 없다 |
| 5 | `_state/`·`.github/`·`tests/`·`docs/`·`scripts/` 외 변경 없음 | skip |

## 검증

**ignoreCommand 를 `vercel.json` 에서 다시 추출해** worktree 로 각 커밋을 체크아웃하고 실제 평가했다 (정적 읽기 아님) — 6케이스 전부 기대와 일치:

| 케이스 | 결과 |
|---|---|
| 포스트 추가 커밋 | BUILD ✓ |
| `_state/` 만 바뀐 수집기 커밋 | SKIP ✓ |
| 병합 커밋 | BUILD ✓ |
| postbuild 스크립트 변경 | BUILD ✓ |
| 부모 없음(root) | BUILD ✓ |
| 비-main 브랜치 | SKIP ✓ |

- 오늘 40커밋 시뮬레이션: 빌드 22 / 생략 18 → **45% 절감**
- `bundle exec jekyll build` 성공(118s). `_site` 에서 제외 대상 5종 전부 부재 확인, `index.html`/`sitemap.xml`/`feed.xml`/`404.html` 정상, 포스트 페이지 **2324개**
- `check_sitemap_local.py`: **2339 URL 전부** 빌드 산출물에 매핑
- 전체 스위트 **5292 passed**, coverage 74.32%

## 이 PR 이 해결하지 못하는 것

- **24시간 rate limit 자체는 해소되지 않는다** — 리셋 대기 또는 플랜 업그레이드 필요.
- PR 프리뷰는 Vercel 이 **배포를 생성한 뒤** ignoreCommand 로 빌드만 건너뛰므로 배포 수 쿼터를 계속 소비한다. 저장소 설정으로는 막을 수 없고 Vercel 대시보드에서 꺼야 한다.
- 실제 쿼터 한도와 잔량은 대시보드에서만 확인 가능하다. 여기서 측정한 것은 GitHub deployments API 기준 오늘 Production 배포 **26건**이며, 프리뷰는 이 수치에 포함되지 않을 수 있다.