### PR TITLE
feat: 스케줄 워크플로우 알림 커버리지 가드 + Slack 오류 fail-loud

### DIFF
--- a/.github/workflows/alert-consecutive-failures.yml
+++ b/.github/workflows/alert-consecutive-failures.yml
@@ -84,6 +84,7 @@ jobs:
         if: steps.check.outputs.alert == 'true' && steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/classify-workflow-failures.yml
+++ b/.github/workflows/classify-workflow-failures.yml
@@ -15,7 +15,6 @@ on:
       - Collect Market Indicators
       - Collect Geopolitical Risk Data
       - Generate Daily Summary
-      - Generate Market Summary
       - Weekly Digest
       - Ops 10AM Digest
       - Backfill Post Summaries
@@ -202,6 +201,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/cleanup-old-images.yml
+++ b/.github/workflows/cleanup-old-images.yml
@@ -120,6 +120,7 @@ jobs:
         if: failure() && steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/collect-defi-llama.yml
+++ b/.github/workflows/collect-defi-llama.yml
@@ -47,6 +47,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/collect-defi-yields.yml
+++ b/.github/workflows/collect-defi-yields.yml
@@ -47,6 +47,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/collector-heartbeat.yml
+++ b/.github/workflows/collector-heartbeat.yml
@@ -90,6 +90,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/generate-daily-summary.yml
+++ b/.github/workflows/generate-daily-summary.yml
@@ -43,6 +43,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/generate-weekly-report.yml
+++ b/.github/workflows/generate-weekly-report.yml
@@ -77,6 +77,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/notify-deploy-status.yml
+++ b/.github/workflows/notify-deploy-status.yml
@@ -63,6 +63,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/ops-10am-digest.yml
+++ b/.github/workflows/ops-10am-digest.yml
@@ -71,6 +71,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true' && steps.digest.outputs.should_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/push-folder-info-to-slack.yml
+++ b/.github/workflows/push-folder-info-to-slack.yml
@@ -193,6 +193,7 @@ jobs:
         if: steps.slack-config.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack-config.outputs.token }}
           payload-file-path: ${{ runner.temp }}/slack-payload.json

--- a/.github/workflows/site-health-check.yml
+++ b/.github/workflows/site-health-check.yml
@@ -140,6 +140,7 @@ jobs:
         if: steps.site_check.outputs.http_code != '200' && steps.site_check.outputs.is_rate_limit != 'true' && steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/watchdog-zero-job-runs.yml
+++ b/.github/workflows/watchdog-zero-job-runs.yml
@@ -82,6 +82,7 @@ jobs:
         if: steps.scan.outputs.hit_count != '0' && steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -45,6 +45,7 @@ jobs:
         if: steps.slack.outputs.can_post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ steps.slack.outputs.token }}
           payload: |

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 53 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 149 |
+| 테스트 파일 (tests/test_*.py) | 150 |
 
 <!-- component-counts:end -->

--- a/tests/test_workflow_alerting_coverage_guard.py
+++ b/tests/test_workflow_alerting_coverage_guard.py
@@ -1,0 +1,241 @@
+"""스케줄 워크플로우의 실패 알림 커버리지 가드.
+
+## 왜 있나
+
+2026-08-18 에 `Push Folder Info To Slack` 이 **11일 연속 매일 실패**하고 있던 것을
+발견했다(마지막 성공 08-07 04:08). Dependabot 이 `slackapi/slack-github-action` 을
+3.0.1 → 4.0.0 으로 올리면서 payload YAML 파싱이 엄격해진 것이 원인이었는데,
+문제는 **아무 알림도 울리지 않았다**는 것이다.
+
+`docs/ops-external-watchdog.md` 는 4계층 알림 피라미드를 문서화하고 있다. 이번
+장애는 네 계층을 전부 통과했다:
+
+| 계층 | 커버 범위 | 이번 장애 |
+|---|---|---|
+| `alert-consecutive-failures` | `workflow_call` — 각 워크플로우가 **직접 호출**해야 함 | 호출하지 않음 |
+| `watchdog-zero-job-runs` | `startup_failure` 만 | 일반 step 실패라 해당 없음 |
+| 외부 서버(Layer 4) | 위 watchdog 감시 | 무관 |
+| `classify-workflow-failures` | **20개 화이트리스트** | 목록에 없음 |
+
+즉 커버리지가 **두 개의 옵트인 목록**으로 관리되는데 둘 다 조용히 드리프트한다.
+워크플로우를 새로 만들거나 이름을 바꿔도 등록 누락을 아무것도 감지하지 않는다.
+발견 시점 실측으로 워크플로우 53개 중 32개가 무커버리지였고, 그중 **17개가
+스케줄 실행** — 이번처럼 매일 조용히 실패할 수 있는 것들이었다.
+
+## 이 파일이 지키는 것
+
+1. **새 갭이 생기지 않을 것.** 스케줄 워크플로우가 두 계층 중 어디에도 없으면
+   `KNOWN_UNCOVERED` 에 명시적으로 적어야 통과한다. 적는 행위가 리뷰 대상이 된다.
+2. **목록이 저절로 줄어들 것.** 비교는 부분집합이 아니라 **정확한 일치**다. 커버리지를
+   붙였는데 `KNOWN_UNCOVERED` 에서 안 빼면 red — 목록이 낡은 채로 남지 않는다.
+3. **이름 드리프트를 잡을 것.** `classify-workflow-failures.yml` 의 화이트리스트는
+   워크플로우의 `name:` 문자열로 매칭한다. 워크플로우 이름을 바꾸면 그 항목이 조용히
+   아무것도 가리키지 않게 되고 커버리지가 사라진다. 실존을 강제한다.
+
+이 가드는 갭을 **없애지 않는다.** 갭이 11일 뒤가 아니라 PR 시점에 보이게 할 뿐이다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+CLASSIFIER = WORKFLOWS_DIR / "classify-workflow-failures.yml"
+CONSECUTIVE_ALERT_REF = "./.github/workflows/alert-consecutive-failures.yml"
+
+# 커버리지가 없는 스케줄 워크플로우 — 2026-08-18 발견 시점의 실측 baseline.
+#
+# **이 목록은 줄어들기만 해야 한다.** 늘리려면 "왜 이 워크플로우는 조용히 실패해도
+# 되는가" 를 PR 에서 답해야 한다. 위 `Push Folder Info To Slack` 이 정확히 이 목록에
+# 있었어야 할 종류였고, 없었기 때문에 11일이 걸렸다.
+#
+# 몇 개는 특히 눈에 띈다:
+# - `Watchdog — Zero-Job / startup_failure Runs` 는 알림 계층 3 자신이다. Layer 4
+#   (외부 서버)가 본다고 문서화돼 있지만 이 저장소 안에서는 무커버리지다.
+# - `Vercel Quota Report` 는 관측 축적이 목적이라 조용히 죽으면 데이터가 빈다.
+# - `Guard Falsifiability` 는 가드의 가드다.
+KNOWN_UNCOVERED: frozenset[str] = frozenset(
+    {
+        "Action Pin Verify",
+        "Backfill URL Summaries",
+        "Check Post Images",
+        "Check Post Summary",
+        "Collector Heartbeat",
+        "Dependency Security Check",
+        "GSC Index Audit",
+        "Generate Weekly Report",
+        "Guard Falsifiability",
+        "Integrated Quality Report",
+        "OpenClaw Hourly Improvement Loop",
+        "Push Folder Info To Slack",
+        "Respond AI Mentions",
+        "Supply-chain Lock Promotion Reminder",
+        "Supply-chain Lock Verify",
+        "Vercel Quota Report",
+        "Watchdog — Zero-Job / startup_failure Runs",
+    }
+)
+
+
+def _load(path: Path) -> dict:
+    """워크플로우 YAML 을 읽는다.
+
+    `on:` 은 YAML 1.1 에서 **boolean True 로 파싱된다.** 문자열 키로 찾으면 트리거가
+    없는 것처럼 보여 모든 워크플로우가 "스케줄 아님" 이 되고, 이 가드가 통째로
+    vacuous 해진다.
+    """
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _triggers(wf: dict) -> dict:
+    on = wf.get("on", wf.get(True))
+    return on if isinstance(on, dict) else {}
+
+
+def _workflow_name(path: Path, wf: dict) -> str:
+    name = wf.get("name")
+    return str(name) if isinstance(name, str) and name.strip() else path.stem
+
+
+def _all_workflows() -> dict[str, Path]:
+    found: dict[str, Path] = {}
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        found[_workflow_name(path, _load(path))] = path
+    return found
+
+
+def _scheduled() -> set[str]:
+    names: set[str] = set()
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        wf = _load(path)
+        if "schedule" in _triggers(wf):
+            names.add(_workflow_name(path, wf))
+    return names
+
+
+def _classifier_allowlist() -> set[str]:
+    wf = _load(CLASSIFIER)
+    run = _triggers(wf).get("workflow_run") or {}
+    listed = run.get("workflows") or []
+    return {str(n) for n in listed}
+
+
+def _consecutive_alert_callers() -> set[str]:
+    names: set[str] = set()
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        if CONSECUTIVE_ALERT_REF in path.read_text(encoding="utf-8"):
+            names.add(_workflow_name(path, _load(path)))
+    return names
+
+
+def _covered() -> set[str]:
+    return _classifier_allowlist() | _consecutive_alert_callers()
+
+
+def test_scheduled_workflows_are_discovered() -> None:
+    """스캐너가 붕괴하면 아래 단언이 전부 vacuous 해진다.
+
+    `on:` 이 boolean True 로 파싱되는 함정 때문에 실제로 0개가 나올 수 있다.
+    """
+    scheduled = _scheduled()
+    assert len(scheduled) >= 20, f"스케줄 워크플로우 {len(scheduled)}개 — 스캐너가 깨졌을 것"
+    assert "Push Folder Info To Slack" in scheduled
+
+
+def test_coverage_sources_are_discovered() -> None:
+    """두 커버리지 원본이 다 읽혀야 한다. 하나가 비면 갭이 과대 보고된다."""
+    assert len(_classifier_allowlist()) >= 15, "classify 화이트리스트를 못 읽었다"
+    assert len(_consecutive_alert_callers()) >= 10, "alert-consecutive-failures 호출자를 못 찾았다"
+
+
+def test_no_new_uncovered_scheduled_workflow() -> None:
+    """새 스케줄 워크플로우는 알림 계층에 등록되거나 baseline 에 명시돼야 한다.
+
+    정확한 일치를 요구한다 — 커버리지를 붙이고 baseline 에서 빼지 않으면 red 다.
+    목록이 낡은 채로 남으면 "17개 갭" 이라는 숫자가 거짓이 된다.
+    """
+    uncovered = _scheduled() - _covered()
+
+    newly_uncovered = uncovered - KNOWN_UNCOVERED
+    assert not newly_uncovered, (
+        f"알림 커버리지 없는 스케줄 워크플로우가 새로 생겼다: {sorted(newly_uncovered)}. "
+        "classify-workflow-failures.yml 의 workflows: 목록에 넣거나, "
+        "alert-consecutive-failures.yml 를 호출하거나, "
+        "조용히 실패해도 되는 이유를 적고 KNOWN_UNCOVERED 에 추가할 것."
+    )
+
+    now_covered = KNOWN_UNCOVERED - uncovered
+    assert not now_covered, (
+        f"커버리지가 생겼는데 baseline 에 남아 있다: {sorted(now_covered)}. "
+        "KNOWN_UNCOVERED 에서 뺄 것 — 목록은 줄어들기만 해야 한다."
+    )
+
+
+def test_classifier_allowlist_names_exist() -> None:
+    """화이트리스트는 `name:` 문자열 매칭이다 — 이름을 바꾸면 조용히 커버리지가 사라진다.
+
+    `COLLECTOR_WORKFLOWS` 가 파일명 조립으로 겪은 것과 같은 종류의 드리프트다.
+    """
+    known = set(_all_workflows())
+    dangling = _classifier_allowlist() - known
+    assert not dangling, (
+        f"classify-workflow-failures.yml 이 존재하지 않는 워크플로우를 가리킨다: {sorted(dangling)}. "
+        "이름이 바뀌었다면 그 워크플로우는 지금 무커버리지다."
+    )
+
+
+def test_known_uncovered_entries_exist() -> None:
+    """baseline 에 없는 이름이 남아 있으면 그만큼 갭이 작아 보인다."""
+    known = set(_all_workflows())
+    stale = KNOWN_UNCOVERED - known
+    assert not stale, f"KNOWN_UNCOVERED 에 존재하지 않는 워크플로우가 있다: {sorted(stale)}"
+
+
+@pytest.mark.parametrize("path", sorted(WORKFLOWS_DIR.glob("*.yml")), ids=lambda p: p.name)
+def test_every_workflow_declares_a_name(path: Path) -> None:
+    """`name:` 이 없으면 파일명으로 폴백하는데, 그 값은 화이트리스트와 절대 일치하지 않는다.
+
+    즉 이름 없는 워크플로우는 등록해도 커버되지 않는다.
+    """
+    wf = _load(path)
+    assert isinstance(wf.get("name"), str) and wf["name"].strip(), f"{path.name} 에 name: 이 없다"
+
+
+def test_alert_reference_path_is_current() -> None:
+    """호출자 탐지는 경로 문자열 매칭이다 — 재사용 워크플로우가 옮겨지면 조용히 0건이 된다."""
+    assert (WORKFLOWS_DIR / "alert-consecutive-failures.yml").is_file(), (
+        f"{CONSECUTIVE_ALERT_REF} 가 없다 — 호출자 탐지가 전부 빗나간다"
+    )
+
+
+def test_regression_marker_push_folder_info() -> None:
+    """이 가드를 만들게 한 그 워크플로우가 실제로 무커버리지로 잡히는지.
+
+    잡히지 않으면 가드가 원래 문제를 재현하지 못하는 것이다.
+    """
+    assert "Push Folder Info To Slack" in _scheduled() - _covered()
+
+
+def test_yaml_on_key_trap_is_handled() -> None:
+    """`on:` 이 True 로 파싱되는 것을 처리하지 못하면 이 가드는 전부 vacuous 하다."""
+    raw = yaml.safe_load("name: X\non:\n  schedule:\n    - cron: '0 0 * * *'\n")
+    assert "on" not in raw and True in raw, "PyYAML 동작이 바뀌었다 — _triggers 를 재검토할 것"
+    assert "schedule" in _triggers(raw)
+
+
+def test_yaml_quoted_on_key_also_works() -> None:
+    """`'on':` 으로 따옴표를 쓴 워크플로우도 있을 수 있다."""
+    raw = yaml.safe_load("name: X\n'on':\n  schedule:\n    - cron: '0 0 * * *'\n")
+    assert "schedule" in _triggers(raw)
+
+
+def test_scanner_ignores_non_workflow_files() -> None:
+    """`AGENTS.md` 같은 비-yml 파일이 섞여도 이름 집합이 오염되지 않아야 한다."""
+    assert all(p.suffix == ".yml" for p in WORKFLOWS_DIR.glob("*.yml"))
+    assert "AGENTS" not in _all_workflows()


### PR DESCRIPTION
#1172 의 11일 장애가 우연이 아니라 구조적 갭이었음을 실측하고, 그 갭을 PR 시점에 보이게 한다.

## 측정된 갭

`docs/ops-external-watchdog.md` 는 4계층 피라미드를 문서화하지만 #1172 는 전부 통과했다:

| 계층 | 커버 범위 | 이번 장애 |
|---|---|---|
| `alert-consecutive-failures` | `workflow_call` — 직접 호출 필요 | 호출 안 함 |
| `watchdog-zero-job-runs` | `startup_failure` 만 | 일반 step 실패 |
| 외부 서버 (Layer 4) | 위 watchdog 감시 | 무관 |
| `classify-workflow-failures` | **20개 화이트리스트** | 목록에 없음 |

```
워크플로우 53개 → 커버 21 / 무커버리지 32
                  그중 스케줄 실행 17  ← 조용히 매일 실패 가능
```

무커버리지 17개에 `Vercel Quota Report`, `Guard Falsifiability`, 그리고 **`Watchdog — Zero-Job` 자신**도 있다.

## 1. 드리프트 가드 (`tests/test_workflow_alerting_coverage_guard.py`)

갭을 **없애지 않는다.** 11일 뒤가 아니라 PR 시점에 보이게 한다.

- 새 무커버리지 스케줄 워크플로우 → red. baseline 에 적어야 통과하므로 "왜 조용히 실패해도 되는가" 가 리뷰 대상이 된다.
- **정확한 일치** 비교 — 커버리지를 붙이고 baseline 에서 안 빼면 red. 목록이 낡지 않는다.
- classify 화이트리스트 항목의 **실존 강제** — 이름 매칭이라 rename 이 조용히 커버리지를 없앤다.

**만들자마자 실제 드리프트 1건을 잡았다**: classify 목록의 `Generate Market Summary` 가 2026-07-06(`db1273c8f`)에 은퇴한 워크플로우를 가리키고 있었다. 제거했다.

`on:` 이 YAML 1.1 에서 boolean `True` 로 파싱되는 함정을 처리한다 — 문자열 키만 보면 스케줄 워크플로우가 0개로 잡혀 가드가 통째로 vacuous 해진다.

### 뮤테이션 검증 (4/4 red)

| 주입 | 결과 |
|---|---|
| 새 무커버리지 스케줄 워크플로우 추가 | 1 failed |
| 커버리지 생겼는데 baseline 잔존 | 1 failed |
| 워크플로우 rename → 목록이 허공 | 2 failed |
| `on:` 함정 미처리 | 5 failed |
| (복원) | 63 passed |

## 2. `errors: true` — 14개 파일

Slack 게시 step 14개가 **하나도** `errors:` 를 명시하지 않아 기본값 `false` 로 돌았다. 즉 `chat.postMessage` 가 실패해도 step 은 성공이다. #1172 검증 때 이것 때문에 "step success" 로 배달을 증명할 수 없었다.

⚠️ **실패 의미가 바뀐다.** Slack API 가 지속 실패하면(`retries: 5` 이후) 그 잡이 red 가 된다.

- **알림 계열**(watchdog, classify, heartbeat, site-health, notify-deploy, ops-digest, push-folder-info, alert-consecutive) — 배달이 목적이므로 red 가 맞다.
- **콘텐츠 계열**(defi-llama, defi-yields, daily-summary, weekly-report, weekly-digest, cleanup-images) — 알림 실패가 수집 성공을 red 로 만든다.

후자가 과하다고 판단되면 콘텐츠 6개만 되돌리면 된다. 일단 조용한 실패를 없애는 쪽을 택했다.

## 검증

- `actionlint` 53개 워크플로우 전부 통과
- 커버리지 가드 63 passed, 뮤테이션 4/4 red
- 전체 스위트 **5530 passed / 17 skipped**
- `ruff check` + `format --check` 클린
- `component-counts.md` 재생성 (테스트 149→150)
- **검증되지 않은 것**: `errors: true` 의 실제 발동(Slack API 실패 시 red)은 관측하지 않았다. 정상 경로만 #1172 dispatch 로 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)