### PR TITLE
feat: requirements.lock 자동 동기 워크플로우 (토큰 불필요 부분집합)

### DIFF
--- a/.github/workflows/requirements-lock-sync.yml
+++ b/.github/workflows/requirements-lock-sync.yml
@@ -1,0 +1,170 @@
+name: Requirements Lock Sync
+
+# `scripts/requirements.txt` 를 bump 하는 PR(대부분 dependabot)에서 락을 in-place
+# 재생성해, **적용 가능한 결과물**을 그 자리에 내놓는다.
+#
+# 배경: 설계 docs/devsecops/requirements-lock-autosync-design.md
+#
+# ## 이 워크플로우가 게이트가 아니다
+#
+# 차단은 이미 두 곳이 한다 — code-quality 의
+# `tests/test_requirements_lock_version_sync.py` 와 `supply-chain-lock.yml`.
+# 여기서 하는 일은 그 red 를 **해소 가능하게** 만드는 것이다: 재생성된 락 전문을
+# artifact 로, diff 를 step summary 로 내놓는다. 그래서 사람이 로컬에 python3.11 을
+# 갖추고 헬퍼를 돌리지 않아도 된다.
+#
+# 그럼에도 drift 시 잡을 **실패**시킨다. 재생성 결과가 어긋나는데 green 으로 끝나면
+# 이 워크플로우 자체가 fail-open 신호가 되어, 나중에 게이트가 느슨해졌을 때 아무도
+# 모른다.
+#
+# ## 왜 커밋백이 아닌가 (설계 §5.1)
+#
+# dependabot 이벤트의 `GITHUB_TOKEN` 은 read-only 로 축소되고, 그 토큰으로 푸시한
+# 커밋은 워크플로우를 재트리거하지 않는다. 커밋백에는 별도 PAT/App 토큰이 필요하다.
+# 그 토큰이 등록되기 전까지 쓸 수 있는 버전이 이것이다.
+#
+# 커밋백으로 올리려면: PAT/App 토큰을 `secrets.LOCK_SYNC_TOKEN` 으로 등록하고,
+# checkout 에 `ref: ${{ github.head_ref }}` + `token:` 을 주고, 아래 "Fail on lock
+# drift" 를 커밋·푸시 step 으로 교체한다. 지금 그 경로를 미리 넣지 않은 것은 의도다 —
+# 토큰이 없어 한 번도 실행해 볼 수 없는 코드가 된다.
+#
+# ## 하지 않는 것
+#
+# `pull_request_target` 은 쓰지 않는다(설계 §5.2). write 토큰 + PR head 코드 실행은
+# 전형적 권한 상승 패턴이고, `pip-compile` 은 sdist 빌드로 임의 코드를 실행할 수 있다.
+#
+# 무한 루프도 구조적으로 없다: `paths` 가 `requirements.txt` 뿐이라 락만 바뀐 푸시는
+# 이 워크플로우를 트리거하지 않는다(설계 §5.4).
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/requirements.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # drift 요약을 PR 에 남기기 위한 것. dependabot 런에서는 토큰이 read-only 로
+  # 축소돼 실패할 수 있으므로 그 step 은 best-effort 다(아래 주석 참조).
+  pull-requests: write
+
+concurrency:
+  group: requirements-lock-sync-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # 락은 Python 3.11 에서 생성됐다. 다른 마이너로 생성하면 내용이 달라진다
+      # (헬퍼가 경고한다). 결정성 요구사항이므로 고정한다(설계 §5.5).
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.11'
+
+      # 헬퍼가 내부에서 `python3 -m pytest tests/test_requirements_lock_coverage.py` 로
+      # 커버리지 가드를 돌린다. 그 테스트는 stdlib 만 쓰므로 pytest 만 있으면 된다.
+      - name: Install helper prerequisites
+        run: pip install pytest
+
+      # PYTHON=python3 — setup-python 이 깐 python3 가 3.11 이다. 헬퍼 기본값인
+      # `python3.11` 이라는 이름은 러너 PATH 에 없을 수 있다.
+      #
+      # in-place 재생성이다(`--upgrade` 없음). 체크아웃된 기존 락이 앵커로 남아
+      # requirements.txt 에서 실제로 바뀐 패키지만 이동하고, 무관 패키지의 상류
+      # drift 는 0 이다(설계 §3).
+      - name: Regenerate lock in place
+        env:
+          PYTHON: python3
+        run: bash scripts/refresh_requirements_lock.sh
+
+      - name: Summarize lock drift
+        id: drift
+        run: |
+          if git diff --quiet -- scripts/requirements.lock; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## requirements.lock 동기 상태: 일치"
+              echo
+              echo "재생성 결과가 커밋된 락과 동일합니다 — 이 PR 은 락을 갱신할 필요가 없습니다."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "drift=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "## requirements.lock 이 requirements.txt 와 어긋납니다"
+            echo
+            echo "이 PR 은 \`scripts/requirements.txt\` 를 바꿨지만 \`scripts/requirements.lock\` 은 그대로입니다."
+            echo "이 상태로 머지되면 런타임은 txt 로 **신버전**을 설치하고 해시 무결성 검증은 락의 **구버전**을 확인합니다."
+            echo
+            echo "### 해소 (둘 중 하나)"
+            echo
+            echo "로컬에서 재생성:"
+            echo '```bash'
+            echo 'bash scripts/refresh_requirements_lock.sh'
+            echo 'git add scripts/requirements.lock && git commit'
+            echo '```'
+            echo
+            echo "또는 이 런의 artifact \`requirements-lock\` 을 내려받아 \`scripts/requirements.lock\` 을 덮어쓰고 커밋합니다."
+            echo "artifact 는 이 잡이 방금 생성한 바로 그 파일입니다(python 3.11 + pip-tools 핀, in-place 앵커)."
+            echo
+            echo "### 재생성 결과 diff"
+            echo
+            echo '```diff'
+            git diff -- scripts/requirements.lock | head -c 60000
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload regenerated lock
+        if: steps.drift.outputs.drift == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: requirements-lock
+          path: scripts/requirements.lock
+          retention-days: 14
+
+      # best-effort. dependabot 런은 `GITHUB_TOKEN` 이 read-only 로 축소돼 이 호출이
+      # 403 이 될 수 있다. 그래도 신호는 잃지 않는다 — 권위 있는 출력은 위 step summary
+      # 와 artifact 이고, 아래 step 이 잡을 실패시킨다. 즉 이 step 의 실패가 무언가를
+      # 가리는 구조가 아니다.
+      - name: Comment drift on PR (best-effort)
+        if: steps.drift.outputs.drift == 'true' && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const runUrl = `${process.env.SERVER_URL}/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                '### ⚠️ `scripts/requirements.lock` 이 갱신되지 않았습니다',
+                '',
+                '이 PR 은 `scripts/requirements.txt` 를 바꿨지만 락은 구버전을 핀한 채입니다.',
+                '',
+                '해소:',
+                '```bash',
+                'bash scripts/refresh_requirements_lock.sh',
+                'git add scripts/requirements.lock && git commit',
+                '```',
+                '',
+                `재생성된 락 전문과 diff: ${runUrl} (artifact \`requirements-lock\` + step summary)`,
+              ].join('\n'),
+            });
+        env:
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+
+      - name: Fail on lock drift
+        if: steps.drift.outputs.drift == 'true'
+        run: |
+          echo "::error title=requirements.lock drift::락이 requirements.txt 와 어긋납니다. step summary 의 diff 와 artifact 'requirements-lock' 을 확인하세요."
+          exit 1

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -11,8 +11,8 @@
 | 수집기 (scripts/collect_*.py) | 13 |
 | 생성기 (scripts/generate_*.py) | 6 |
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
-| GitHub Actions 워크플로우 (.github/workflows/*.yml) | 53 |
+| GitHub Actions 워크플로우 (.github/workflows/*.yml) | 54 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 152 |
+| 테스트 파일 (tests/test_*.py) | 153 |
 
 <!-- component-counts:end -->

--- a/docs/devsecops/requirements-lock-autosync-design.md
+++ b/docs/devsecops/requirements-lock-autosync-design.md
@@ -1,8 +1,40 @@
 # requirements.lock 자동 동기 PR 파이프라인 — 설계 (#2 원안)
 
-> 상태: **설계 (미구현)** · 작성 2026-06-24 · 대상 `scripts/requirements.txt` ↔ `scripts/requirements.lock`
+> 상태: **부분 구현** (2026-08-21) · 작성 2026-06-24 · 대상 `scripts/requirements.txt` ↔ `scripts/requirements.lock`
 > 선행 컨텍스트: `supply-chain-lock.yml`, `tests/test_requirements_lock_coverage.py`,
 > `scripts/refresh_requirements_lock.sh`, `.github/dependabot.yml`, `.github/workflows/dependabot-auto-merge.yml`
+
+## 0. 구현 상태 (2026-08-21)
+
+`.github/workflows/requirements-lock-sync.yml` — 옵션 A 의 **토큰 불필요 부분집합**.
+인바리언트 가드는 `tests/test_requirements_lock_sync_workflow_guard.py`.
+
+| 설계 항목 | 상태 |
+|---|---|
+| §2 in-place 앵커 재생성 | 구현 — 헬퍼 그대로 호출, `--upgrade` 없음 (가드가 강제) |
+| §5.2 `pull_request_target` 금지 | 구현 — `pull_request` 만 사용 (가드가 강제) |
+| §5.4 무한 루프 방지 | 구현 — `paths` 를 `requirements.txt` 로 한정 (가드가 강제) |
+| §5.5 결정성 (python 3.11) | 구현 (가드가 강제) |
+| §6.1 임시 버전-동기 가드 | 이미 존재 — `tests/test_requirements_lock_version_sync.py` |
+| §5.1 커밋백 | **미구현** — `secrets.LOCK_SYNC_TOKEN` 부재 |
+| §5.3 자동머지 순서 강제 | **미구현** — 아래 참조 |
+
+### 커밋백을 넣지 않은 이유
+
+토큰이 없다. 그래서 워크플로우는 재생성된 락을 **artifact + step summary** 로 내놓고
+drift 시 잡을 실패시키는 데까지만 한다. 토큰 없이 커밋백 코드를 미리 넣으면 한 번도
+실행해 볼 수 없는 경로가 되므로 넣지 않았다. 올리는 절차는 워크플로우 상단 주석에 있다.
+
+### §5.3 은 여전히 열려 있다 (실측 2026-08-21)
+
+main 룰셋(`20539046`)에는 **required status check 가 하나도 없다** — `deletion` 과
+`non_fast_forward` 뿐이다. 즉 `test_requirements_lock_version_sync` 가 red 여도 머지를
+물리적으로 막지 못하고, `dependabot-auto-merge.yml` 은 semver-patch 를 자동 승인·자동
+머지한다. stale 락이 사람 리뷰 없이 들어갈 수 있는 구조가 그대로 남아 있다.
+
+`supply-chain-lock.yml` 은 `paths:` 필터가 있어 그대로 required 로 지정하면 무관 PR 이
+영구 대기한다(룰셋 Phase 2 가 막힌 것과 같은 이유). aggregator 잡 선행이 필요하며 이
+문서 범위 밖의 별도 작업이다.
 
 ## 1. 문제 (왜 필요한가)
 

--- a/tests/test_requirements_lock_sync_workflow_guard.py
+++ b/tests/test_requirements_lock_sync_workflow_guard.py
@@ -1,0 +1,202 @@
+"""`requirements-lock-sync.yml` 의 CI 인바리언트 가드.
+
+이 워크플로우는 `scripts/requirements.txt` bump PR 에서 락을 재생성해 결과물을
+내놓는다. 설계 근거와 foot-gun 목록은
+`docs/devsecops/requirements-lock-autosync-design.md` §5.
+
+## 왜 가드가 필요한가
+
+지키는 성질 넷은 전부 **조용히 무너질 수 있다** — 무너져도 워크플로우는 계속 green
+이고, 무너진 사실이 드러나는 시점은 사고가 난 뒤다.
+
+| 성질 | 무너지면 |
+|---|---|
+| `pull_request_target` 금지 | write 토큰 + PR head 코드 실행. `pip-compile` 은 sdist 빌드로 임의 코드를 실행할 수 있다 → 권한 상승 |
+| `paths` 를 txt 로 한정 | 락만 바뀐 푸시가 다시 트리거 → 커밋백 도입 시 무한 루프 |
+| python 3.11 고정 | 다른 마이너로 생성한 락은 내용이 달라진다 → 무관 패키지 drift, 재현 불가 |
+| drift 시 잡 실패 | 재생성 결과가 어긋나는데 green. 이 워크플로우 자체가 fail-open 신호가 된다 |
+| in-place 앵커 재생성 | `--upgrade` 가 붙으면 전 패키지 상류 drift. "봇이 올린 그 패키지만" 이라는 전제가 깨진다 |
+
+## 왜 텍스트 매칭이 아니라 구조 파싱인가
+
+이 워크플로우의 **주석에 `pull_request_target` 과 `--upgrade` 가 실제로 등장한다**
+(둘 다 "쓰지 않는다"는 설명이다). 그래서 `"pull_request_target" not in text` 같은
+텍스트 가드는 자기 주석에 걸려 오탐한다. `yaml.safe_load` 로 파싱하면 주석은
+애초에 보이지 않으므로 이 문제가 구조적으로 사라진다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "requirements-lock-sync.yml"
+
+HELPER = "scripts/refresh_requirements_lock.sh"
+REQUIRED_PYTHON = "3.11"
+TRIGGER_PATHS = ["scripts/requirements.txt"]
+
+
+def _workflow() -> dict:
+    """파싱된 워크플로우. 파일이 없으면 아래 단언들이 vacuous 해지므로 실패시킨다."""
+    assert WORKFLOW.is_file(), (
+        f"{WORKFLOW.relative_to(REPO_ROOT)} 가 없다. 이름을 바꿨거나 삭제했다면 이 가드도 "
+        "함께 옮길 것 — 그러지 않으면 아무것도 지키지 않는다."
+    )
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{WORKFLOW.name}: 최상위가 매핑이 아니다"
+    return data
+
+
+def _triggers(wf: dict) -> dict:
+    """`on:` 블록.
+
+    PyYAML 은 YAML 1.1 규칙으로 무인용 `on` 을 불리언 `True` 로 읽는다. 두 키를 다
+    본다 — 한쪽만 보면 인용 방식이 바뀔 때 조용히 빈 dict 가 되어 vacuous 해진다.
+    """
+    raw = wf.get("on", wf.get(True))
+    assert isinstance(raw, dict), f"{WORKFLOW.name}: `on:` 블록을 읽지 못했다 (얻은 값: {raw!r})"
+    return raw
+
+
+def _steps(wf: dict) -> list[dict]:
+    out: list[dict] = []
+    for job in (wf.get("jobs") or {}).values():
+        if isinstance(job, dict):
+            out.extend(s for s in (job.get("steps") or []) if isinstance(s, dict))
+    assert out, f"{WORKFLOW.name}: step 을 하나도 찾지 못했다 — 잡 구조가 바뀌었다"
+    return out
+
+
+def test_workflow_exists() -> None:
+    """카나리. 파일이 사라지면 나머지 단언이 조용히 통과하는 대신 여기서 실패한다."""
+    _workflow()
+
+
+def test_does_not_use_pull_request_target() -> None:
+    """write 토큰 + PR head 코드 실행은 권한 상승 패턴이다(설계 §5.2).
+
+    `pip-compile` 은 의존성 sdist 를 빌드하며 임의 코드를 실행할 수 있으므로, 이
+    워크플로우는 특히 위험하다. 방향: 존재 금지.
+    """
+    triggers = _triggers(_workflow())
+    assert "pull_request_target" not in triggers, (
+        f"{WORKFLOW.name}: `pull_request_target` 트리거가 생겼다. 이 워크플로우는 PR head 의 "
+        "코드(pip-compile → sdist 빌드)를 실행하므로 write 토큰과 결합하면 권한 상승이 된다. "
+        "커밋백이 필요하면 `pull_request` 를 유지하고 푸시만 별도 토큰으로 하라(설계 §5.1~§5.2)."
+    )
+
+
+def test_trigger_paths_are_limited_to_requirements_txt() -> None:
+    """락만 바뀐 푸시는 트리거하지 않아야 한다 — 커밋백 도입 시 무한 루프 방지(설계 §5.4).
+
+    방향: 정확히 일치. 경로가 늘어나면(특히 `requirements.lock` 이 들어오면) 재확인이
+    필요하므로 넓어지는 것도 red 다.
+    """
+    pull_request = _triggers(_workflow()).get("pull_request")
+    assert isinstance(pull_request, dict), (
+        f"{WORKFLOW.name}: `pull_request` 트리거가 없거나 매핑이 아니다 (얻은 값: {pull_request!r})"
+    )
+    assert pull_request.get("paths") == TRIGGER_PATHS, (
+        f"{WORKFLOW.name}: `paths` 가 {TRIGGER_PATHS} 가 아니다 "
+        f"(현재: {pull_request.get('paths')!r}). `requirements.lock` 이 포함되면 커밋백을 "
+        "붙였을 때 자기 자신을 다시 트리거한다."
+    )
+
+
+def test_python_is_pinned_to_the_lock_generation_version() -> None:
+    """락은 3.11 에서 생성됐다. 다른 마이너로 만들면 내용이 달라진다(설계 §5.5).
+
+    방향: 정확히 일치. 올리는 것도 red 다 — 올릴 때는 커밋된 락을 같은 버전으로
+    재생성해 byte 수준 영향을 먼저 확인해야 한다.
+    """
+    setup = [s for s in _steps(_workflow()) if str(s.get("uses") or "").startswith("actions/setup-python@")]
+    assert setup, f"{WORKFLOW.name}: setup-python step 이 없다 — 버전 고정이 사라졌다"
+    for step in setup:
+        version = str((step.get("with") or {}).get("python-version") or "")
+        assert version == REQUIRED_PYTHON, (
+            f"{WORKFLOW.name}: python-version 이 '{REQUIRED_PYTHON}' 이 아니다 (현재: {version!r}). "
+            "락 생성 버전이 바뀌면 무관 패키지까지 drift 한다. 의도적으로 올린다면 커밋된 "
+            "락을 새 버전으로 재생성해 diff 를 먼저 확인하고 이 가드의 상수도 갱신할 것."
+        )
+
+
+def test_regeneration_stays_in_place() -> None:
+    """`--upgrade` 없이 기존 락을 앵커로 재생성해야 한다(설계 §3).
+
+    앵커가 있으면 requirements.txt 에서 실제로 바뀐 패키지만 이동하고 무관 패키지의
+    상류 drift 가 0 이다. `--upgrade` 가 붙으면 그 전제가 깨져 봇 PR 하나가 전 의존성을
+    끌어올린다. 방향: 플래그 존재 금지.
+    """
+    calls = [s for s in _steps(_workflow()) if HELPER in str(s.get("run") or "")]
+    assert calls, (
+        f"{WORKFLOW.name}: `{HELPER}` 를 호출하는 step 이 없다. 재생성 방식을 직접 인라인 "
+        "pip-compile 로 바꿨다면 in-place 앵커 성질을 새로 검증하고 이 가드를 다시 써야 한다."
+    )
+    for step in calls:
+        run = str(step.get("run") or "")
+        assert "--upgrade" not in run, (
+            f"{WORKFLOW.name}: 헬퍼 호출에 `--upgrade` 가 붙었다 (step: {step.get('name')!r}). "
+            "무관 패키지까지 상류로 끌어올려 '봇이 올린 그 패키지만' 이라는 전제가 깨진다."
+        )
+
+
+def test_drift_fails_the_job() -> None:
+    """재생성 결과가 어긋나면 잡이 실패해야 한다.
+
+    green 으로 끝나면 이 워크플로우 자체가 fail-open 신호가 된다 — 나중에 차단 게이트가
+    느슨해졌을 때 아무도 모른다. 방향: 실패 경로 존재 + 그 step 이 blocking.
+    """
+    failing = [
+        s for s in _steps(_workflow()) if "drift" in str(s.get("if") or "") and "exit 1" in str(s.get("run") or "")
+    ]
+    assert failing, (
+        f"{WORKFLOW.name}: drift 조건에 걸린 `exit 1` step 이 없다. 락이 어긋나는데 잡이 "
+        "green 이면 이 워크플로우가 '동기 확인됨' 으로 오독된다."
+    )
+    for step in failing:
+        assert not step.get("continue-on-error"), (
+            f"{WORKFLOW.name}: drift 실패 step '{step.get('name')}' 에 continue-on-error 가 "
+            "붙었다. 실패가 흡수되면 exit 1 이 아무 의미가 없다."
+        )
+
+
+def test_best_effort_steps_do_not_include_the_failure_path() -> None:
+    """`continue-on-error` 는 PR 코멘트처럼 **없어도 신호가 남는** step 에만 허용한다.
+
+    dependabot 런은 토큰이 read-only 로 축소돼 코멘트가 403 이 될 수 있고, 그건 흡수해도
+    된다 — 권위 있는 출력은 step summary + artifact 이고 위 실패 step 이 잡을 red 로
+    만든다. 반대로 요약·업로드·실패 step 이 흡수되면 신호가 사라진다.
+    """
+    absorbed = [s for s in _steps(_workflow()) if s.get("continue-on-error")]
+    for step in absorbed:
+        run = str(step.get("run") or "")
+        assert "exit 1" not in run, (
+            f"{WORKFLOW.name}: '{step.get('name')}' 이 continue-on-error 인데 exit 1 을 한다 — "
+            "실패가 흡수되므로 아무 효과가 없다."
+        )
+        assert "GITHUB_STEP_SUMMARY" not in run, (
+            f"{WORKFLOW.name}: '{step.get('name')}' 이 continue-on-error 인데 step summary 를 "
+            "쓴다 — 조용히 실패하면 사람이 볼 유일한 diff 가 사라진다."
+        )
+        assert not str(step.get("uses") or "").startswith("actions/upload-artifact@"), (
+            f"{WORKFLOW.name}: artifact 업로드가 continue-on-error 다 — 조용히 실패하면 재생성된 락을 내려받을 수 없다."
+        )
+
+
+@pytest.mark.parametrize("field", ["contents", "pull-requests"])
+def test_permissions_are_declared_explicitly(field: str) -> None:
+    """토큰 권한을 명시한다. 생략하면 저장소 기본값(넓을 수 있음)을 상속한다."""
+    permissions = _workflow().get("permissions")
+    assert isinstance(permissions, dict), (
+        f"{WORKFLOW.name}: 최상위 `permissions:` 가 없다 — 기본 토큰 권한을 그대로 상속한다."
+    )
+    assert field in permissions, f"{WORKFLOW.name}: `permissions.{field}` 가 선언되지 않았다"
+    assert permissions.get("contents") == "read", (
+        f"{WORKFLOW.name}: `contents` 가 read 가 아니다 (현재: {permissions.get('contents')!r}). "
+        "이 워크플로우는 커밋백을 하지 않으므로 write 가 필요 없다. 커밋백을 도입한다면 "
+        "설계 §5.1~§5.2 를 먼저 다시 읽을 것."
+    )


### PR DESCRIPTION
## 문제

dependabot 이 `scripts/requirements.txt` 를 bump 할 때 `scripts/requirements.lock` 은 자동 갱신되지 않습니다. 그래서 락 게이트 둘이 동시에 red 가 되고 PR 이 그 상태로 멈춥니다.

**실측: 현재 열린 dependabot PR 7건이 전부 같은 이유입니다.**

```
quality (Code Quality) — tests/test_requirements_lock_version_sync.py
  AssertionError: 락 핀이 requirements.txt 명세를 만족하지 않음(버전 bump 후 락 미갱신?):
  assert not ["matplotlib: txt '~=3.11.1' ↛ lock '3.10.9'"]

verify (Supply-chain Lock Verify) — 같은 원인
```

| PR | txt → | lock 현재 |
|---|---|---|
| #1164 | boto3 `>=1.43.71` | `1.43.66` |
| #1163 | numpy `~=2.5.2` | `2.4.6` |
| #1143 | numpy `~=2.5.1` | `2.4.6` |
| #1142 | beautifulsoup4 `4.15.0` | `4.14.3` |
| #1141 | pillow `>=12.3.0` | `12.2.0` |
| #1139 | matplotlib `~=3.11.1` | `3.10.9` |

`docs/devsecops/requirements-lock-autosync-design.md` 가 2026-06-24 에 이 시나리오를 설계했지만 **"설계 (미구현)"** 로 남아 있었습니다. 막힌 지점은 하나 — 커밋백 토큰(§5.1, §7.1).

## 조치 — 옵션 A 의 토큰 불필요 부분집합

`requirements-lock-sync.yml`: `scripts/requirements.txt` 를 바꾸는 PR 에서 기존 헬퍼(`scripts/refresh_requirements_lock.sh`)로 락을 in-place 재생성하고,

- 어긋나면 **diff 를 step summary** 에, **재생성된 락 전문을 artifact** 로 내놓습니다
- PR 코멘트는 best-effort (dependabot 런은 토큰이 read-only 로 축소될 수 있습니다)
- 그리고 **잡을 실패**시킵니다

### 이 워크플로우는 게이트가 아닙니다

차단은 이미 기존 두 곳(`test_requirements_lock_version_sync`, `supply-chain-lock.yml`)이 합니다. 이 워크플로우가 하는 일은 그 red 를 **해소 가능하게** 만드는 것입니다 — 사람이 로컬에 python3.11 을 갖추고 헬퍼를 돌리지 않아도 artifact 를 내려받아 덮어쓰면 됩니다.

그럼에도 drift 시 green 으로 끝내지 않는 이유: 그러면 이 워크플로우 자체가 "동기 확인됨" 으로 오독되는 fail-open 신호가 됩니다.

## 커밋백을 넣지 않은 이유

`secrets.LOCK_SYNC_TOKEN` 이 없습니다 (실측: `gh secret list` 출력에 부재 — 등록된 9개는 전부 Slack/API 키). dependabot 이벤트의 `GITHUB_TOKEN` 은 read-only 로 축소되고 그 토큰으로 푸시한 커밋은 워크플로우를 재트리거하지 않으므로, 커밋백에는 별도 PAT/App 토큰이 필요합니다.

토큰 없이 그 코드를 미리 넣으면 **한 번도 실행해 볼 수 없는 경로**가 되므로 넣지 않았습니다. 올리는 절차는 워크플로우 상단 주석에 적었습니다.

`pull_request_target` 도 쓰지 않습니다(설계 §5.2). write 토큰 + PR head 코드 실행은 권한 상승 패턴이고, `pip-compile` 은 sdist 빌드로 임의 코드를 실행할 수 있습니다.

## 가드 — 그리고 왜 구조 파싱인가

`tests/test_requirements_lock_sync_workflow_guard.py`, 9건.

**텍스트 매칭을 쓰지 않았습니다.** 이 워크플로우의 주석에 `pull_request_target` 과 `--upgrade` 가 실제로 등장합니다(둘 다 "쓰지 않는다"는 설명입니다). 그래서 `"pull_request_target" not in text` 같은 텍스트 가드는 **자기 주석에 걸려 오탐**합니다. `yaml.safe_load` 로 파싱하면 주석은 애초에 보이지 않습니다.

PyYAML 이 무인용 `on` 을 YAML 1.1 규칙으로 불리언 `True` 로 읽는 것도 양쪽 키를 다 보게 처리했습니다 — 한쪽만 보면 인용 방식이 바뀔 때 조용히 빈 dict 가 되어 vacuous 해집니다.

### 뮤테이션 하네스 — 8/8 FALSIFIABLE

임시 사본에 주입하고 모듈의 `WORKFLOW` 상수를 갈아끼웠습니다. 실제 워크플로우 파일은 무수정입니다. 각 케이스마다 (a) 뮤테이션이 YAML 로 파싱되는지 먼저 확인해 허위 red 를 배제하고 (b) 실패가 그 가드 자신의 단언인지 확인했습니다.

| 뮤테이션 | 잡은 가드 |
|---|---|
| `on:` 에 `pull_request_target` 추가 | `test_does_not_use_pull_request_target` |
| `paths` 에 `requirements.lock` 추가 | `test_trigger_paths_are_limited_to_requirements_txt` |
| python-version 3.11 → 3.12 | `test_python_is_pinned_to_the_lock_generation_version` |
| 헬퍼 호출에 `--upgrade` 추가 | `test_regeneration_stays_in_place` |
| drift 실패 step 에 `continue-on-error` | `test_drift_fails_the_job` |
| drift 실패 step 의 `exit 1` 제거 | `test_drift_fails_the_job` |
| `permissions.contents` → `write` | `test_permissions_are_declared_explicitly` |
| artifact 업로드에 `continue-on-error` | `test_best_effort_steps_do_not_include_the_failure_path` |

positive 방향(원본에서 9/9 통과)도 같은 하네스로 확인했습니다.

## 검증

```
python3 -m pytest tests/ --no-cov -q                         → 5508 passed, 80 skipped (exit 0)
python3 -m pytest <새 가드 파일>                              → 9 passed
python3 /tmp/probe_locksync_guard.py                          → 8/8 FALSIFIABLE
python3 -m ruff check tests/ scripts/                         → All checks passed!
python3 -m ruff format --check tests/ scripts/                → 299 files already formatted
python3 -m basedpyright <새 가드 파일>                          → 0 errors, 0 warnings, 0 notes
actionlint .github/workflows/requirements-lock-sync.yml        → rc=0, 출력 없음
python3 scripts/tools/component_counts.py --write             → 워크플로우 53→54, 테스트 152→153 (실측 일치)
```

새 워크플로우가 **기존 파라미터화 가드 2건에 자동 편입**되어 통과했습니다:
- `test_workflow_alerting_coverage_guard.py::test_every_workflow_declares_a_name`
- `test_workflow_step_if_safety.py::test_step_if_uses_no_credential_context` — step `if:` 에서 자격증명 컨텍스트 참조 금지. 이 워크플로우가 `secrets` 를 step `if:` 에서 쓰지 않음을 확인해 줍니다

## 남은 것 — 설계 §5.3 은 이 PR 이 닫지 않습니다

실측(2026-08-21): main 룰셋(`20539046`)에 **required status check 가 하나도 없습니다** — `deletion` 과 `non_fast_forward` 뿐입니다.

```json
{"enforcement":"active","name":"main: block force-push and deletion (phase 1)",
 "required_checks":[],"rules":["deletion","non_fast_forward"]}
```

즉 락 가드가 red 여도 머지를 **물리적으로 막지 못하고**, `dependabot-auto-merge.yml` 은 semver-patch 를 자동 승인·자동 머지합니다. stale 락이 사람 리뷰 없이 들어갈 수 있는 구조가 그대로입니다.

`supply-chain-lock.yml` 은 `paths:` 필터 때문에 그대로 required 로 지정하면 무관 PR 이 영구 대기하므로(룰셋 Phase 2 가 막힌 것과 같은 이유) aggregator 잡이 선행돼야 합니다. 별도 작업으로 남깁니다.

또한 이 워크플로우 자체는 `paths` 필터가 있어 required check 로 지정할 수 없습니다 — 같은 제약입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
