### PR TITLE
feat: 자기참조 위험 큰 스케줄 워크플로우 3건에 실패 알림 연결

### DIFF
--- a/.github/workflows/classify-workflow-failures.yml
+++ b/.github/workflows/classify-workflow-failures.yml
@@ -22,6 +22,7 @@ on:
       - Site Health Check
       - Security Scan
       - Code Quality
+      - Guard Falsifiability
     types: [completed]
 
 permissions:

--- a/.github/workflows/vercel-quota-report.yml
+++ b/.github/workflows/vercel-quota-report.yml
@@ -26,6 +26,10 @@ on:
 
 permissions:
   contents: read
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구한다. 재사용 워크플로우는
+  # 호출자의 permissions 를 상속하므로 여기서 주지 않으면 알림이 런타임에 죽는다.
+  actions: read
+  issues: write
 
 concurrency:
   group: vercel-quota-report

--- a/.github/workflows/vercel-quota-report.yml
+++ b/.github/workflows/vercel-quota-report.yml
@@ -143,3 +143,14 @@ jobs:
             vercel-quota-report.txt
             vercel-quota-report-collector.txt
           retention-days: 90
+
+  # 주 1회라 threshold 3 이면 3주 뒤에야 운다. 관측 축적이 목적이라
+  # 한 번 빠지면 그 주 데이터가 통째로 비므로 첫 실패에 알린다.
+  alert-consecutive-failures:
+    needs: report
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Vercel Quota Report'
+      threshold: 1
+    secrets: inherit

--- a/.github/workflows/watchdog-zero-job-runs.yml
+++ b/.github/workflows/watchdog-zero-job-runs.yml
@@ -14,6 +14,8 @@ on:
 permissions:
   actions: read
   contents: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구한다(상속).
+  issues: write
 
 jobs:
   check-and-alert:

--- a/.github/workflows/watchdog-zero-job-runs.yml
+++ b/.github/workflows/watchdog-zero-job-runs.yml
@@ -88,3 +88,14 @@ jobs:
           payload: |
             channel: "${{ steps.slack.outputs.channel }}"
             text: ":rotating_light: [${{ steps.slack.outputs.profile_label }}] *Workflow startup failure detected* (${{ steps.scan.outputs.hit_count }} run(s))\n\n${{ steps.scan.outputs.slack_lines }}\n\nInvestigate within 5 min. <https://github.com/${{ github.repository }}/actions|View all runs>"
+
+  # 알림 계층 3 자신이다. 이게 죽으면 startup_failure 를 아무도 못 본다.
+  # `*/5` 라 threshold 3 은 약 15분 — 일시 실패는 흡수하고 지속 고장은 빨리 잡는다.
+  alert-consecutive-failures:
+    needs: check-and-alert
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Watchdog — Zero-Job / startup_failure Runs'
+      threshold: 3
+    secrets: inherit

--- a/tests/test_workflow_alerting_coverage_guard.py
+++ b/tests/test_workflow_alerting_coverage_guard.py
@@ -54,11 +54,15 @@ CONSECUTIVE_ALERT_REF = "./.github/workflows/alert-consecutive-failures.yml"
 # 되는가" 를 PR 에서 답해야 한다. 위 `Push Folder Info To Slack` 이 정확히 이 목록에
 # 있었어야 할 종류였고, 없었기 때문에 11일이 걸렸다.
 #
-# 몇 개는 특히 눈에 띈다:
-# - `Watchdog — Zero-Job / startup_failure Runs` 는 알림 계층 3 자신이다. Layer 4
-#   (외부 서버)가 본다고 문서화돼 있지만 이 저장소 안에서는 무커버리지다.
-# - `Vercel Quota Report` 는 관측 축적이 목적이라 조용히 죽으면 데이터가 빈다.
-# - `Guard Falsifiability` 는 가드의 가드다.
+# 자기참조 위험이 가장 컸던 3건은 2026-08-18 에 커버리지를 붙여 여기서 뺐다.
+# 메커니즘이 갈렸다:
+# - `Watchdog — Zero-Job` 자신 · `Vercel Quota Report` → `alert-consecutive-failures`
+#   호출(`if: failure()` 라 정상 실행 비용 0)
+# - `Guard Falsifiability` → classify 화이트리스트. 이 워크플로우의 `gate` 는
+#   required-check aggregator라 `test_required_check_aggregator_guard.py` 가 "모든 잡이
+#   gate.needs 에 있어야 한다" 를 강제하는데, 알림 잡은 gate 실패 **뒤에** 도는 잡이라
+#   순환이 된다. PR 에서 도는 워크플로우는 화이트리스트가 정석이다.
+# 남은 14건은 아직 조용히 실패할 수 있다.
 KNOWN_UNCOVERED: frozenset[str] = frozenset(
     {
         "Action Pin Verify",
@@ -69,15 +73,12 @@ KNOWN_UNCOVERED: frozenset[str] = frozenset(
         "Dependency Security Check",
         "GSC Index Audit",
         "Generate Weekly Report",
-        "Guard Falsifiability",
         "Integrated Quality Report",
         "OpenClaw Hourly Improvement Loop",
         "Push Folder Info To Slack",
         "Respond AI Mentions",
         "Supply-chain Lock Promotion Reminder",
         "Supply-chain Lock Verify",
-        "Vercel Quota Report",
-        "Watchdog — Zero-Job / startup_failure Runs",
     }
 )
 


### PR DESCRIPTION
#1173 이 드러낸 무커버리지 17건 중, 조용히 죽으면 피해가 가장 큰 셋을 붙인다.

| 워크플로우 | 왜 급한가 | 메커니즘 | threshold |
|---|---|---|---|
| `Watchdog — Zero-Job` | **알림 계층 3 자신.** 죽으면 startup_failure 를 아무도 못 봄 | `alert-consecutive-failures` | 3 (≈15분) |
| `Vercel Quota Report` | 관측 축적이 목적 — 한 번 빠지면 그 주 데이터가 빔 | `alert-consecutive-failures` | 1 |
| `Guard Falsifiability` | 가드의 가드 | **classify 화이트리스트** | 즉시 |

## 메커니즘이 갈린 이유 (설계 정보)

앞의 둘은 `alert-consecutive-failures` 호출이다. `if: failure()` 게이팅이라 정상 실행 비용이 0이다 — `*/5` 로 도는 watchdog 에도 부담이 없다.

`Guard Falsifiability` 는 **그렇게 할 수 없다.** 이 워크플로우의 `gate` 는 required-check aggregator 이고, `tests/test_required_check_aggregator_guard.py` 가 "모든 잡이 `gate.needs` 에 있어야 한다"를 강제한다. 알림 잡은 `gate` 실패 **뒤에** 도는 잡이라 넣으면 순환이다.

**이건 추측이 아니라 실제로 red 로 잡혔다** — 처음에 알림 잡으로 붙였다가 그 가드가 실패시켰다. 가드를 약화시키는 대신 메커니즘을 바꿨다. PR 에서 도는 워크플로우는 classify 화이트리스트가 정석이고, `Code Quality`·`Security Scan` 도 같은 방식이라 일관된다.

## threshold 1 검증

`alert-consecutive-failures` 는 `needed = THRESHOLD - 1` 로 두고 **현재 실행을 뺀** 이전 실패 수와 `-ge` 비교한다. 따라서 `threshold: 1` → `needed=0` → 첫 실패에 운다. 잡 자체가 `if: failure()` 라 현재 실행은 이미 실패한 상태다.

## baseline 17 → 14

`KNOWN_UNCOVERED` 가 3건 줄었다. 이 감소는 **가드가 red 로 요구해서** 이뤄졌다 — 정확한 일치를 요구하는 설계라 커버리지를 붙이고 목록에서 안 빼면 실패한다. 설계 의도대로 동작함이 실증된 셈이다.

## 검증

- `actionlint` 53개 전부 통과
- 커버리지 가드 + aggregator 가드 68 passed
- 전체 스위트 **5530 passed / 17 skipped**
- `ruff check` + `format --check` 클린
- 재측정: 스케줄 36개 중 커버 22 / 무커버리지 14 (이전 19/17)
- **검증되지 않은 것**: 알림이 실제로 발화하는지는 관측하지 않았다. 세 워크플로우를 일부러 실패시켜야 하므로 하지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)