### PR TITLE
fix: lock-sync 워크플로우에 pytest-cov 설치 추가 (첫 실행에서 깨졌다)

### DIFF
--- a/.github/workflows/requirements-lock-sync.yml
+++ b/.github/workflows/requirements-lock-sync.yml
@@ -67,10 +67,20 @@ jobs:
         with:
           python-version: '3.11'
 
-      # 헬퍼가 내부에서 `python3 -m pytest tests/test_requirements_lock_coverage.py` 로
-      # 커버리지 가드를 돌린다. 그 테스트는 stdlib 만 쓰므로 pytest 만 있으면 된다.
+      # 헬퍼가 내부에서 `python3 -m pytest tests/test_requirements_lock_coverage.py --no-cov`
+      # 로 커버리지 가드를 돌린다.
+      #
+      # **pytest-cov 도 반드시 필요하다.** 그 테스트 자체는 stdlib 만 쓰지만,
+      # `pyproject.toml` 의 `addopts = "--cov=scripts --cov-fail-under=70"` 이 모든
+      # pytest 호출에 붙는다. pytest-cov 가 없으면 `--cov`/`--no-cov` 를 인자 파싱
+      # 단계에서 거부해 헬퍼가 죽는다 — 실측(run 32454917372):
+      #
+      #     error: unrecognized arguments: --cov=scripts --cov-fail-under=70 --no-cov
+      #
+      # 로컬에는 pytest-cov 가 이미 깔려 있어 드러나지 않는 종류의 차이다.
+      # `tests/test_requirements_lock_sync_workflow_guard.py` 가 두 패키지를 지킨다.
       - name: Install helper prerequisites
-        run: pip install pytest
+        run: pip install pytest pytest-cov
 
       # PYTHON=python3 — setup-python 이 깐 python3 가 3.11 이다. 헬퍼 기본값인
       # `python3.11` 이라는 이름은 러너 PATH 에 없을 수 있다.

--- a/tests/test_requirements_lock_sync_workflow_guard.py
+++ b/tests/test_requirements_lock_sync_workflow_guard.py
@@ -27,6 +27,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -38,6 +39,16 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "requirements-lock-sync.yml"
 HELPER = "scripts/refresh_requirements_lock.sh"
 REQUIRED_PYTHON = "3.11"
 TRIGGER_PATHS = ["scripts/requirements.txt"]
+
+# 헬퍼가 내부에서 `python3 -m pytest ... --no-cov` 를 돌린다. 그 호출은 pyproject 의
+# `addopts = "--cov=scripts --cov-fail-under=70"` 를 상속하므로 **pytest 만 깔면
+# 인자 파싱에서 죽는다** — 실측(run 32454917372):
+#     error: unrecognized arguments: --cov=scripts --cov-fail-under=70 --no-cov
+# 로컬에는 pytest-cov 가 이미 있어 드러나지 않는 종류의 차이라 가드로 못 박는다.
+HELPER_PREREQS = frozenset({"pytest", "pytest-cov"})
+
+# `pkg==1.2`, `pkg>=1`, `pkg[extra]` 에서 배포 이름만 떼어낸다.
+_PKG_NAME = re.compile(r"^[^<>=!~\[;]+")
 
 
 def _workflow() -> dict:
@@ -71,9 +82,48 @@ def _steps(wf: dict) -> list[dict]:
     return out
 
 
+def _pip_installed_packages(wf: dict) -> set[str]:
+    """워크플로우가 `pip install` 로 설치하는 배포 이름 집합.
+
+    토큰 단위로 떼어낸다 — `"pytest" in run` 같은 부분문자열 검사는 `pytest-cov`
+    한 줄만 있어도 만족되어 vacuous 해진다.
+    """
+    found: set[str] = set()
+    for step in _steps(wf):
+        for line in str(step.get("run") or "").splitlines():
+            _, sep, rest = line.strip().partition("pip install")
+            if not sep:
+                continue
+            for token in rest.split():
+                if token.startswith("-"):
+                    continue
+                match = _PKG_NAME.match(token)
+                if match:
+                    found.add(match.group(0).strip())
+    return found
+
+
 def test_workflow_exists() -> None:
     """카나리. 파일이 사라지면 나머지 단언이 조용히 통과하는 대신 여기서 실패한다."""
     _workflow()
+
+
+def test_helper_prerequisites_satisfy_pytest_addopts() -> None:
+    """헬퍼의 내부 pytest 호출이 죽지 않도록 pytest-cov 까지 깔아야 한다.
+
+    `pyproject.toml` 의 `addopts` 가 모든 pytest 호출에 `--cov` 를 붙이므로, pytest 만
+    설치하면 인자 파싱 단계에서 실패한다. 로컬에는 pytest-cov 가 이미 있어 재현되지
+    않는다 — 그래서 실제로 CI 에서 한 번 깨진 뒤에 이 가드를 넣었다.
+
+    방향: 두 패키지 모두 존재. addopts 가 다른 플러그인을 요구하게 바뀌면 여기도 갱신할 것.
+    """
+    installed = _pip_installed_packages(_workflow())
+    missing = HELPER_PREREQS - installed
+    assert not missing, (
+        f"{WORKFLOW.name}: `pip install` 에 {sorted(missing)} 가 없다 (설치 목록: "
+        f"{sorted(installed)}). pyproject 의 addopts 가 `--cov` 를 붙이므로 pytest-cov 가 "
+        "없으면 헬퍼의 내부 pytest 호출이 `unrecognized arguments` 로 죽는다."
+    )
 
 
 def test_does_not_use_pull_request_target() -> None:


### PR DESCRIPTION
## 무엇이 깨졌나

#1179 로 들어간 `requirements-lock-sync.yml` 을 `workflow_dispatch` 로 **실제 돌려 보니** `Regenerate lock in place` 에서 죽었습니다 ([run 32454917372](https://github.com/Twodragon0/investing/actions/runs/32454917372)):

```
[refresh-lock] 커버리지/해시 가드 검증 (network 불필요)
[refresh-lock]  → 가드 실패 — tests/test_requirements_lock_coverage.py 출력 확인
ERROR: usage: python -m pytest [options] [file_or_dir] [file_or_dir] [...]
python -m pytest: error: unrecognized arguments: --cov=scripts --cov-fail-under=70 --no-cov
  inifile: /home/runner/work/investing/investing/pyproject.toml
```

## 원인

`refresh_requirements_lock.sh` 는 내부에서 `python3 -m pytest tests/test_requirements_lock_coverage.py --no-cov` 를 돌립니다. 그 호출은 `pyproject.toml:65` 의 `addopts = "--cov=scripts --cov-fail-under=70"` 를 상속하므로 **pytest-cov 가 없으면 인자 파싱 단계에서 죽습니다.**

저는 "그 테스트는 stdlib 만 쓰니 pytest 만 있으면 된다"고 판단해 `pip install pytest` 만 넣었습니다. 틀렸습니다 — 요구하는 쪽은 테스트가 아니라 **pytest 설정**입니다. 로컬에는 pytest-cov 가 이미 깔려 있어 로컬 검증으로는 재현되지 않는 종류의 차이였습니다.

락 재생성 자체는 성공했습니다(전체 락을 출력하고 가드 단계까지 도달). 실패는 헬퍼의 마지막 검증 단계에서만 났습니다.

## 조치

`pip install pytest pytest-cov`

## 가드

`test_helper_prerequisites_satisfy_pytest_addopts` 추가. 설치 목록을 **토큰 단위**로 떼어내 비교합니다 — `"pytest" in run` 같은 부분문자열 검사는 `pytest-cov` 한 줄만 있어도 만족되어 vacuous 해집니다.

| 뮤테이션 | 결과 |
|---|---|
| `pytest-cov` 제거 (= 원래 버그 상태) | **red** — `['pytest-cov'] 가 없다 (설치 목록: ['pytest'])` |
| 설치 step 자체 제거 | **red** — `['pytest', 'pytest-cov'] 가 없다 (설치 목록: [])` |

기존 8케이스 하네스도 재실행해 **8/8 FALSIFIABLE** 유지를 확인했습니다.

## 검증

```
python3 -m pytest tests/test_requirements_lock_sync_workflow_guard.py --no-cov -q  → 10 passed
python3 -m ruff check tests/                                                        → All checks passed!
actionlint .github/workflows/requirements-lock-sync.yml                              → rc=0
python3 scripts/tools/component_counts.py --check                                    → OK
```

머지 후 다시 `workflow_dispatch` 로 돌려 실제 성공을 확인하겠습니다 — 그때까지 이 수정은 **런타임 검증되지 않음**입니다.

## 교훈

CI 워크플로우는 로컬 lint·파싱·actionlint 가 전부 통과해도 **한 번 실행해 보지 않으면 검증된 것이 아닙니다.** #1179 는 actionlint rc=0, 가드 9/9, 뮤테이션 8/8, 전체 스위트 5508 passed 를 전부 통과하고도 첫 실행에서 죽었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)