### PR TITLE
feat: 발견 경로 exit 0 전환 — 스케줄 워크플로우 무커버리지 0 달성

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
   issues: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
 
 concurrency:
   group: dependency-check
@@ -109,8 +111,28 @@ jobs:
         env:
           VULN_COUNT: ${{ steps.audit.outputs.vuln_count }}
 
-      - name: Fail on vulnerabilities
+      # **발견은 실패가 아니다.** 예전에는 여기서 exit 1 했는데, 그러면 잡 실패가
+      # "취약점을 찾았다" 와 "워크플로우가 죽었다" 두 가지를 뜻해 밖에서 구분되지
+      # 않는다. 그래서 크래시에 알림을 붙일 수 없었고, 이 워크플로우는 실패 알림
+      # 커버리지에서 면제로 남아 있었다.
+      #
+      # 이제 발견은 exit 0 + 이슈다. 잡 실패는 크래시만 뜻하므로 아래
+      # `alert-consecutive-failures` 가 의미를 갖는다.
+      #
+      # 발견의 유일한 출력 경로가 위 "Create issue on vulnerabilities" 가 되므로
+      # 그 step 은 반드시 blocking 이어야 한다(`continue-on-error` 금지).
+      # `tests/test_findings_exit_zero_guard.py` 가 강제한다.
+      - name: Report vulnerabilities (non-failing)
         if: steps.audit.outputs.vuln_count != '0'
         run: |
-          echo "::error title=pip-audit findings::pip-audit 가 ${{ steps.audit.outputs.vuln_count }} 건의 취약점을 발견했습니다. audit-report.txt 와 자동 생성된 이슈를 확인하세요."
-          exit 1
+          echo "::warning title=pip-audit findings::pip-audit 가 ${{ steps.audit.outputs.vuln_count }} 건의 취약점을 발견했습니다. 자동 생성된 이슈를 확인하세요."
+
+  # 주 1회. 발견을 exit 0 으로 옮겼으므로 잡 실패는 크래시만 뜻한다 — 첫 실패에 알린다.
+  alert-consecutive-failures:
+    needs: audit
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Dependency Security Check'
+      threshold: 1
+    secrets: inherit

--- a/.github/workflows/integrated-quality-report.yml
+++ b/.github/workflows/integrated-quality-report.yml
@@ -24,6 +24,8 @@ on:
 permissions:
   contents: read
   issues: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구(상속됨).
+  actions: read
 
 concurrency:
   group: integrated-quality-report-${{ github.ref }}
@@ -147,8 +149,19 @@ jobs:
               labels: ['quality', 'integrated-report'],
             });
 
-      - name: Fail the job on combined failure
+      # 발견은 실패가 아니다 — `dependency-check.yml` 의 같은 자리 주석 참조.
+      # 회귀 발견은 exit 0 + 이슈이고, 잡 실패는 크래시만 뜻한다.
+      - name: Report combined regressions (non-failing)
         if: steps.combine.outputs.combined_status == 'failure'
         run: |
-          echo "::error::Integrated quality report flagged regressions — see step summary and opened issue."
-          exit 1
+          echo "::warning::Integrated quality report flagged regressions — see step summary and opened issue."
+
+  # 주 1회. 위와 같은 이유로 잡 실패 = 크래시.
+  alert-consecutive-failures:
+    needs: integrated-report
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Integrated Quality Report'
+      threshold: 1
+    secrets: inherit

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 53 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 150 |
+| 테스트 파일 (tests/test_*.py) | 151 |
 
 <!-- component-counts:end -->

--- a/tests/test_findings_exit_zero_guard.py
+++ b/tests/test_findings_exit_zero_guard.py
@@ -1,0 +1,145 @@
+"""발견 경로가 exit 0 이 된 워크플로우의 출력 경로 가드.
+
+## 왜 있나
+
+`Dependency Security Check` 와 `Integrated Quality Report` 는 원래 발견 시(취약점 /
+품질 회귀) 의도적으로 `exit 1` 했다. 그래서 잡 실패가 **두 가지**를 뜻했다:
+
+    실패 = "찾았다"  또는  "죽었다"
+
+밖에서 구분되지 않으니 크래시에만 알림을 붙일 수 없었고, 두 워크플로우는
+`test_workflow_alerting_coverage_guard.py` 의 면제 목록에 남아 있었다 — 즉 워크플로우가
+통째로 죽어도 아무도 몰랐다.
+
+2026-08-18 에 발견 경로를 `exit 0` 으로 옮겼다. 이제 잡 실패는 크래시만 뜻하고
+`alert-consecutive-failures` 가 의미를 갖는다.
+
+## 그래서 생긴 새 위험
+
+**발견의 유일한 출력 경로가 이슈 생성 step 하나가 됐다.** 예전에는 그 step 이 조용히
+실패해도 뒤의 `exit 1` 이 잡을 red 로 만들어 흔적이 남았다. 지금은 그 안전망이 없다 —
+이슈 생성이 `continue-on-error` 로 덮이거나 조건이 틀어지면 **취약점을 찾고도 아무
+일도 일어나지 않는다.** 그리고 잡은 green 이다.
+
+이 파일은 그 한 지점을 지킨다.
+
+## 지키는 것
+
+1. 발견 경로에 `exit 1` 이 되돌아오지 않을 것 (되돌아오면 면제 상태로 회귀한다)
+2. 이슈 생성 step 이 blocking 일 것 (`continue-on-error` 금지)
+3. 이슈 생성 step 이 실제로 존재하고 발견 조건에 걸려 있을 것
+4. 알림이 연결돼 있을 것 — exit 0 전환의 대가로 얻어야 하는 것
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+ALERT_REF = "./.github/workflows/alert-consecutive-failures.yml"
+
+# 파일 → (발견 조건을 담은 step 이름, 그 조건이 참조하는 출력)
+CONVERTED: dict[str, tuple[str, str]] = {
+    "dependency-check.yml": ("Create issue on vulnerabilities", "vuln_count"),
+    "integrated-quality-report.yml": ("Open issue on combined failure", "combined_status"),
+}
+
+
+def _load(name: str) -> dict:
+    data = yaml.safe_load((WORKFLOWS_DIR / name).read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _steps(wf: dict) -> list[dict]:
+    out: list[dict] = []
+    for job in (wf.get("jobs") or {}).values():
+        if isinstance(job, dict):
+            out.extend(s for s in (job.get("steps") or []) if isinstance(s, dict))
+    return out
+
+
+def _step_named(wf: dict, name: str) -> dict | None:
+    return next((s for s in _steps(wf) if s.get("name") == name), None)
+
+
+@pytest.mark.parametrize("workflow", sorted(CONVERTED))
+def test_issue_creation_step_exists(workflow: str) -> None:
+    """발견의 유일한 출력 경로다. 이름이 바뀌면 아래 단언들이 vacuous 해진다."""
+    step_name, _ = CONVERTED[workflow]
+    assert _step_named(_load(workflow), step_name) is not None, (
+        f"{workflow}: '{step_name}' step 이 없다. 이름을 바꿨다면 CONVERTED 도 갱신할 것 — "
+        "이 가드가 조용히 아무것도 지키지 않게 된다."
+    )
+
+
+@pytest.mark.parametrize("workflow", sorted(CONVERTED))
+def test_issue_creation_is_blocking(workflow: str) -> None:
+    """`continue-on-error` 가 붙으면 취약점을 찾고도 아무 일이 없고 잡은 green 이다."""
+    step_name, _ = CONVERTED[workflow]
+    step = _step_named(_load(workflow), step_name)
+    assert step is not None
+    assert not step.get("continue-on-error"), (
+        f"{workflow}: '{step_name}' 에 continue-on-error 가 붙었다. 발견의 유일한 출력 "
+        "경로이므로 실패하면 잡도 실패해야 한다 — 예전엔 뒤의 exit 1 이 안전망이었지만 "
+        "이제 없다."
+    )
+
+
+@pytest.mark.parametrize("workflow", sorted(CONVERTED))
+def test_issue_creation_is_gated_on_the_finding(workflow: str) -> None:
+    """조건이 발견 신호를 참조해야 한다. 상수 조건이면 매번 이슈가 생기거나 안 생긴다."""
+    step_name, signal = CONVERTED[workflow]
+    step = _step_named(_load(workflow), step_name)
+    assert step is not None
+    condition = str(step.get("if") or "")
+    assert signal in condition, (
+        f"{workflow}: '{step_name}' 의 if 가 `{signal}` 을 참조하지 않는다 (현재: {condition!r})"
+    )
+
+
+@pytest.mark.parametrize("workflow", sorted(CONVERTED))
+def test_finding_path_does_not_exit_nonzero(workflow: str) -> None:
+    """발견 경로에 `exit 1` 이 되돌아오면 면제 상태로 회귀한다.
+
+    잡 실패가 다시 "찾았다/죽었다" 두 뜻이 되고, 아래 알림이 모든 발견에 울게 된다.
+    """
+    _, signal = CONVERTED[workflow]
+    for step in _steps(_load(workflow)):
+        run = str(step.get("run") or "")
+        if signal in str(step.get("if") or "") and "exit 1" in run:
+            pytest.fail(
+                f"{workflow}: 발견 조건({signal})이 걸린 step '{step.get('name')}' 에 exit 1 이 있다. "
+                "발견은 exit 0 + 이슈여야 잡 실패가 크래시만 뜻한다."
+            )
+
+
+@pytest.mark.parametrize("workflow", sorted(CONVERTED))
+def test_alerting_is_attached(workflow: str) -> None:
+    """exit 0 전환의 대가로 얻어야 하는 것. 없으면 크래시가 다시 조용해진다."""
+    text = (WORKFLOWS_DIR / workflow).read_text(encoding="utf-8")
+    assert ALERT_REF in text, (
+        f"{workflow}: 발견을 exit 0 으로 옮겼는데 실패 알림이 없다. "
+        "크래시가 green 도 red 도 아닌 채로 아무에게도 안 보인다."
+    )
+
+
+def test_check_post_summary_covers_crashes_by_issue_on_failure() -> None:
+    """`check-post-summary.yml` 은 전환 대상이 **아니다** — 이미 다른 방식으로 덮고 있다.
+
+    이 워크플로우의 이슈 생성은 `if: failure()` 라 회귀뿐 아니라 **크래시에도** 돈다.
+    그래서 exit 0 전환 없이도 크래시가 보인다. 그 성질이 사라지면(조건이 좁아지면)
+    전환 대상이 되므로 여기서 지킨다.
+    """
+    wf = _load("check-post-summary.yml")
+    step = _step_named(wf, "Open issue on regression")
+    assert step is not None, "'Open issue on regression' step 이 사라졌다"
+    condition = str(step.get("if") or "")
+    assert "failure()" in condition, (
+        f"check-post-summary.yml: 이슈 생성 조건이 `failure()` 가 아니다 (현재: {condition!r}). "
+        "좁아졌다면 크래시가 더 이상 이슈를 만들지 않으므로 exit 0 전환이 필요하다."
+    )
+    assert not step.get("continue-on-error"), "이슈 생성이 non-blocking 이 되면 크래시가 조용해진다"

--- a/tests/test_workflow_alerting_coverage_guard.py
+++ b/tests/test_workflow_alerting_coverage_guard.py
@@ -48,29 +48,22 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 CLASSIFIER = WORKFLOWS_DIR / "classify-workflow-failures.yml"
 CONSECUTIVE_ALERT_REF = "./.github/workflows/alert-consecutive-failures.yml"
 
-# 커버리지가 없는 스케줄 워크플로우 — 2026-08-18 발견 시점의 실측 baseline.
+# 커버리지가 없는 스케줄 워크플로우 — 2026-08-18 기준 **0건**.
 #
-# **이 목록은 줄어들기만 해야 한다.** 늘리려면 "왜 이 워크플로우는 조용히 실패해도
-# 되는가" 를 PR 에서 답해야 한다. 위 `Push Folder Info To Slack` 이 정확히 이 목록에
-# 있었어야 할 종류였고, 없었기 때문에 11일이 걸렸다.
+# 발견 시점에는 17건이었다. 셋으로 나눠 없앴다:
+# - 11건 → `alert-consecutive-failures` 호출 (#1176)
+# - 3건  → 자기참조 위험 우선 (#1174)
+# - 2건  → 발견 경로를 exit 0 으로 옮겨 잡 실패가 크래시만 뜻하게 만든 뒤 알림 연결.
+#          `tests/test_findings_exit_zero_guard.py` 가 그 전환의 불변식을 지킨다.
+# - 1건  → `check-post-summary.yml`. 전환 없이 이미 커버돼 있었다 — 이슈 생성이
+#          `if: failure()` 라 크래시에도 돈다. `_issue_on_failure_workflows()` 가 그
+#          메커니즘을 모델에 넣는다.
 #
-# 2026-08-18 에 17건 → 3건으로 줄였다. 남은 셋은 **실패가 곧 설계된 신호**라
-# 알림을 붙이면 모든 발견이 이슈와 Slack 에 중복된다:
-#
-# - `Dependency Security Check` — 취약점 발견 시 의도적 `exit 1` + 이슈 자동 생성
-# - `Integrated Quality Report` — 회귀 감지 시 `exit 1` + 이슈
-# - `Check Post Summary` — 회귀 시 이슈 생성
-#
-# **면제에는 남은 구멍이 있다.** 진짜 크래시와 "찾았음" 이 외부에서 구분되지 않아
-# 크래시는 여전히 안 보인다. 근본 해결은 두 경로를 분리하는 것(발견 시 이슈를 만들고
-# exit 0, 크래시만 실패)인데 각 워크플로우의 계약 변경이라 별건이다.
-KNOWN_UNCOVERED: frozenset[str] = frozenset(
-    {
-        "Check Post Summary",
-        "Dependency Security Check",
-        "Integrated Quality Report",
-    }
-)
+# **비어 있다고 가드가 무의미해지지 않는다.** 새 스케줄 워크플로우가 커버리지 없이
+# 들어오면 여기 적어야 통과하고, 적는 행위가 리뷰 대상이 된다.
+# `test_uncovered_scheduled_workflow_would_be_detected` 가 탐지 로직이 vacuous 하지
+# 않음을 따로 지킨다.
+KNOWN_UNCOVERED: frozenset[str] = frozenset()
 
 
 def _load(path: Path) -> dict:
@@ -125,8 +118,34 @@ def _consecutive_alert_callers() -> set[str]:
     return names
 
 
+def _issue_on_failure_workflows() -> set[str]:
+    """실패 시(크래시 포함) 이슈를 만드는 워크플로우 — 세 번째 커버리지 메커니즘.
+
+    `check-post-summary.yml` 이 이 방식이다. 이슈 생성 step 의 `if:` 가 `failure()` 라
+    회귀뿐 아니라 크래시에도 돌므로, 알림 계층에 등록돼 있지 않아도 고장이 보인다.
+
+    이 메커니즘을 모델에 넣지 않으면 baseline 이 "커버 안 됨" 과 "다르게 커버됨" 을
+    뒤섞어, 남은 숫자가 실제 위험을 과장한다.
+    """
+    names: set[str] = set()
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        wf = _load(path)
+        for job in (wf.get("jobs") or {}).values():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                if "failure()" not in str(step.get("if") or ""):
+                    continue
+                script = str((step.get("with") or {}).get("script") or "")
+                if "issues.create" in script:
+                    names.add(_workflow_name(path, wf))
+    return names
+
+
 def _covered() -> set[str]:
-    return _classifier_allowlist() | _consecutive_alert_callers()
+    return _classifier_allowlist() | _consecutive_alert_callers() | _issue_on_failure_workflows()
 
 
 def test_scheduled_workflows_are_discovered() -> None:
@@ -143,6 +162,7 @@ def test_coverage_sources_are_discovered() -> None:
     """두 커버리지 원본이 다 읽혀야 한다. 하나가 비면 갭이 과대 보고된다."""
     assert len(_classifier_allowlist()) >= 15, "classify 화이트리스트를 못 읽었다"
     assert len(_consecutive_alert_callers()) >= 10, "alert-consecutive-failures 호출자를 못 찾았다"
+    assert _issue_on_failure_workflows(), "`if: failure()` 이슈 생성 워크플로우를 못 찾았다"
 
 
 def test_no_new_uncovered_scheduled_workflow() -> None:


### PR DESCRIPTION
#1173(가드) → #1174(3건) → #1176(11건) 의 마지막 조각.

```
무커버리지 스케줄 워크플로우:  17 → 3 → 0
```

## 문제 — `exit 1` 이 두 가지를 뜻했다

`Dependency Security Check` · `Integrated Quality Report` 는 발견 시 의도적으로 `exit 1` 했다:

```
실패 = "찾았다"  또는  "죽었다"      ← 밖에서 구분 불가
```

그래서 크래시에만 알림을 붙일 수 없었고, 두 워크플로우는 **통째로 죽어도 아무도 모르는** 상태로 면제 목록에 남아 있었다.

## 조치 — 발견은 exit 0 + 이슈

`::error ... exit 1` → `::warning`. 이제 잡 실패는 크래시만 뜻하므로 `alert-consecutive-failures` 를 붙였다.

⚠️ **대가로 새 위험이 생긴다.** 발견의 유일한 출력 경로가 이슈 생성 step 하나가 됐다. 예전엔 그 step 이 조용히 실패해도 뒤의 `exit 1` 이 잡을 red 로 만들어 흔적이 남았는데, 이제 그 안전망이 없다 — `continue-on-error` 가 붙으면 **취약점을 찾고도 아무 일이 없고 잡은 green** 이다.

`tests/test_findings_exit_zero_guard.py` 가 그 한 지점을 지킨다: step 실존 / blocking / 발견 조건 참조 / `exit 1` 미복귀 / 알림 연결.

## `check-post-summary` 는 전환하지 않았다 (계획 정정)

셋을 같은 방식으로 처리하려던 계획이 **틀렸다.** 조사해 보니 이미 커버돼 있었다 — 이슈 생성이 `if: failure()` 라 회귀뿐 아니라 **크래시에도** 돈다.

대신 커버리지 가드에 이 세 번째 메커니즘(`_issue_on_failure_workflows`)을 넣었다. 모델에 없으면 baseline 이 "커버 안 됨"과 "다르게 커버됨"을 뒤섞어 남은 숫자가 실제 위험을 과장한다.

## 결과

```
스케줄 36 / 커버 36 / 무커버리지 0
메커니즘: classify 20 · alert 호출 28 · issue-on-failure 1
KNOWN_UNCOVERED: 비어 있음
```

**비어 있어도 가드는 유효하다.** 새 스케줄 워크플로우가 커버리지 없이 들어오면 red 이고, `test_uncovered_scheduled_workflow_would_be_detected` 가 탐지 로직의 vacuity 를 따로 막는다.

## 뮤테이션 검증 (4/4 red)

| 주입 | 결과 |
|---|---|
| 발견 경로에 `exit 1` 복귀 | 1 failed |
| 이슈 생성에 `continue-on-error` | 1 failed |
| 알림 연결 제거 | 2 failed |
| `check-post-summary` 이슈 조건 축소 | 3 failed |
| (복원) | 75 passed |

## 검증

- `check_workflow_permissions.py` → OK
- `actionlint` 53개 전부 통과
- 전체 스위트 **5542 passed / 17 skipped**
- ruff clean, `component-counts` 재생성 (테스트 150→151)
- **검증되지 않은 것**: 실제 취약점 발견 시 green + 이슈가 나오는지는 관측하지 않았다(취약점을 만들어야 함). 알림 발화도 미관측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)