### PR TITLE
chore(deps-dev): ruff 0.15.8 → 0.16.1 (핀 3곳 동기화)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,8 +52,8 @@ jobs:
         run: |
           # ruff는 핀 고정: floating(unpinned) 시 새 릴리스의 format 규칙 변경으로
           # 코드 변경 없이 main이 갑자기 red가 될 수 있음. .pre-commit-config.yaml의
-          # ruff-pre-commit rev(v0.15.8) 및 requirements-dev.txt와 반드시 동기화할 것.
-          pip install -r scripts/requirements.txt ruff==0.15.8 yamllint basedpyright pytest pytest-cov pytest-xdist pre-commit
+          # ruff-pre-commit rev(v0.16.1) 및 requirements-dev.txt와 반드시 동기화할 것.
+          pip install -r scripts/requirements.txt ruff==0.16.1 yamllint basedpyright pytest pytest-cov pytest-xdist pre-commit
           curl -sSL "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
           tar -xzf /tmp/actionlint.tgz -C /tmp
           install /tmp/actionlint /usr/local/bin/actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,9 @@ repos:
   # ruff lint + format — CI(code-quality.yml)의 `ruff check`/`ruff format --check
   # scripts/ tests/`를 로컬 커밋 단계에서 미리 잡는다. 2026-06-10 R2 세션이 미포맷
   # 파일을 push해 Code Quality가 이틀간 silently red였던 회귀(ruff format 누락) 재발 방지.
-  # rev는 로컬/CI ruff 버전(0.15.8)에 맞춤 — CI ruff가 floating이므로 버전 갱신 시 함께 올릴 것.
+  # rev는 로컬/CI ruff 버전(0.16.1)에 맞춤 — CI ruff가 floating이므로 버전 갱신 시 함께 올릴 것.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.16.1
     hooks:
       - id: ruff
         name: ruff lint (scripts/ tests/)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pytest-timeout>=2.3
 # Lint/format — CI(code-quality.yml)와 .pre-commit-config.yaml(ruff-pre-commit rev)이
 # 동일 버전을 써야 format 규칙 불일치로 인한 spurious CI red를 막을 수 있음.
 # 세 곳(여기 / code-quality.yml / .pre-commit-config.yaml)을 항상 함께 갱신할 것.
-ruff==0.15.8
+ruff==0.16.1
 
 # Type check — CI(code-quality.yml)가 `python -m basedpyright`(include=["scripts"])를
 # 실행한다. .pre-commit-config.yaml 의 local basedpyright 훅이 로컬 커밋 단계에서


### PR DESCRIPTION
## 왜 #1102 를 그대로 머지하지 않는가

#1102 는 `requirements-dev.txt` **한 곳만** 올린다. 이 저장소는 ruff 핀을 **3곳**에 두고 `tests/test_ruff_version_pin_sync.py` 가 동일성을 강제하므로, 한 곳만 올리면 가드가 red 가 된다.

| # | 위치 | 값 |
|---|---|---|
| 1 | `requirements-dev.txt` | `ruff==0.16.1` |
| 2 | `.github/workflows/code-quality.yml` | `pip install ... ruff==0.16.1` |
| 3 | `.pre-commit-config.yaml` | `astral-sh/ruff-pre-commit` `rev: v0.16.1` |

버전을 언급하는 주석 2곳도 함께 갱신했다 — 주석이 stale 하면 다음 사람이 어느 값이 진실인지 알 수 없다. 잔여 `0.15.8` 문자열 **0건** 확인.

## 규칙 변화 없음 (핀 올리기 전 측정)

임시 venv 에 0.16.1 을 설치해 영향을 먼저 측정했다. 이 저장소에는 lint·format 변화가 **전혀 없다**:

```
ruff check scripts/ tests/   -> All checks passed!
ruff format --check          -> 283 files already formatted
```

ruff 마이너 bump 는 format 규칙 변경으로 "코드 변경 없이 CI red" 를 만든 이력이 있고(핀을 3곳에 둔 이유가 그것) 그래서 사전 측정이 필요했다. 이번엔 재포맷 커밋이 필요 없다.

## 검증

- `test_ruff_version_pin_sync.py` 3건 통과
- 로컬 ruff 를 **0.16.1 로 실제 설치**한 뒤 `check` + `format --check` 통과
- actionlint OK
- 전체 스위트 **5292 passed**, 16 skipped, coverage 74.32%

머지 후 #1102 는 이 PR 로 대체되므로 닫는다.