### PR TITLE
feat: 남은 스케줄 워크플로우 11건에 실패 알림 연결 (무커버리지 14→3)

### DIFF
--- a/.github/workflows/action-pin-verify.yml
+++ b/.github/workflows/action-pin-verify.yml
@@ -31,6 +31,9 @@ on:
 
 permissions:
   contents: read
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 concurrency:
   group: action-pin-verify-${{ github.ref }}
@@ -62,3 +65,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/tools/verify_action_pins.py
+
+  # 주 1회 + PR. 업스트림 API 의존이라 PR 실패는 머지를 막지 않는 설계다 — 스케줄만 본다.
+  alert-consecutive-failures:
+    needs: verify
+    if: failure() && github.event_name == 'schedule'
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Action Pin Verify'
+      threshold: 1
+    secrets: inherit

--- a/.github/workflows/backfill-url-summaries.yml
+++ b/.github/workflows/backfill-url-summaries.yml
@@ -36,6 +36,9 @@ on:
 
 permissions:
   contents: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 concurrency:
   # 자기 자신과 겹치면 같은 블러브를 두 러너가 동시에 고쳐 푸시 경합이 난다.
@@ -131,3 +134,13 @@ jobs:
           done
           echo "::error::All $MAX_RETRIES push attempts failed"
           exit 1
+
+  # 일 1회. 실패하면 요약 백필이 밀리고 커밋이 안 나온다.
+  alert-consecutive-failures:
+    needs: backfill
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Backfill URL Summaries'
+      threshold: 2
+    secrets: inherit

--- a/.github/workflows/check-post-images.yml
+++ b/.github/workflows/check-post-images.yml
@@ -20,6 +20,9 @@ on:
 
 permissions:
   contents: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 concurrency:
   group: check-post-images-${{ github.ref }}
@@ -126,3 +129,13 @@ jobs:
           done
           echo "::error::All $MAX_RETRIES push attempts failed"
           exit 1
+
+  # 일 1회 + push/PR. PR 실패는 작성자가 이미 보므로 스케줄만 본다.
+  alert-consecutive-failures:
+    needs: check-images
+    if: failure() && github.event_name == 'schedule'
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Check Post Images'
+      threshold: 2
+    secrets: inherit

--- a/.github/workflows/collector-heartbeat.yml
+++ b/.github/workflows/collector-heartbeat.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   actions: read
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  issues: write
+  contents: read
 
 jobs:
   heartbeat:
@@ -96,3 +99,13 @@ jobs:
           payload: |
             channel: "${{ steps.slack.outputs.channel }}"
             text: "${{ steps.report.outputs.header }}\n${{ steps.report.outputs.lines }}"
+
+  # 일 1회. 이틀 연속이면 수집기 상태를 이틀 모르는 것이다.
+  alert-consecutive-failures:
+    needs: heartbeat
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Collector Heartbeat'
+      threshold: 2
+    secrets: inherit

--- a/.github/workflows/continuous-improvement-loop.yml
+++ b/.github/workflows/continuous-improvement-loop.yml
@@ -11,6 +11,9 @@ concurrency:
 
 permissions:
   contents: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 jobs:
   loop-cycle:
@@ -137,3 +140,13 @@ jobs:
             --channel "${{ steps.slack_dev.outputs.channel }}" \
             --message-path _state/continuous-improvement-roles/continuous-improvement-loop-uiux.txt \
             --marker "[multi-agent-forum]"
+
+  # 시간당 실행이라 threshold 3 = 약 3시간.
+  alert-consecutive-failures:
+    needs: loop-cycle
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'OpenClaw Hourly Improvement Loop'
+      threshold: 3
+    secrets: inherit

--- a/.github/workflows/generate-weekly-report.yml
+++ b/.github/workflows/generate-weekly-report.yml
@@ -13,6 +13,9 @@ on:
 
 permissions:
   contents: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 concurrency:
   group: collect-data
@@ -83,3 +86,13 @@ jobs:
           payload: |
             channel: "${{ steps.slack.outputs.channel }}"
             text: ":bar_chart: *Weekly Report* generated (run #${{ github.run_number }}) — https://github.com/Twodragon0/investing/tree/main/docs\n${{ steps.rejection.outputs.oneliner }}"
+
+  # 주 1회라 threshold 3 이면 3주 뒤다. 리포트 커밋이 통째로 빠지므로 첫 실패에 알린다.
+  alert-consecutive-failures:
+    needs: generate
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Generate Weekly Report'
+      threshold: 1
+    secrets: inherit

--- a/.github/workflows/gsc-index-audit.yml
+++ b/.github/workflows/gsc-index-audit.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 concurrency:
   group: gsc-index-audit-${{ github.ref }}
@@ -61,3 +64,13 @@ jobs:
           name: gsc-audit-${{ github.run_id }}
           path: gsc-audit-output.txt
           retention-days: 30
+
+  # 주 1회. 색인 감사가 빠지면 그 주 데이터가 없다.
+  alert-consecutive-failures:
+    needs: audit
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'GSC Index Audit'
+      threshold: 1
+    secrets: inherit

--- a/.github/workflows/push-folder-info-to-slack.yml
+++ b/.github/workflows/push-folder-info-to-slack.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 concurrency:
   group: push-folder-info
@@ -197,3 +200,13 @@ jobs:
           method: chat.postMessage
           token: ${{ steps.slack-config.outputs.token }}
           payload-file-path: ${{ runner.temp }}/slack-payload.json
+
+  # 일 1회. 2026-08-08~18 에 11일간 조용히 실패한 당사자다(#1172).
+  alert-consecutive-failures:
+    needs: push-folder-info
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Push Folder Info To Slack'
+      threshold: 2
+    secrets: inherit

--- a/.github/workflows/respond-ai-mentions.yml
+++ b/.github/workflows/respond-ai-mentions.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 concurrency:
   group: respond-ai-mentions
@@ -64,3 +67,13 @@ jobs:
           SLACK_BOT_TOKEN: ${{ steps.slack-config.outputs.token }}
           SLACK_CHANNEL_ID: ${{ steps.slack-config.outputs.channel }}
         run: python3 scripts/respond_ai_mentions.py
+
+  # 시간당 실행. 멘션 무응답은 사용자가 체감하므로 3시간 내 감지.
+  alert-consecutive-failures:
+    needs: respond-mentions
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Respond AI Mentions'
+      threshold: 3
+    secrets: inherit

--- a/.github/workflows/supply-chain-lock-promotion-reminder.yml
+++ b/.github/workflows/supply-chain-lock-promotion-reminder.yml
@@ -17,6 +17,8 @@ on:
 permissions:
   contents: read
   issues: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
 
 concurrency:
   group: supply-chain-lock-promotion-reminder
@@ -106,3 +108,13 @@ jobs:
               owner, repo, title, body, labels: [label, 'ops'],
             });
             core.info(`리마인더 이슈 #${created.data.number} 생성`);
+
+  # 주 1회.
+  alert-consecutive-failures:
+    needs: remind
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Supply-chain Lock Promotion Reminder'
+      threshold: 1
+    secrets: inherit

--- a/.github/workflows/supply-chain-lock.yml
+++ b/.github/workflows/supply-chain-lock.yml
@@ -47,6 +47,9 @@ on:
 
 permissions:
   contents: read
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
+  issues: write
 
 concurrency:
   group: supply-chain-lock
@@ -186,3 +189,13 @@ jobs:
               )
           print(f"OK: 직접 의존성 {len(direct)}개 핀 모두 txt 명세 만족.")
           PY
+
+  # 주 1회 + push/PR. PR 실패는 작성자가 이미 본다.
+  alert-consecutive-failures:
+    needs: verify
+    if: failure() && github.event_name == 'schedule'
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Supply-chain Lock Verify'
+      threshold: 1
+    secrets: inherit

--- a/tests/test_workflow_alerting_coverage_guard.py
+++ b/tests/test_workflow_alerting_coverage_guard.py
@@ -54,31 +54,21 @@ CONSECUTIVE_ALERT_REF = "./.github/workflows/alert-consecutive-failures.yml"
 # 되는가" 를 PR 에서 답해야 한다. 위 `Push Folder Info To Slack` 이 정확히 이 목록에
 # 있었어야 할 종류였고, 없었기 때문에 11일이 걸렸다.
 #
-# 자기참조 위험이 가장 컸던 3건은 2026-08-18 에 커버리지를 붙여 여기서 뺐다.
-# 메커니즘이 갈렸다:
-# - `Watchdog — Zero-Job` 자신 · `Vercel Quota Report` → `alert-consecutive-failures`
-#   호출(`if: failure()` 라 정상 실행 비용 0)
-# - `Guard Falsifiability` → classify 화이트리스트. 이 워크플로우의 `gate` 는
-#   required-check aggregator라 `test_required_check_aggregator_guard.py` 가 "모든 잡이
-#   gate.needs 에 있어야 한다" 를 강제하는데, 알림 잡은 gate 실패 **뒤에** 도는 잡이라
-#   순환이 된다. PR 에서 도는 워크플로우는 화이트리스트가 정석이다.
-# 남은 14건은 아직 조용히 실패할 수 있다.
+# 2026-08-18 에 17건 → 3건으로 줄였다. 남은 셋은 **실패가 곧 설계된 신호**라
+# 알림을 붙이면 모든 발견이 이슈와 Slack 에 중복된다:
+#
+# - `Dependency Security Check` — 취약점 발견 시 의도적 `exit 1` + 이슈 자동 생성
+# - `Integrated Quality Report` — 회귀 감지 시 `exit 1` + 이슈
+# - `Check Post Summary` — 회귀 시 이슈 생성
+#
+# **면제에는 남은 구멍이 있다.** 진짜 크래시와 "찾았음" 이 외부에서 구분되지 않아
+# 크래시는 여전히 안 보인다. 근본 해결은 두 경로를 분리하는 것(발견 시 이슈를 만들고
+# exit 0, 크래시만 실패)인데 각 워크플로우의 계약 변경이라 별건이다.
 KNOWN_UNCOVERED: frozenset[str] = frozenset(
     {
-        "Action Pin Verify",
-        "Backfill URL Summaries",
-        "Check Post Images",
         "Check Post Summary",
-        "Collector Heartbeat",
         "Dependency Security Check",
-        "GSC Index Audit",
-        "Generate Weekly Report",
         "Integrated Quality Report",
-        "OpenClaw Hourly Improvement Loop",
-        "Push Folder Info To Slack",
-        "Respond AI Mentions",
-        "Supply-chain Lock Promotion Reminder",
-        "Supply-chain Lock Verify",
     }
 )
 
@@ -215,12 +205,25 @@ def test_alert_reference_path_is_current() -> None:
     )
 
 
-def test_regression_marker_push_folder_info() -> None:
-    """이 가드를 만들게 한 그 워크플로우가 실제로 무커버리지로 잡히는지.
+def test_regression_marker_push_folder_info_is_now_covered() -> None:
+    """이 가드를 만들게 한 워크플로우(11일 조용한 실패, #1172)가 이제 커버되는지.
 
-    잡히지 않으면 가드가 원래 문제를 재현하지 못하는 것이다.
+    2026-08-18 에 `alert-consecutive-failures` 를 붙였다. 여기서 red 가 나면 그 연결이
+    끊어진 것이고, 같은 사고가 다시 조용히 일어날 수 있다.
     """
-    assert "Push Folder Info To Slack" in _scheduled() - _covered()
+    name = "Push Folder Info To Slack"
+    assert name in _scheduled(), "스케줄 트리거가 사라졌다 — 이 단언의 전제가 깨졌다"
+    assert name in _covered(), "알림 연결이 끊어졌다 — #1172 와 같은 사고가 다시 조용해진다"
+
+
+def test_uncovered_scheduled_workflow_would_be_detected() -> None:
+    """탐지 로직 자체가 살아 있는지 — baseline 이 비어 가도 vacuous 해지지 않게.
+
+    커버리지가 100% 가 되면 `_scheduled() - _covered()` 가 항상 빈 집합이라 위
+    단언들이 전부 자동 통과한다. 합성 입력으로 탐지 로직을 따로 확인한다.
+    """
+    synthetic_scheduled = _scheduled() | {"Synthetic Uncovered Workflow"}
+    assert "Synthetic Uncovered Workflow" in synthetic_scheduled - _covered()
 
 
 def test_yaml_on_key_trap_is_handled() -> None:


### PR DESCRIPTION
#1173(가드) → #1174(3건) 에 이어 나머지를 붙인다.

```
스케줄 36개 중 커버  22 → 33
무커버리지          14 → 3
alert 호출자        15 → 26
```

## threshold 를 주기에 맞췄다

| 주기 | threshold | 감지까지 | 대상 |
|---|---|---|---|
| 1시간 | 3 | ~3시간 | OpenClaw Loop, Respond AI Mentions |
| 1일 | 2 | 2일 | Collector Heartbeat, Push Folder Info, Backfill URL Summaries, Check Post Images |
| 1주 | 1 | 첫 실패 | Generate Weekly Report, GSC Index Audit, Lock Promotion Reminder, Action Pin Verify, Lock Verify |

주간 워크플로우에 기본값 3 을 쓰면 **3주 뒤**에야 운다.

## push/PR 트리거는 스케줄만 본다

`Check Post Images` · `Action Pin Verify` · `Supply-chain Lock Verify` 는 `github.event_name == 'schedule'` 로 좁혔다. PR 실패는 작성자가 이미 보는 정상 신호다. 특히 `Action Pin Verify` 는 업스트림 API 의존이라 PR 실패가 머지를 막지 않는 설계(`branch-protection.md`)다.

## 권한 상속을 또 밟았다

재사용 워크플로우는 호출자의 `permissions:` 를 상속한다. 11개 전부에 `actions: read` / `issues: write` 보강이 필요했고, 스크립트의 REQUIRED 집합에서 `contents: read` 를 빠뜨려 `collector-heartbeat` 하나가 걸렸다 — `check_workflow_permissions.py` 가 잡았다.

**로컬 pytest 에는 이 검사가 없다.** 워크플로우를 건드리면 따로 돌려야 한다.

## 남은 3건은 면제

`Dependency Security Check` · `Integrated Quality Report` · `Check Post Summary` 는 발견 시 **의도적으로** `exit 1` 하고 이슈를 만든다(코드에서 확인). 알림을 붙이면 모든 발견이 이슈와 Slack 에 중복된다.

⚠️ **면제에는 남은 구멍이 있다**: 진짜 크래시와 "찾았음" 이 외부에서 구분되지 않아 크래시는 여전히 안 보인다. baseline 주석에 적어 뒀다.

## 회귀 마커 재작성

"Push Folder Info 가 무커버리지로 잡히는가" 는 이제 성립하지 않는다(커버됐으므로). "커버되어 있는가" 로 뒤집고, 커버리지가 100% 에 가까워져도 탐지 로직이 vacuous 해지지 않도록 합성 입력 테스트를 추가했다.

알림 연결을 끊는 뮤테이션으로 red 확인.

## 검증

- `check_workflow_permissions.py` → OK
- `actionlint` 53개 전부 통과
- 커버리지 가드 64 passed
- 전체 스위트 **5531 passed / 17 skipped**
- ruff clean, `component_counts --check` OK
- **검증되지 않은 것**: 알림 발화는 관측하지 않았다(11개를 일부러 실패시켜야 함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)