### PR TITLE
fix: 이슈 중복 판정을 발견 지문으로 좁혀 exit 0 무음 상태를 없앤다

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -71,6 +71,33 @@ jobs:
           echo "vuln_count=$VULN_COUNT" >> "$GITHUB_OUTPUT"
           echo "Found $VULN_COUNT vulnerabilities"
 
+          # 발견 지문(취약점 ID 집합의 해시). 이슈 중복 판정에 쓴다.
+          #
+          # 제목이 상수였을 때는 **열려 있는 이슈 하나가 이후 모든 발견의 이슈 생성을
+          # 영구히 억제**했다. 실제로 #985(2026-06-01, 지금은 ignore 목록에 든
+          # PYSEC-2022-252)가 82일간 그 역할을 했다. 발견이 exit 1 이던 시절에는
+          # 잡이 red 라 흔적이 남았지만, exit 0 으로 옮긴 뒤에는 잡도 green 이라
+          # 신호가 하나도 남지 않는다.
+          #
+          # 지문을 제목에 넣으면 발견 내용이 바뀔 때마다 새 이슈가 열리고, 같은
+          # 발견의 주간 재실행만 억제된다(원래 의도한 멱등성).
+          VULN_FINGERPRINT=$(python3 -c "
+          import hashlib, json
+          try:
+              with open('audit-report.json') as f:
+                  data = json.load(f)
+              ids = sorted(
+                  v.get('id', '')
+                  for d in data.get('dependencies', [])
+                  for v in d.get('vulns', [])
+              )
+              print(hashlib.sha256('|'.join(ids).encode()).hexdigest()[:12] if ids else 'none')
+          except Exception:
+              print('unknown')
+          ")
+          echo "vuln_fingerprint=$VULN_FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "Finding fingerprint: $VULN_FINGERPRINT"
+
       - name: Check outdated packages
         run: pip list --outdated --format=columns 2>/dev/null || true
 
@@ -85,7 +112,8 @@ jobs:
               report = fs.readFileSync('audit-report.txt', 'utf8');
             } catch (e) {}
 
-            const title = `🔒 Dependency Security: ${process.env.VULN_COUNT} vulnerabilities found`;
+            const fingerprint = process.env.VULN_FINGERPRINT;
+            const title = `🔒 Dependency Security: ${process.env.VULN_COUNT} vulnerabilities found [${fingerprint}]`;
             const body = `## Dependency Security Audit\n\n` +
               `**Vulnerabilities Found**: ${process.env.VULN_COUNT}\n\n` +
               `### Details\n\`\`\`\n${report.substring(0, 3000)}\n\`\`\`\n\n` +
@@ -98,7 +126,10 @@ jobs:
               labels: 'security'
             });
 
-            const existing = issues.data.find(i => i.title.includes('Dependency Security'));
+            // **지문이 같은** 열린 이슈만 중복이다. 상수 접두어로 판정하면 이미 열려
+            // 있는 이슈 하나가 이후 모든 발견을 침묵시킨다(위 audit step 주석 참조).
+            // tests/test_findings_exit_zero_guard.py 가 이 판정식을 지킨다.
+            const existing = issues.data.find(i => i.title.includes(`[${fingerprint}]`));
             if (!existing) {
               await github.rest.issues.create({
                 owner: context.repo.owner,
@@ -110,6 +141,7 @@ jobs:
             }
         env:
           VULN_COUNT: ${{ steps.audit.outputs.vuln_count }}
+          VULN_FINGERPRINT: ${{ steps.audit.outputs.vuln_fingerprint }}
 
       # **발견은 실패가 아니다.** 예전에는 여기서 exit 1 했는데, 그러면 잡 실패가
       # "취약점을 찾았다" 와 "워크플로우가 죽었다" 두 가지를 뜻해 밖에서 구분되지

--- a/tests/test_findings_exit_zero_guard.py
+++ b/tests/test_findings_exit_zero_guard.py
@@ -29,10 +29,29 @@
 2. 이슈 생성 step 이 blocking 일 것 (`continue-on-error` 금지)
 3. 이슈 생성 step 이 실제로 존재하고 발견 조건에 걸려 있을 것
 4. 알림이 연결돼 있을 것 — exit 0 전환의 대가로 얻어야 하는 것
+5. 이슈 **중복 판정이 새 발견을 억제할 수 없을 것** (2026-08-21 추가)
+
+## 5번을 뒤늦게 추가한 이유 (실측)
+
+1~4 는 "step 이 실행되는가" 를 지켰다. 그런데 step 이 **실행되고 성공하면서도 아무
+이슈를 만들지 않는** 경로가 남아 있었다 — 중복 판정이다.
+
+`dependency-check.yml` 의 판정은 제목의 상수 접두어(`'Dependency Security'`)를 훑었다.
+그래서 그 접두어를 가진 **열린 이슈가 하나라도 있으면 이후 모든 발견의 이슈 생성이
+영구히 억제**됐다. 실측: #985 가 2026-06-01 에 열린 뒤 82일간(`createdAt == updatedAt`)
+그 역할을 했고, 정작 그 이슈의 취약점(PYSEC-2022-252)은 이미 `--ignore-vuln` 목록에
+들어가 닫혀야 했던 것이다.
+
+발견이 `exit 1` 이던 시절엔 억제돼도 잡이 red 라 흔적이 남았다. exit 0 전환 이후엔
+잡도 green 이므로 **신호가 0** 이다. 즉 전환이 이 잠복 버그를 무음 사고로 승격시켰다.
+
+조치는 지문(발견 ID 집합의 해시)을 제목에 넣고 판정을 지문으로 좁힌 것이다. 아래 두
+테스트가 그 성질을 지킨다 — 제목이 다시 상수가 되거나 판정이 다시 넓어지면 red.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -47,6 +66,22 @@ CONVERTED: dict[str, tuple[str, str]] = {
     "dependency-check.yml": ("Create issue on vulnerabilities", "vuln_count"),
     "integrated-quality-report.yml": ("Open issue on combined failure", "combined_status"),
 }
+
+# 파일 → 이슈 제목과 중복 판정이 반드시 참조해야 하는 "발견마다 달라지는" 값.
+#
+# 두 워크플로우가 서로 다른 수단을 쓴다 — 하나로 통일하지 않은 것은 의도다.
+#   dependency-check       : 발견 ID 집합의 해시. 같은 취약점의 주간 재실행은 억제해야
+#                            하므로 실행마다 달라지면 안 된다.
+#   integrated-quality-report: `run_id`. 애초에 중복 조회가 없어 억제될 수 없고, 회귀
+#                            리포트는 매 실행 스냅샷이라 실행마다 새 이슈가 맞다.
+FINDING_SCOPED_DEDUP: dict[str, str] = {
+    "dependency-check.yml": "fingerprint",
+    "integrated-quality-report.yml": "github.run_id",
+}
+
+# 제목을 **만드는** 줄의 앵커. `i.title.includes(...)` 같은 속성 접근은 제외해야 한다
+# (아니면 판정식 줄이 제목 줄로 오인되어 단언이 vacuous 해진다 — 실측 확인).
+_TITLE_ASSIGN = re.compile(r"^\s*(?:const\s+|let\s+|var\s+)?title\s*[:=]")
 
 
 def _load(name: str) -> dict:
@@ -124,6 +159,65 @@ def test_alerting_is_attached(workflow: str) -> None:
     assert ALERT_REF in text, (
         f"{workflow}: 발견을 exit 0 으로 옮겼는데 실패 알림이 없다. "
         "크래시가 green 도 red 도 아닌 채로 아무에게도 안 보인다."
+    )
+
+
+def _issue_script(workflow: str) -> str:
+    """이슈 생성 step 의 github-script 본문. 없으면 아래 단언들이 vacuous 해지므로 실패."""
+    step_name, _ = CONVERTED[workflow]
+    step = _step_named(_load(workflow), step_name)
+    assert step is not None, f"{workflow}: '{step_name}' step 이 없다"
+    script = str((step.get("with") or {}).get("script") or "")
+    assert script, (
+        f"{workflow}: '{step_name}' 에 github-script 본문이 없다. 이슈 생성 방식이 바뀌었다면 "
+        "중복 억제 가드도 새 형태에 맞춰 다시 써야 한다."
+    )
+    return script
+
+
+@pytest.mark.parametrize("workflow", sorted(FINDING_SCOPED_DEDUP))
+def test_issue_title_varies_with_the_finding(workflow: str) -> None:
+    """제목이 상수면 중복 판정이 이후 모든 발견을 억제할 수 있다(#985, 82일)."""
+    token = FINDING_SCOPED_DEDUP[workflow]
+    script = _issue_script(workflow)
+    # 제목을 **만드는** 줄만 본다 — 변수 대입(`const title = ...`)과 create() 인자
+    # 리터럴(`title: ...`).
+    #
+    # 느슨하게 `"title" in ln` 으로 걸면 중복 판정식(`i.title.includes(...)`)까지
+    # 잡혀서, 그 줄에 있는 지문이 이 단언을 우연히 만족시킨다. 실측으로 확인했다:
+    # 제목에서 지문을 제거하는 뮤테이션이 통과했다(2026-08-21). 접두어 앵커 필수.
+    title_lines = [ln for ln in script.splitlines() if _TITLE_ASSIGN.match(ln)]
+    assert title_lines, f"{workflow}: 이슈 제목을 만드는 줄을 찾지 못했다 — 형태가 바뀌었다"
+    assert any(token in ln for ln in title_lines), (
+        f"{workflow}: 이슈 제목이 `{token}` 을 담지 않는다. 제목이 발견마다 달라지지 않으면 "
+        f"열린 이슈 하나가 이후 모든 발견을 침묵시킨다. 현재 제목 줄: {title_lines!r}"
+    )
+
+
+@pytest.mark.parametrize("workflow", sorted(FINDING_SCOPED_DEDUP))
+def test_dedup_lookup_cannot_suppress_a_different_finding(workflow: str) -> None:
+    """열린 이슈를 훑어 중복을 판정한다면, 그 판정은 발견마다 달라지는 값에 걸려야 한다.
+
+    상수 접두어로 판정하면 step 은 실행되고 성공하면서도 이슈를 만들지 않는다.
+    exit 0 전환 이후에는 잡도 green 이라 그 침묵이 어디에도 드러나지 않는다.
+    """
+    token = FINDING_SCOPED_DEDUP[workflow]
+    script = _issue_script(workflow)
+
+    if "listForRepo" not in script and ".find(" not in script:
+        # 중복 조회가 아예 없으면 억제될 수 없다. 이 상태가 유지되는지만 확인한다 —
+        # 나중에 조회가 추가되면 위 조건이 참이 되어 아래 판정식 단언이 살아난다.
+        assert "issues.create" in script, f"{workflow}: 중복 조회도 없고 이슈 생성도 없다. 발견의 출력 경로가 사라졌다."
+        return
+
+    predicates = [ln for ln in script.splitlines() if ".find(" in ln]
+    assert predicates, (
+        f"{workflow}: 열린 이슈를 조회(listForRepo)하는데 중복 판정식(.find)을 찾지 못했다. "
+        "판정 형태가 바뀌었다면 이 가드를 새 형태에 맞춰 다시 써야 한다."
+    )
+    assert all(token in ln for ln in predicates), (
+        f"{workflow}: 중복 판정식이 `{token}` 을 참조하지 않는다 — 발견 내용과 무관하게 "
+        f"매칭되므로 열린 이슈 하나가 이후 모든 발견을 억제한다. 현재: {predicates!r}"
     )
 
 


### PR DESCRIPTION
`dependency-check.yml` 의 이슈 중복 판정이 제목의 **상수 접두어**를 훑고 있었습니다.

```js
const existing = issues.data.find(i => i.title.includes('Dependency Security'));
```

그래서 그 접두어를 가진 열린 이슈가 하나라도 있으면 **이후 모든 발견의 이슈 생성이 영구히 억제**됩니다.

## 실측

| 항목 | 값 |
|---|---|
| 억제 중인 이슈 | #985 `🔒 Dependency Security: 1 vulnerabilities found` |
| 열린 시점 | 2026-06-01 (`createdAt == updatedAt`, 82일간 무변경) |
| 그 이슈의 취약점 | `deep-translator 1.11.4 / PYSEC-2022-252` |
| 현재 그 취약점 상태 | 이 워크플로우가 `--ignore-vuln PYSEC-2022-252` 로 **이미 영구 수용** → 닫혀야 했던 이슈 |
| 최근 스케줄 런(2026-08-17) | `No known vulnerabilities found, 1 ignored` → 현재 `vuln_count=0` (잠복) |

## 왜 지금 심각해졌나

발견이 `exit 1` 이던 시절엔 억제돼도 잡이 red 여서 흔적이 남았습니다. #1177 이 발견을 `exit 0` 으로 옮긴 뒤에는 잡도 green 입니다.

| | 신규 취약점 발견 시 |
|---|---|
| #1177 **이전** | 이슈 억제 + **exit 1 → 잡 red** → 눈에 보임 |
| #1177 **이후** | 이슈 억제 + **exit 0 → 잡 green** → `::warning` 로그 한 줄, 알림 0건 |

`alert-consecutive-failures` 는 `if: failure()` 이므로 울지 않습니다. #1177 이 본문에서 경고한 "발견의 유일한 출력 경로" 위험이 **이미 막혀 있던** 셈입니다.

기존 가드 4개(step 실존 / blocking / 발견조건 게이팅 / exit 1 미복귀)는 이 경로를 잡지 못합니다 — step 은 **실행되고 성공하면서** no-op 하기 때문입니다.

## 조치

발견 ID 집합의 sha256 앞 12자리를 지문으로 만들어 제목에 넣고, 중복 판정을 그 지문으로 좁혔습니다. 발견 내용이 바뀌면 새 이슈가 열리고, 같은 발견의 주간 재실행만 억제됩니다(원래 의도한 멱등성 유지).

지문 코드는 격리 프로브로 4가지 성질을 실측했습니다:

| 입력 | 결과 |
|---|---|
| 취약점 2건 | `1fc999f959e3` |
| 같은 집합, 순서만 다름 | `1fc999f959e3` (동일 — `sorted` 적용) |
| 발견 0건 | `none` |
| `audit-report.json` 파손 | `unknown` |
| 다른 취약점 집합 | `50ef7048989a` (다름) |

## 가드 — 그리고 가드가 한 번 vacuous 했다는 것

`test_findings_exit_zero_guard.py` 에 5번 항목을 추가했습니다: 제목이 발견마다 달라질 것, 중복 판정식이 그 값을 참조할 것.

뮤테이션 실증:

| 뮤테이션 | 결과 |
|---|---|
| 판정식을 상수 접두어로 되돌림 | **red** — `중복 판정식이 fingerprint 을 참조하지 않는다` |
| 제목에서 지문 제거 | **red** — `이슈 제목이 fingerprint 을 담지 않는다` |

두 번째 뮤테이션은 **처음에 통과했습니다.** 제목-줄 필터를 `"title" in ln` 으로 느슨하게 썼더니 판정식 줄(`i.title.includes(...)`)까지 제목 줄로 잡히고, 그 줄에 있는 `fingerprint` 때문에 단언이 우연히 만족됐습니다. 대입문 앵커(`_TITLE_ASSIGN` 정규식)로 좁혀 red 를 확인했습니다. 뮤테이션을 돌리지 않았으면 아무것도 지키지 않는 가드를 커밋했을 것입니다.

## 검증

```
python3 -m pytest tests/test_findings_exit_zero_guard.py --no-cov -q   → 15 passed
python3 -m ruff check tests/ scripts/                                   → All checks passed!
python3 -m ruff format --check tests/ scripts/                          → 298 files already formatted
actionlint .github/workflows/dependency-check.yml                       → rc=0, 출력 없음
python3 -c "yaml.safe_load(...)"                                        → yaml_parse_ok
```

## 범위 밖으로 남기는 것

- `integrated-quality-report.yml` 은 제목에 `run_id` 가 들어가 중복 조회 자체가 없습니다 — 억제될 수 없습니다. 두 워크플로우를 같은 방식으로 통일하지 않았고, 가드가 각자의 수단을 따로 지킵니다.
- **이슈 #985 는 별도로 닫아야 합니다.** 이 PR 은 앞으로의 억제를 막지만, 이미 열린 #985 자체를 정리하지는 않습니다(지문이 달라 새 발견은 이제 통과하므로 기능적 차단은 해소됨).
- `guard_falsifiability.py --list-targets` 32개 대상에 이 파일은 포함돼 있지 않습니다 — CI 의 자동 vacuity 감시는 받지 않고, 위 뮤테이션 증거는 수동입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
