### PR TITLE
fix: Slack payload YAML 파손 복구 — 11일째 매일 실패하던 폴더 리포트

### DIFF
--- a/.github/workflows/push-folder-info-to-slack.yml
+++ b/.github/workflows/push-folder-info-to-slack.yml
@@ -161,12 +161,38 @@ jobs:
           SLACK_CHANNEL_ID_AI: ${{ secrets.SLACK_CHANNEL_ID_AI }}
           SLACK_CHANNEL_ID_INVESTING: ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
 
+      # payload 를 YAML 로 조립하지 않는다. `summary.outputs.message` 는 멀티라인이라
+      # `text: "..."` 안에 그대로 보간되면 2번째 줄부터 들여쓰기가 없는 상태로
+      # 스칼라를 벗어난다 — js-yaml 이 `deficient indentation (3:1)` 로 죽는다.
+      #
+      # v3.0.1 은 이 입력을 관대하게 다뤘고 v4.0.0(#1099, 2026-08-07 17:39 머지)부터
+      # 엄격히 파싱한다. 그 bump 이후 이 워크플로우는 **11일 연속 매일 실패**했고
+      # (마지막 성공 08-07 04:08, 첫 실패 08-08 03:07) 아무도 알아채지 못했다 —
+      # 5개 매트릭스 중 4개는 채널 시크릿이 없어 skip 되므로 실패가 openclaw 하나에만
+      # 나타나고, 그마저 Slack 알림 워크플로우 자신이라 알릴 통로가 없었다.
+      #
+      # jq 로 JSON 을 만들어 파일로 넘기면 이스케이프가 구조적으로 보장된다. 값은
+      # env 로 받는다 — `${{ }}` 를 셸에 직접 보간하면 주입 경로가 된다.
+      - name: Build Slack payload
+        if: steps.slack-config.outputs.can_post == 'true'
+        shell: bash
+        env:
+          SLACK_CHANNEL: ${{ steps.slack-config.outputs.channel }}
+          PROFILE_LABEL: ${{ steps.slack-config.outputs.profile_label }}
+          SUMMARY_MESSAGE: ${{ steps.summary.outputs.message }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg channel "$SLACK_CHANNEL" \
+            --arg label "$PROFILE_LABEL" \
+            --arg message "$SUMMARY_MESSAGE" \
+            '{channel: $channel, text: ("[" + $label + "]\n" + $message)}' \
+            > "${RUNNER_TEMP}/slack-payload.json"
+
       - name: Post to Slack investing channel
         if: steps.slack-config.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
           method: chat.postMessage
           token: ${{ steps.slack-config.outputs.token }}
-          payload: |
-            channel: "${{ steps.slack-config.outputs.channel }}"
-            text: "[${{ steps.slack-config.outputs.profile_label }}]\n${{ steps.summary.outputs.message }}"
+          payload-file-path: ${{ runner.temp }}/slack-payload.json


### PR DESCRIPTION
## 발견

CI red 이력 점검 중 `Push Folder Info To Slack` 이 **11일 연속 매일 실패** 중인 것을 찾았다.

```
마지막 성공  2026-08-07 04:08
첫 실패      2026-08-08 03:07
이후 08-08 ~ 08-18 전부 failure (11일)
```

## 원인

`payload:` 를 YAML 로 조립하는데 `summary.outputs.message` 가 멀티라인이라, `text: "..."` 안에 보간되면 2번째 줄부터 들여쓰기 없이 스칼라를 벗어난다. 실행 로그가 그대로 보여준다:

```
YAMLException: deficient indentation (3:1)
 1 | channel: "***"
 2 | text: "[openclaw-agent]\n*Daily  ...
 3 | - time (UTC): 2026-08-18T02:34:19Z
-----^
```

이 구성 자체는 오래됐고 v3.0.1 은 관대하게 넘겼다. **`chore(deps): Bump slackapi/slack-github-action from 3.0.1 to 4.0.0 (#1099)` 이 2026-08-07 17:39 에 머지**됐고 v4.0.0 부터 엄격히 파싱한다. 마지막 성공과 첫 실패 사이에 이 워크플로우를 건드린 커밋은 이것 하나다.

## 왜 11일간 아무도 몰랐나

매트릭스 5개(ops·dev·security·openclaw·investing) 중 **4개는 채널 시크릿이 없어 skip** 되므로 실패가 openclaw 하나에만 나타난다. 그리고 그마저 **Slack 알림 워크플로우 자신**이라 알릴 통로가 없었다 — 알림 경로가 자기 고장을 알릴 수 없다.

## 수정

`jq` 로 JSON 을 만들어 `payload-file-path` 로 넘긴다. 이스케이프가 구조적으로 보장된다. 값은 env 로 받아 `${{ }}` 셸 직접 보간(주입 경로)도 없앴다.

`payload-file-path` 가 v4.0.0 의 입력인지는 핀된 SHA 의 `action.yml` 을 직접 읽어 확인했다.

## 같은 패턴 스캔

이 액션을 쓰는 워크플로우 14개를 스캔해 "멀티라인 GITHUB_OUTPUT 을 payload 에 보간" 패턴을 찾았다. 후보 2건 중:

- `push-folder-info-to-slack.yml` — **실제 파손** (이 PR)
- `classify-workflow-failures.yml` — **안전.** `evidence_snippet` 은 payload 가 아니라 github-script 의 env 로만 간다. payload 의 `text: |` 블록은 단일 줄 보간뿐이다.

## 검증

- `actionlint` 통과
- 실패한 실행의 **실제 메시지**(멀티라인 + 한글 + 따옴표 + 백슬래시)로 jq 조립 실행 → 유효한 JSON, 줄 구조 보존(7→8줄, 라벨 1줄 추가), 특수문자 보존 확인
- **검증되지 않은 것**: 로컬 PyYAML 로는 기존 방식이 재현되지 않는다(PyYAML 이 js-yaml 보다 관대함). 진단 근거는 실행 로그의 `YAMLException` 과 버전 bump 시점 일치다.
- **실제 Slack 전송은 미검증** — `workflow_dispatch` 로 돌리면 openclaw 채널에 실제 메시지가 나가므로 승인 없이 실행하지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)