### PR TITLE
fix: vercel ignoreCommand 가 256자 스키마 제한을 넘어 배포가 전부 실패했다

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 52 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 139 |
+| 테스트 파일 (tests/test_*.py) | 140 |
 
 <!-- component-counts:end -->

--- a/tests/test_vercel_config_guard.py
+++ b/tests/test_vercel_config_guard.py
@@ -1,0 +1,131 @@
+"""CI config regression guard: `vercel.json` stays within Vercel's schema limits.
+
+## The incident this exists for (2026-08-07)
+
+`vercel.json` gained a path-aware `ignoreCommand` so that pushes which cannot
+change the built site skip the build. The command was **456 characters**.
+Vercel's own schema (`https://openapi.vercel.sh/vercel.json`) caps every command
+field at **256**, so the deployment never ran:
+
+    Vercel: failure — "Deployment failed."
+    target_url: https://vercel.com/docs/concepts/projects/project-configuration
+
+Production stopped deploying for every commit after that merge. Nothing in the
+repo caught it: the JSON was valid, `jekyll build` passed locally, and the whole
+test suite was green — the constraint lives in Vercel's schema, not in the file.
+
+## The second trap: `:!` pathspec magic depends on the path's first character
+
+The shortened command used `':!_state'`. Git reads what follows `:!` as pathspec
+*magic* and rejects `_`:
+
+    fatal: Unimplemented pathspec magic '_' in ':!_state'
+
+Measured on git 2.x, 2026-08-07: `:!tests`, `:!docs`, `:!.github`, `:!scripts`
+all parse fine — only `:!_state` aborts. So the bare form is not broken in
+general; whether it works **depends on the first character of the path**, which
+is a terrible property for a config nobody re-tests.
+
+Worse, the failure is silent. `ignoreCommand` is fail-open by design (non-zero
+exit means "build") and git's fatal *is* non-zero, so the broken command still
+answered "build" — four of five hand-checked cases looked correct. Only the one
+case whose expected verdict was "skip" exposed it.
+
+This guard therefore **mandates the unambiguous form** (`:!./path` or
+`:(exclude)path`) rather than claiming bare forms are broken. It will reject
+`:!tests`, which does work today; that is the intended trade — it removes the
+whole class instead of relying on nobody ever excluding a path that starts with
+the wrong character.
+
+Direction: `<=` for the length cap (shorter is fine), presence for the pathspec
+form. Text/JSON scan only — no network, no Vercel CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_VERCEL_JSON = _REPO_ROOT / "vercel.json"
+
+# https://openapi.vercel.sh/vercel.json — `maxLength: 256` on each command field.
+# Confirmed against the live schema on 2026-08-07. If Vercel raises the cap,
+# bump this constant and say so here; do not silently exceed it.
+_COMMAND_MAX_LENGTH = 256
+_COMMAND_FIELDS = ("buildCommand", "installCommand", "devCommand", "ignoreCommand")
+
+# `:!` followed by anything other than `/` or `.` re-enters magic-letter parsing.
+_SHORT_EXCLUDE_RE = re.compile(r":!(?![./])")
+
+
+def _config() -> dict:
+    return json.loads(_VERCEL_JSON.read_text(encoding="utf-8"))
+
+
+def test_vercel_json_exists_and_parses() -> None:
+    """Canary: a moved or malformed file fails here rather than vacuously."""
+    assert _VERCEL_JSON.is_file(), f"{_VERCEL_JSON} not found"
+    assert isinstance(_config(), dict), "vercel.json must be a JSON object"
+
+
+@pytest.mark.parametrize("field", _COMMAND_FIELDS)
+def test_command_fields_within_vercel_length_cap(field: str) -> None:
+    """Vercel rejects the whole config when a command exceeds 256 characters."""
+    value = _config().get(field)
+    if value is None:
+        pytest.skip(f"{field} not configured")
+    assert len(value) <= _COMMAND_MAX_LENGTH, (
+        f"vercel.json `{field}` is {len(value)} characters; Vercel's schema caps it at "
+        f"{_COMMAND_MAX_LENGTH}. Exceeding it makes every deployment fail with "
+        '"Deployment failed." and a link to the project-configuration docs — the '
+        "site silently stops updating. Move logic out of the command or shorten it."
+    )
+
+
+def test_ignore_command_uses_unambiguous_exclude_pathspec_form() -> None:
+    """Require `:!./path` or `:(exclude)path` — never bare `:!path`.
+
+    Whether the bare form parses depends on the path's first character
+    (`:!tests` works, `:!_state` aborts), and the abort is fail-open so it reads
+    as "build" rather than as an error.
+    """
+    command = _config().get("ignoreCommand")
+    if command is None:
+        pytest.skip("ignoreCommand not configured")
+    bad = _SHORT_EXCLUDE_RE.findall(command)
+    assert not bad, (
+        "vercel.json `ignoreCommand` uses a bare `:!<path>` pathspec. Git reads what "
+        "follows `:!` as pathspec magic, so whether it works depends on the path's "
+        "first character — `:!_state` aborts with "
+        "`fatal: Unimplemented pathspec magic '_'` while `:!tests` is fine. Because the "
+        'command is fail-open, that abort silently reads as "build". Use `:!./<path>` '
+        "or `:(exclude)<path>`."
+    )
+
+
+def test_ignore_command_still_gates_on_main() -> None:
+    """Presence: previews must stay skipped, or every PR burns deploy quota."""
+    command = _config().get("ignoreCommand")
+    if command is None:
+        pytest.skip("ignoreCommand not configured")
+    assert "VERCEL_GIT_COMMIT_REF" in command, (
+        "`ignoreCommand` no longer checks `VERCEL_GIT_COMMIT_REF`. Without the branch "
+        "gate, non-main refs build too, which is what the original command existed to "
+        "prevent."
+    )
+
+
+def test_exclude_pathspec_detector_is_bidirectional() -> None:
+    """A detector loosened to match nothing would leave the assertion green.
+
+    `:!tests` is listed as disallowed even though it parses today — the rule is
+    "always prefix", not "only the forms that happen to break".
+    """
+    for disallowed in (":!_state", ":!tests", ":!docs", "':!_state'", ":!scripts"):
+        assert _SHORT_EXCLUDE_RE.search(disallowed), f"detector misses bare form {disallowed!r}"
+    for allowed in (":!./_state", ":!./.github", ":!./tests", ":(exclude)_state"):
+        assert not _SHORT_EXCLUDE_RE.search(allowed), f"detector flags prefixed form {allowed!r}"

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "outputDirectory": "_site",
   "regions": ["icn1"],
   "trailingSlash": true,
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]; then exit 0; fi; if git rev-parse --verify --quiet HEAD^2 >/dev/null; then exit 1; fi; if ! git rev-parse --verify --quiet HEAD^ >/dev/null; then exit 1; fi; if ! git diff --quiet HEAD^ HEAD -- scripts/tools/postbuild_fix_feed_enclosures.py; then exit 1; fi; if git diff --quiet HEAD^ HEAD -- . ':(exclude)_state' ':(exclude).github' ':(exclude)tests' ':(exclude)docs' ':(exclude)scripts'; then exit 0; fi; exit 1",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = main ] || exit 0; git rev-parse -q --verify HEAD^2 >/dev/null && exit 1; git diff --quiet HEAD^ HEAD -- . ':!./_state' ':!./.github' ':!./tests' ':!./docs' && exit 0; exit 1",
   "redirects": [
     {
       "source": "/investing/:path*",


### PR DESCRIPTION
## 내가 만든 회귀 (#1124)

#1124 에서 넣은 경로 기반 `ignoreCommand` 는 **456자**였다. Vercel 스키마(`https://openapi.vercel.sh/vercel.json`)는 모든 command 필드를 **`maxLength: 256`** 으로 제한한다. 그래서 배포가 아예 만들어지지 않았다:

```
Vercel: failure — "Deployment failed."
target_url: https://vercel.com/docs/concepts/projects/project-configuration
```

`7152f2a2`(#1124 머지) 이후 main 커밋 **전부**가 이 상태였다. **#1124 는 배포를 줄이려다 배포를 멈췄다.**

앞서 보고한 `rate limited` 와 구분해야 한다 — 그 메시지는 `2b8cb99e` 까지이고, `7152f2a2` 부터 `Deployment failed` + project-configuration 문서 링크로 바뀌었다. Production deployment 레코드도 `3d2dc7dc`(성공) 이후 생성되지 않았다.

무엇도 이걸 잡지 못했다: JSON 은 유효하고, `jekyll build` 는 로컬에서 통과하고, 스위트도 green 이었다 — 제약이 파일이 아니라 **Vercel 스키마**에 있기 때문이다.

## 2차 함정 — `:!_state` 는 조용히 죽는다

256자에 맞추려 `:(exclude)` 를 `:!` 로 줄였더니:

```
fatal: Unimplemented pathspec magic '_' in ':!_state'
```

실측(2026-08-07): `:!tests`·`:!docs`·`:!.github`·`:!scripts` 는 정상이고 **`:!_state` 만** 죽는다 — **경로 첫 글자에 따라 갈린다.** 게다가 `ignoreCommand` 는 fail-open 이라 git 의 fatal 이 "build" 로 읽힌다. 그래서 손으로 확인한 5케이스 중 **4개가 통과처럼 보였다**(기대값이 이미 BUILD 였으니까). 기대값이 SKIP 인 1케이스만이 드러냈다. `:!./_state` 로 고쳤다.

## 절감률 정정: 45% → 30%

256자 안에서는 `scripts/` 제외 + postbuild 예외(305자)를 넣을 수 없다. `scripts/` 변경은 빌드하는 보수적 안(**202자**)을 택한다. 오늘 40커밋 기준 절감 12/40 = **30%**. #1124 의 45% 주장은 이 PR 로 정정된다.

## 가드 추가 — 이 사고를 잡는다

`tests/test_vercel_config_guard.py` (7케이스):

| 불변식 | 방향 |
|---|---|
| command 필드 4종이 256자 이하 | `<=` |
| `ignoreCommand` 에 bare `:!<path>` 금지 (`:!./` / `:(exclude)` 의무화) | presence |
| 브랜치 게이트(`VERCEL_GIT_COMMIT_REF`) 존재 | presence |
| 탐지기 양방향 | — |

변형 주입으로 세 결함을 모두 잡음을 확인했다: 456자 → 잡음 / bare `:!_state` → 잡음 / 게이트 제거 → 잡음 / control → 통과.

bare 형태 금지는 `:!tests`(오늘은 작동)까지 거부한다. 의도한 트레이드다 — "깨지는 형태만 막기"가 아니라 클래스 자체를 없앤다.

## 검증

- `ignoreCommand` **202자** (제한 256)
- worktree 로 각 커밋을 체크아웃해 실제 평가, **git fatal 발생 여부까지 확인**:

| 케이스 | 결과 |
|---|---|
| 포스트 추가 | BUILD ✓ |
| `_state` 만 | **SKIP ✓** (명령이 실제로 작동한다는 증거) |
| 병합 커밋 | BUILD ✓ |
| postbuild 스크립트 변경 | BUILD ✓ |
| 비-main | SKIP ✓ |
| 부모 없는 root 커밋 | BUILD (git 에러 → 의도된 fail-open) |

- shallow clone(depth 1·2)에서도 BUILD 로 fail-open 확인
- 전체 스위트 **5304 passed**, 17 skipped, component-counts 재생성