### PR TITLE
fix: state 가드 매칭을 명령 위치로 좁히고 깨진 JSON 출력 수정

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -89,6 +89,13 @@ oh-my-claudecode 플러그인이 관리. `omc update` 시 덮어씌워지므로 
 | `pre-commit-state-guard.sh` | PreToolUse (Bash) | `_state/` 파일이 staged 면 `git commit` 차단 |
 | `component-counts-drift-guard.sh` | PreToolUse (Bash) | `docs/component-counts.md` 드리프트 시 `git push` 차단 |
 
+Bash 훅 둘은 `git` 하위명령을 **명령 위치**에서만 인정한다 — 줄/세그먼트 시작이거나
+`;`/`&&`/`||`/`|` 뒤일 때. 부분문자열로 보면 문자열 안의 언급까지 걸려서
+`git commit -m "docs: git push 훅 추가"` 나 `git log --grep="git commit"` 이 막힌다
+(2026-08-12 실측). 반대로 `git -C /repo commit` 처럼 리터럴이 없는 형태는 **놓친다**.
+양방향은 `tests/test_state_guard_command_matching.py` 와
+`tests/test_component_counts_drift_hook_guard.py` 가 실제 스크립트를 돌려 강제한다.
+
 `component-counts-drift-guard.sh` 는 CI 의
 `tests/test_component_counts.py::test_generated_doc_in_sync` 앞단의 빠른 피드백이다.
 2026-08-11 PR #1157·#1158 순차 머지에서 리베이스의 3-way 머지가 카운트를 조용히 잘못

--- a/.claude/hooks/pre-commit-state-guard.sh
+++ b/.claude/hooks/pre-commit-state-guard.sh
@@ -1,20 +1,44 @@
 #!/bin/bash
 # pre-commit-state-guard.sh - Prevent committing _state/*.json (auto-managed by collectors)
-# Triggers on Bash tool invocations matching `git commit`.
+# Triggers on Bash tool invocations that actually run `git commit`.
+#
+# 2026-08-12: 매칭과 출력 두 곳을 고쳤다. 근거·실측은
+# tests/test_state_guard_command_matching.py 의 docstring.
+#
+# - 매칭: `*"git commit"*` 부분문자열은 오탐과 미탐을 함께 냈다. 문자열 안의 언급
+#   (`echo "실행: git commit …"`, `git log --grep="git commit"`)을 막았고, 반대로
+#   `git -C /repo commit` 은 리터럴이 없어서 **놓쳤다**.
+# - 출력: 이유를 셸 보간으로 JSON 에 넣었는데 staged 목록은 개행 구분이라
+#   `_state` 파일이 2개 이상이면 원시 개행이 들어가 invalid JSON 이 됐다.
+#   1개일 때만 우연히 유효해서 눈에 띄지 않았다.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Only act on commits
-if [[ "$COMMAND" != *"git commit"* ]]; then
+# `git commit` 을 **명령 위치**에서만 인정한다 — 줄/세그먼트 시작, 또는 `;`/`&&`/`||`/`|`
+# 뒤. `component-counts-drift-guard.sh` 와 같은 규칙이다.
+#
+# 남는 한계: `git --git-dir=… commit` 같은 다른 전역 플래그 조합은 안 잡는다. 완전히
+# 풀려면 셸 파싱이 필요하다. 못 잡으면 `_state` 가 커밋될 수 있으므로, 그 형태를 쓸
+# 일이 생기면 이 패턴에 추가할 것.
+COMMIT_RE='(^|[;&|])[[:space:]]*git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+commit([[:space:]]|$)'
+if ! printf '%s' "$COMMAND" | grep -Eq "$COMMIT_RE"; then
   exit 0
 fi
 
-# Check if any _state/ files are staged
-STAGED=$(git -C "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" diff --cached --name-only 2>/dev/null | grep "^_state/" || true)
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+STAGED=$(git -C "$ROOT" diff --cached --name-only 2>/dev/null | grep "^_state/" || true)
+
 if [[ -n "$STAGED" ]]; then
-  REASON="Cowardly refusing to commit _state/ files (auto-managed by collectors). Staged: $STAGED. Use 'git restore --staged _state/' first."
-  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"$REASON\"}}" >&2
+  REASON="Cowardly refusing to commit _state/ files (auto-managed by collectors).
+
+Staged:
+$STAGED
+
+Use 'git restore --staged _state/' first."
+  # jq 로 만든다 — staged 목록의 개행이 셸 보간에서는 invalid JSON 이 된다.
+  jq -nc --arg reason "$REASON" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}' >&2
   exit 2
 fi
 exit 0

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 53 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 151 |
+| 테스트 파일 (tests/test_*.py) | 152 |
 
 <!-- component-counts:end -->

--- a/tests/test_state_guard_command_matching.py
+++ b/tests/test_state_guard_command_matching.py
@@ -1,0 +1,166 @@
+"""`pre-commit-state-guard.sh` 의 명령 매칭과 출력 형식 가드.
+
+## 고친 문제 두 개 (2026-08-12)
+
+**1. 부분문자열 매칭.** 훅은 `[[ "$COMMAND" != *"git commit"* ]]` 로 판정했다. 문자열
+안의 언급까지 걸려서 `_state` 가 staged 인 동안 다음이 전부 차단됐다 — 실측:
+
+| 명령 | 기존 | 옳은 결과 |
+|---|---|---|
+| `git commit -m "x"` | rc=2 | rc=2 ✓ |
+| `echo "실행: git commit -m x"` | rc=2 ❌ | rc=0 |
+| `git log --grep="git commit"` | rc=2 ❌ | rc=0 |
+
+`component-counts-drift-guard.sh` 가 같은 함정을 이미 겪었다(그 훅을 만드는 도중
+`echo '{"command":"git push"}'` 가 차단됐다). 같은 명령-위치 매칭으로 통일한다.
+
+**2. 깨진 JSON.** 이유 문자열을 셸 보간으로 JSON 에 넣는데, staged 목록은 `grep` 이
+개행으로 구분해 준다. `_state` 파일이 **2개 이상이면 원시 개행이 문자열 안에 들어가
+invalid JSON** 이 된다 — 실측:
+
+```
+Invalid control character at: line 1 column 202
+```
+
+이 세션에서 실제로 8개 파일이 staged 된 채 차단됐고, 그 출력이 깨진 JSON 이었다.
+1개일 때는 우연히 유효해서 눈에 띄지 않는다 — 그래서 조용하다.
+
+## 방향
+
+블로킹 가드이므로 **양방향을 다 강제**한다. 좁히다 새면 `_state` 가 커밋되고(원래
+막으려던 사고), 넓으면 무관한 명령이 막혀 사람이 훅을 끄게 된다.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_HOOK = _ROOT / ".claude" / "hooks" / "pre-commit-state-guard.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("jq") is None or shutil.which("bash") is None,
+    reason="훅은 bash + jq 를 요구한다",
+)
+
+
+def _run_hook(command: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(_HOOK)],
+        input=json.dumps({"tool_input": {"command": command}}),
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+def _repo(tmp_path: Path, *, staged_state: int = 0, staged_other: bool = False) -> Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    if staged_state:
+        (tmp_path / "_state").mkdir()
+        for i in range(staged_state):
+            (tmp_path / "_state" / f"f{i}.json").write_text("{}", encoding="utf-8")
+        subprocess.run(["git", "add", "_state/"], cwd=tmp_path, check=True)
+    if staged_other:
+        (tmp_path / "note.md").write_text("x", encoding="utf-8")
+        subprocess.run(["git", "add", "note.md"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 실제 커밋 형태는 빠짐없이 막는다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git commit -m x",
+        'git commit -m "여러 단어"',
+        "git commit --amend --no-edit",
+        "git commit -F -",
+        "git -C /repo commit -m x",
+        "git add . && git commit -m x",
+        "git add .; git commit -m x",
+    ],
+)
+def test_blocks_real_commit_forms(tmp_path, command):
+    """좁히다 새면 `_state` 가 커밋된다 — 원래 막으려던 사고 그 자체."""
+    repo = _repo(tmp_path, staged_state=2)
+    result = _run_hook(command, repo)
+    assert result.returncode == 2, f"실제 커밋을 놓쳤다 {command!r} (rc={result.returncode})"
+
+
+# ---------------------------------------------------------------------------
+# 문자열 안의 언급은 막지 않는다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo "실행: git commit -m x"',
+        'git log --grep="git commit"',
+        """echo '{"tool_input":{"command":"git commit"}}'""",
+        'grep -rn "git commit" docs/',
+        "git status",
+        "git diff --cached",
+        "ls _state/",
+    ],
+)
+def test_does_not_block_mentions_or_other_commands(tmp_path, command):
+    """넓으면 무관한 명령이 막혀 사람이 훅을 끄게 된다."""
+    repo = _repo(tmp_path, staged_state=2)
+    result = _run_hook(command, repo)
+    assert result.returncode == 0, f"무관한 명령을 막았다 {command!r}: {result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# staged 조건
+# ---------------------------------------------------------------------------
+
+
+def test_allows_commit_when_no_state_staged(tmp_path):
+    repo = _repo(tmp_path, staged_other=True)
+    result = _run_hook("git commit -m x", repo)
+    assert result.returncode == 0, f"_state 가 없는데 막았다: {result.stderr}"
+
+
+def test_blocks_when_state_mixed_with_other_files(tmp_path):
+    """콘텐츠와 섞여 있어도 `_state` 가 있으면 막는다."""
+    repo = _repo(tmp_path, staged_state=1, staged_other=True)
+    result = _run_hook("git commit -m x", repo)
+    assert result.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# 출력 형식 — 개행이 들어가도 유효한 JSON
+# ---------------------------------------------------------------------------
+
+
+def test_reason_is_valid_json_with_multiple_staged_files(tmp_path):
+    """staged 목록은 개행 구분이다. 셸 보간으로 넣으면 2개 이상에서 invalid JSON 이 된다.
+
+    1개일 때는 우연히 유효해서 눈에 띄지 않는다 — 그래서 조용한 실패다.
+    """
+    repo = _repo(tmp_path, staged_state=3)
+    result = _run_hook("git commit -m x", repo)
+
+    payload = json.loads(result.stderr)  # 깨졌으면 여기서 raise
+    decision = payload["hookSpecificOutput"]
+    assert decision["permissionDecision"] == "deny"
+    assert decision["hookEventName"] == "PreToolUse"
+
+
+def test_reason_lists_staged_files_and_remedy(tmp_path):
+    repo = _repo(tmp_path, staged_state=2)
+    result = _run_hook("git commit -m x", repo)
+
+    reason = json.loads(result.stderr)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "_state/f0.json" in reason and "_state/f1.json" in reason, f"staged 목록이 없다: {reason}"
+    assert "git restore --staged" in reason, f"해결 방법이 없다: {reason}"


### PR DESCRIPTION
`pre-commit-state-guard.sh` 를 `component-counts-drift-guard.sh`(#1159)와 같은 명령-위치 매칭으로 통일합니다. 확인해 보니 문제가 하나가 아니라 셋이었습니다.

## 1. 오탐 — 문자열 안의 언급을 막았다

`_state` 가 staged 인 상태에서 실측 (`/tmp` 프로브 레포):

| 명령 | 기존 | 옳은 결과 |
|---|---|---|
| `git commit -m "x"` | rc=2 | rc=2 ✓ |
| `echo "실행: git commit -m x"` | **rc=2** ❌ | rc=0 |
| `git log --grep="git commit"` | **rc=2** ❌ | rc=0 |
| `git status` | rc=0 | rc=0 ✓ |

## 2. 미탐 — `git -C /repo commit` 을 놓쳤다

부분문자열 `*"git commit"*` 에는 걸리지 않습니다. 리터럴이 없으니까요.

| 명령 | 기존 | 옳은 결과 |
|---|---|---|
| `git -C /repo commit -m x` | **rc=0** ❌ | rc=2 |

이게 더 나쁜 쪽입니다. 이 경로로 **`_state` 가 커밋될 수 있었습니다** — 훅이 애초에 막으려던 사고 그 자체입니다.

## 3. `_state` 파일 2개 이상이면 invalid JSON

이유 문자열을 셸 보간으로 JSON 에 넣는데, staged 목록은 `grep` 이 개행으로 줍니다. 2개 이상이면 원시 개행이 문자열 안에 들어갑니다:

```
$ echo '{"tool_input":{"command":"git commit -m x"}}' | bash .claude/hooks/pre-commit-state-guard.sh
{"...","permissionDecisionReason":"Cowardly refusing ... Staged: _state/x.json
_state/y.json. Use 'git restore --staged _state/' first."}}

→ JSON 깨짐: Invalid control character at: line 1 column 202
```

**1개일 때만 우연히 유효**해서 눈에 띄지 않습니다 — 그래서 조용한 실패입니다. 이 세션 초반에 실제로 `_state` 8개가 staged 된 채 차단됐고, 그 출력이 깨진 JSON 이었습니다. `jq -n --arg` 로 만들도록 바꿨습니다.

## 고친 방식

```bash
COMMIT_RE='(^|[;&|])[[:space:]]*git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+commit([[:space:]]|$)'
printf '%s' "$COMMAND" | grep -Eq "$COMMIT_RE" || exit 0
```

`git` 하위명령을 줄/세그먼트 시작이거나 `;`/`&&`/`||`/`|` 뒤일 때만 인정합니다. #1159 의 push 가드와 같은 규칙입니다.

## 검증

`tests/test_state_guard_command_matching.py` — **18건**. 훅 스크립트를 서브프로세스로 돌립니다. 셸 로직을 파이썬으로 다시 구현하면 그 구현만 검증하고 정작 훅은 검증하지 못합니다.

| 축 | 케이스 |
|---|---|
| 실제 커밋 차단 (7) | `git commit -m x`, `--amend`, `-F -`, `git -C /repo commit`, `&& git commit`, `; git commit` |
| 언급·무관 명령 통과 (7) | `echo "실행: git commit …"`, `git log --grep=…`, `grep -rn "git commit"`, `git status`, `git diff --cached`, `ls _state/` |
| staged 조건 (2) | `_state` 없으면 통과, 콘텐츠와 섞여도 차단 |
| 출력 형식 (2) | 3개 파일에서도 유효한 JSON, staged 목록+해결법 포함 |

블로킹 가드라 **양방향을 다 강제**했습니다. 좁히다 새면 `_state` 가 커밋되고(2번), 넓으면 무관한 명령이 막혀 사람이 훅을 끄게 됩니다(1번).

```
$ python3 -m ruff check scripts/ tests/          → All checks passed!
$ python3 -m ruff format --check scripts/ tests/ → 292 files already formatted
$ python3 -m basedpyright                        → 0 errors, 0 warnings, 0 notes
$ python3 scripts/tools/component_counts.py --check → OK
$ python3 -m pytest tests/ -q                    → 5401 passed, 17 skipped
                                                    coverage 74.11% (게이트 70%)
```

라이브 재확인 (수정 후, 같은 프로브 레포):

```
rc=2  <- git commit -m "x"
rc=0  <- echo "실행: git commit -m x"      ← 오탐 해소
rc=0  <- git log --grep="git commit"       ← 오탐 해소
rc=2  <- git -C /repo commit -m x          ← 미탐 해소
rc=0  <- git status
```

남는 한계는 훅 주석에 명시했습니다: `git --git-dir=… commit` 류의 다른 전역 플래그 조합은 안 잡습니다. 완전히 풀려면 셸 파싱이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)