### PR TITLE
fix: 연속-실패 알림의 도달 불가 분기 복구 + can_post 오진 문구 수정 (M8 가드 포함)

### DIFF
--- a/.github/workflows/alert-consecutive-failures.yml
+++ b/.github/workflows/alert-consecutive-failures.yml
@@ -62,11 +62,32 @@ jobs:
               'map(select(.conclusion == "failure")) | .[0:5]
                | map("• <\(.url)|\(.createdAt[0:16]) UTC>")
                | join("\\n")')
+            # threshold=1 이면 조회 대상이 현재 런 하나뿐이고, 그 런은 아직 진행 중이라
+            # conclusion 이 "failure" 가 아니어서 위 필터에서 탈락한다 → 목록이 빈 문자열이
+            # 되고 알림에 "Recent failed runs:" 만 덩그러니 남는다.
+            #
+            # `--limit` 을 늘려 채우면 안 된다 — 같은 runs_json 으로 prev_failures 를 세므로
+            # 판정 창이 넓어져 "연속 실패" 가 "창 안에 N건" 으로 의미가 바뀐다.
+            if [ -z "${recent}" ]; then
+              recent="• (이번 런이 창 내 첫 실패 — threshold=${THRESHOLD})"
+            fi
             echo "recent_failures=${recent}" >> "$GITHUB_OUTPUT"
           else
             echo "alert=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # `investing` alias 는 2026-08-21 현재 `can_post=false` 다 —
+      # `SLACK_CHANNEL_ID_INVESTING` 과 `SLACK_CHANNEL_ID` 시크릿이 둘 다 비어 있다.
+      # 같은 composite action 을 쓰는 `push-folder-info-to-slack` 실측(run 32440743053)
+      # 에서 `openclaw` matrix 만 "Post to Slack" 이 success 이고 investing/ops/dev/
+      # security 는 전부 skipped 였다. 살아 있는 alias 는 `openclaw` 하나다.
+      #
+      # alias 를 바꾸지 않은 것은 의도다 — 알림이 어느 채널로 가야 하는지는 진행 중인
+      # Slack 네이밍 마이그레이션의 결정 사항이고, 여기서 조용히 재라우팅하면 그 결정을
+      # 앞질러 버린다. 대신 이 상태를 **드러나게** 만들었다(아래 warning + 이슈 fallback).
+      #
+      # 되살리는 방법: `SLACK_CHANNEL_ID_INVESTING` 시크릿 설정. 그때까지 알림은
+      # Slack 이 아니라 GitHub 이슈로 착지한다.
       - name: Resolve Slack config
         if: steps.check.outputs.alert == 'true'
         id: slack
@@ -78,6 +99,13 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SLACK_CHANNEL_ID_INVESTING: ${{ secrets.SLACK_CHANNEL_ID_INVESTING }}
+
+      # can_post=false 는 "전달 실패" 가 아니라 "애초에 설정 안 됨" 이다. 런 자체에서
+      # 보이게 해 둔다 — 아래 이슈만으로는 이슈를 열어보기 전까지 알 수 없다.
+      - name: Warn when Slack is not configured
+        if: steps.check.outputs.alert == 'true' && steps.slack.outputs.can_post != 'true'
+        run: |
+          echo "::warning title=Slack alert not configured::alias 'investing' 의 can_post=false 입니다(SLACK_CHANNEL_ID_INVESTING 미설정). 알림은 Slack 대신 GitHub 이슈로 생성됩니다."
 
       - name: Post alert to Slack
         id: post-slack
@@ -91,34 +119,60 @@ jobs:
             channel: "${{ steps.slack.outputs.channel }}"
             text: ":rotating_light: [${{ steps.slack.outputs.profile_label }}] *${{ inputs.workflow-name }}* failed ${{ inputs.threshold }}+ consecutive runs\n\n*Recent failed runs:*\n${{ steps.check.outputs.recent_failures }}\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|:link: View current run>"
 
-      - name: Fallback — create GitHub issue if Slack post failed
+      # `!cancelled() &&` 가 없으면 **Slack 전달 실패 분기가 도달 불가**하다.
+      # `post-slack` 에 `continue-on-error` 가 없어 실패 시 잡이 죽고, 이 step 의 `if:`
+      # 는 암묵 `success()` 를 포함하므로 skip 된다. 즉 원래 의도(전달 실패 시 이슈로
+      # 대체)가 코드에 있으면서 한 번도 실행될 수 없었다. can_post=false 분기만
+      # 도달 가능했다(그쪽은 Slack step 이 skip 이지 fail 이 아니므로).
+      #
+      # `always()` 대신 `!cancelled()` 인 이유: 취소된 런에서 이슈를 만들지 않는다.
+      - name: Fallback — create GitHub issue when Slack alert did not land
         if: >-
+          !cancelled() &&
           steps.check.outputs.alert == 'true' &&
           (steps.slack.outputs.can_post != 'true' || steps.post-slack.outcome == 'failure')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
-            const title = `[alert-delivery-failed] ${{ inputs.workflow-name }} consecutive failures (Slack notify failed)`;
+            // 두 원인을 구분한다. 이전 문구는 can_post=false 인데도 "delivery failed" 로
+            // 적고 "토큰 로테이션 확인" 을 지시해, 실제 원인(시크릿 미설정)이 아닌 곳을
+            // 뒤지게 만들었다.
+            const canPost = `${{ steps.slack.outputs.can_post }}`;
+            const notConfigured = canPost !== 'true';
+            const cause = notConfigured ? 'Slack not configured' : 'Slack delivery failed';
+
+            const investigate = notConfigured
+              ? [
+                  `- alias \`investing\` 의 \`can_post\` 가 \`${canPost}\` 다 — 채널이 **설정되지 않았다**(전달 실패가 아니다).`,
+                  `- \`SLACK_CHANNEL_ID_INVESTING\` 시크릿을 설정하면 Slack 경로가 살아난다.`,
+                  `- 2026-08-21 실측 기준 살아 있는 alias 는 \`openclaw\` 하나다. 알림 채널을 옮기려면 \`.github/workflows/alert-consecutive-failures.yml\` 의 \`target_channel_alias\` 를 바꿔야 한다.`,
+                ]
+              : [
+                  `- Slack 토큰 로테이션: \`SLACK_BOT_TOKEN\` 이 유효한지 확인`,
+                  `- 채널 ID 드리프트: \`SLACK_CHANNEL_ID_INVESTING\` 이 기대 채널로 해소되는지 확인`,
+                  `- Slack 장애였다면 알림이 재개된 뒤 이 이슈를 닫아라`,
+                ];
+
+            const title = `[alert-delivery-failed] ${{ inputs.workflow-name }} consecutive failures (${cause})`;
             const body = [
-              `## Alert delivery failure`,
+              `## ${cause}`,
               ``,
-              `The primary Slack alert for **${{ inputs.workflow-name }}** could not be delivered.`,
+              `**${{ inputs.workflow-name }}** 의 연속 실패 알림이 Slack 으로 가지 못해 이슈로 대체 생성됐다.`,
               ``,
               `| Field | Value |`,
               `|-------|-------|`,
               `| Workflow | \`${{ inputs.workflow-name }}\` |`,
               `| Threshold | ${{ inputs.threshold }} consecutive failures |`,
               `| Run | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}> |`,
-              `| Slack can_post | \`${{ steps.slack.outputs.can_post }}\` |`,
+              `| Slack can_post | \`${canPost}\` |`,
               `| Slack step outcome | \`${{ steps.post-slack.outcome }}\` |`,
+              `| Cause | ${cause} |`,
               ``,
               `**Recent failed runs:**`,
               `${{ steps.check.outputs.recent_failures }}`,
               ``,
               `## What to investigate`,
-              `- Slack token rotation: verify \`SLACK_BOT_TOKEN\` / \`SLACK_AI_BOT_TOKEN\` secrets are current`,
-              `- Channel ID drift: confirm \`SLACK_CHANNEL_ID_INVESTING\` still resolves to the expected channel`,
-              `- If Slack was in outage, close this issue once alerts resume`,
+              ...investigate,
             ].join('\n');
 
             await github.rest.issues.create({

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 54 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 153 |
+| 테스트 파일 (tests/test_*.py) | 154 |
 
 <!-- component-counts:end -->

--- a/tests/test_alert_delivery_reachability_guard.py
+++ b/tests/test_alert_delivery_reachability_guard.py
@@ -1,0 +1,258 @@
+"""연속-실패 알림이 **실제로 어딘가에 도달하는지** 지키는 가드.
+
+`test_workflow_alerting_coverage_guard.py` 는 "스케줄 워크플로우에 알림이 붙어 있는가"
+(커버리지)를 본다. 이 파일은 그 다음 질문을 본다 — **붙어 있는 알림이 도달 가능한가.**
+
+## 왜 나중에 추가됐나 (실측 근거)
+
+기존 `test_findings_exit_zero_guard.py::test_alerting_is_attached` 는 워크플로우 파일
+텍스트에 재사용 워크플로우 경로가 있는지만 grep 한다. 그래서 알림 잡을
+`if: false` 로 만들어 **도달 불가**하게 해도 통과한다(2026-08-21 뮤테이션 확인).
+텍스트에 경로가 남아 있기 때문이다.
+
+그리고 재사용 워크플로우 안에도 도달 불가 분기가 실제로 있었다.
+`alert-consecutive-failures.yml` 의 fallback 조건은
+
+    steps.check.outputs.alert == 'true' &&
+    (steps.slack.outputs.can_post != 'true' || steps.post-slack.outcome == 'failure')
+
+인데 status 함수가 없어 암묵 `success()` 가 붙는다. `post-slack` 에는
+`continue-on-error` 가 없으므로 Slack 전달이 실패하면 잡이 죽고 → 암묵 `success()` 가
+깨져 → **fallback 이 skip 된다.** 즉 "전달 실패 시 이슈로 대체" 라는 의도가 코드에
+쓰여 있으면서 한 번도 실행될 수 없었다. `can_post != 'true'` 쪽만 도달 가능했다
+(그쪽은 Slack step 이 skip 이지 fail 이 아니라 `success()` 가 유지된다).
+
+실측 뒷받침: `gh issue list --search "alert-delivery-failed in:title" --state all`
+→ 빈 결과. 이 fallback 은 프로덕션에서 한 번도 산출물을 낸 적이 없다.
+
+## 지키는 것
+
+1. fallback 이 **양쪽 원인 모두**에서 도달 가능할 것 (status 함수 필수)
+2. fallback 이 두 원인을 **구분**할 것 — `can_post=false` 는 전달 실패가 아니라 미설정
+3. Slack post 가 `can_post` 로 게이팅될 것
+4. `recent_failures` 가 빈 문자열로 새지 않을 것
+5. 호출자 28곳의 알림 잡이 **구조적으로** 도달 가능할 것 (M8 구멍)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+ALERT_WORKFLOW = WORKFLOWS_DIR / "alert-consecutive-failures.yml"
+ALERT_REF = "./.github/workflows/alert-consecutive-failures.yml"
+
+FALLBACK_STEP = "Fallback — create GitHub issue when Slack alert did not land"
+SLACK_STEP = "Post alert to Slack"
+
+# 실패한 이전 step 을 넘어 실행되게 하는 status 함수. 하나라도 없으면 암묵 `success()`
+# 가 붙어 전달-실패 분기가 죽는다.
+_SURVIVES_FAILURE = ("always()", "!cancelled()")
+
+
+def _load(path: Path) -> dict:
+    assert path.is_file(), f"{path.relative_to(REPO_ROOT)} 가 없다"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{path.name}: 최상위가 매핑이 아니다"
+    return data
+
+
+def _alert_steps() -> list[dict]:
+    wf = _load(ALERT_WORKFLOW)
+    steps = [
+        s
+        for job in (wf.get("jobs") or {}).values()
+        if isinstance(job, dict)
+        for s in (job.get("steps") or [])
+        if isinstance(s, dict)
+    ]
+    assert steps, f"{ALERT_WORKFLOW.name}: step 을 찾지 못했다 — 잡 구조가 바뀌었다"
+    return steps
+
+
+def _step(name: str) -> dict:
+    """이름으로 step 을 찾는다. 못 찾으면 아래 단언들이 vacuous 해지므로 실패시킨다."""
+    found = next((s for s in _alert_steps() if s.get("name") == name), None)
+    assert found is not None, (
+        f"{ALERT_WORKFLOW.name}: '{name}' step 이 없다. 이름을 바꿨다면 이 가드의 상수도 "
+        "갱신할 것 — 그러지 않으면 도달성을 아무도 지키지 않는다."
+    )
+    return found
+
+
+def _callers() -> list[tuple[str, str, dict]]:
+    """(파일명, 잡 이름, 잡 본체) — 재사용 알림 워크플로우를 호출하는 모든 잡."""
+    out: list[tuple[str, str, dict]] = []
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        try:
+            wf = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:  # pragma: no cover - 파싱 실패는 다른 가드 책임
+            pytest.fail(f"{path.name}: YAML 파싱 실패 — {exc}")
+        if not isinstance(wf, dict):
+            continue
+        for job_name, job in (wf.get("jobs") or {}).items():
+            if isinstance(job, dict) and str(job.get("uses") or "") == ALERT_REF:
+                out.append((path.name, str(job_name), job))
+    assert out, (
+        f"{ALERT_REF} 를 호출하는 잡이 하나도 없다. 경로가 바뀌었다면 ALERT_REF 를 갱신할 것 "
+        "— 그러지 않으면 아래 호출자 단언 전부가 조용히 vacuous 해진다."
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 재사용 워크플로우 내부 — fallback 도달성
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_survives_a_failed_slack_post() -> None:
+    """`post-slack` 실패 분기가 도달 가능해야 한다.
+
+    status 함수가 없으면 암묵 `success()` 가 붙고, `post-slack` 에 `continue-on-error`
+    가 없으므로 전달 실패 시 이 step 이 skip 된다 — 의도가 코드에 있으면서 실행 불가.
+    """
+    condition = str(_step(FALLBACK_STEP).get("if") or "")
+    assert any(fn in condition for fn in _SURVIVES_FAILURE), (
+        f"{ALERT_WORKFLOW.name}: fallback 조건에 {list(_SURVIVES_FAILURE)} 중 어느 것도 없다 "
+        f"(현재: {condition!r}). 암묵 success() 때문에 Slack 전달 실패 시 fallback 이 skip 되고, "
+        "알림이 Slack 도 이슈도 없이 사라진다."
+    )
+
+
+def test_fallback_covers_both_causes() -> None:
+    """미설정(`can_post != 'true'`)과 전달 실패(`outcome == 'failure'`) 둘 다 걸려야 한다.
+
+    한쪽만 남으면 다른 쪽 원인으로 알림이 사라진다.
+    """
+    condition = str(_step(FALLBACK_STEP).get("if") or "")
+    for needle, why in (
+        ("can_post", "Slack 이 설정되지 않은 경우(오늘의 실제 상태)"),
+        ("post-slack", "Slack 전달이 실패한 경우"),
+    ):
+        assert needle in condition, (
+            f"{ALERT_WORKFLOW.name}: fallback 조건이 `{needle}` 을 참조하지 않는다 — "
+            f"{why} 에 알림이 사라진다 (현재: {condition!r})"
+        )
+
+
+def test_fallback_distinguishes_not_configured_from_delivery_failure() -> None:
+    """`can_post=false` 는 전달 실패가 아니라 **미설정**이다.
+
+    이전 문구는 두 경우 모두 "Slack notify failed" 로 적고 "토큰 로테이션 확인" 을
+    지시해, 실제 원인(시크릿 미설정)이 아닌 곳을 뒤지게 만들었다.
+    """
+    script = str((_step(FALLBACK_STEP).get("with") or {}).get("script") or "")
+    assert script, f"{ALERT_WORKFLOW.name}: fallback 에 github-script 본문이 없다"
+
+    # 느슨하게 `"can_post" in script` 로 걸면 안 된다 — 본문의 표 라벨
+    # (`| Slack can_post | ... |`)에 그 문자열이 그대로 들어 있어서, 판정 로직을
+    # 상수로 갈아치우는 뮤테이션이 통과한다(2026-08-21 실측). **출력을 읽는 표현식**을
+    # 앵커로 삼는다.
+    assert "steps.slack.outputs.can_post" in script, (
+        f"{ALERT_WORKFLOW.name}: fallback 본문이 `steps.slack.outputs.can_post` 를 읽지 않는다 "
+        "— 미설정과 전달 실패를 구분할 수 없으므로 진단 문구가 한쪽에는 반드시 틀린다."
+    )
+    for cause in ("Slack not configured", "Slack delivery failed"):
+        assert cause in script, (
+            f"{ALERT_WORKFLOW.name}: fallback 본문에 원인 구분 문구 {cause!r} 가 없다. "
+            "두 원인을 같은 문구로 처리하면 사람이 엉뚱한 곳을 뒤진다."
+        )
+    assert "SLACK_CHANNEL_ID_INVESTING" in script, (
+        f"{ALERT_WORKFLOW.name}: fallback 본문에 되살리는 방법(`SLACK_CHANNEL_ID_INVESTING`)이 "
+        "없다. 이슈만 열리고 무엇을 고쳐야 하는지 알 수 없다."
+    )
+
+
+def test_slack_post_is_gated_on_can_post() -> None:
+    """게이트가 사라지면 미설정 상태에서 Slack 호출이 시도되고 잡이 죽는다."""
+    condition = str(_step(SLACK_STEP).get("if") or "")
+    assert "can_post" in condition, (
+        f"{ALERT_WORKFLOW.name}: '{SLACK_STEP}' 이 `can_post` 로 게이팅되지 않는다 (현재: {condition!r})"
+    )
+
+
+def test_recent_failures_never_leaks_empty() -> None:
+    """threshold=1 이면 조회 대상이 현재 런 하나뿐이라 목록이 빈 문자열이 된다.
+
+    `--limit` 을 늘려 채우면 안 된다 — 같은 JSON 으로 `prev_failures` 를 세므로 판정
+    창이 넓어져 "연속 실패" 가 "창 안에 N건" 으로 의미가 바뀐다. 빈 값 처리로 막는다.
+    """
+    check = _step("Check previous run conclusions")
+    run = str(check.get("run") or "")
+    assert "recent_failures" in run, f"{ALERT_WORKFLOW.name}: recent_failures 출력이 사라졌다"
+    assert '-z "${recent}"' in run or '-z "$recent"' in run, (
+        f"{ALERT_WORKFLOW.name}: `recent` 의 빈 값 처리가 없다. threshold=1 에서 알림 본문에 "
+        "'Recent failed runs:' 만 남는다."
+    )
+
+
+def test_threshold_window_is_not_widened() -> None:
+    """`--limit` 은 THRESHOLD 여야 한다 — 넓히면 판정 의미가 바뀐다.
+
+    현재 로직은 최근 THRESHOLD 건을 가져와 현재 런을 제외하고 실패를 세므로, 실질적으로
+    "직전 THRESHOLD-1 건이 모두 실패" 다. limit 을 늘리면 흩어진 실패도 합산되어
+    "연속" 이 아니게 된다.
+    """
+    run = str(_step("Check previous run conclusions").get("run") or "")
+    assert '--limit "${THRESHOLD}"' in run, (
+        f"{ALERT_WORKFLOW.name}: `--limit` 이 THRESHOLD 가 아니다. 판정 창이 넓어지면 비연속 실패에도 알림이 울린다."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 호출자 측 — M8 구멍
+# ---------------------------------------------------------------------------
+
+
+def test_every_caller_alert_job_runs_on_failure() -> None:
+    """호출자의 알림 잡이 `failure()` 로 걸려 있어야 한다.
+
+    기존 가드는 파일 텍스트에 재사용 워크플로우 경로가 있는지만 grep 하므로, 잡을
+    `if: false` 로 만들어 도달 불가하게 해도 통과한다. 여기서는 구조를 본다.
+    """
+    broken = [(wf, job) for wf, job, body in _callers() if "failure()" not in str(body.get("if") or "")]
+    assert not broken, (
+        f"알림 잡의 조건에 `failure()` 가 없다: {broken}. 텍스트에 경로만 남고 잡이 절대 "
+        "돌지 않으면 커버리지 가드는 green 인데 알림은 0건이다."
+    )
+
+
+def test_every_caller_alert_job_inherits_secrets() -> None:
+    """`secrets: inherit` 이 없으면 재사용 워크플로우에서 `SLACK_BOT_TOKEN` 이 비어
+
+    can_post=false 로 떨어진다 — Slack 알림이 조용히 이슈 fallback 으로 강등된다.
+    """
+    broken = [(wf, job) for wf, job, body in _callers() if body.get("secrets") != "inherit"]
+    assert not broken, (
+        f"알림 잡에 `secrets: inherit` 이 없다: {broken}. 토큰이 전달되지 않아 Slack 경로가 "
+        "죽고 이슈 fallback 으로만 떨어진다."
+    )
+
+
+def test_every_caller_alert_job_needs_an_existing_job() -> None:
+    """`needs` 가 없거나 존재하지 않는 잡을 가리키면 알림이 실행되지 않는다."""
+    problems: list[str] = []
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        wf = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(wf, dict):
+            continue
+        jobs = wf.get("jobs") or {}
+        for job_name, job in jobs.items():
+            if not (isinstance(job, dict) and str(job.get("uses") or "") == ALERT_REF):
+                continue
+            needs = job.get("needs")
+            names = [needs] if isinstance(needs, str) else list(needs or [])
+            if not names:
+                problems.append(f"{path.name}:{job_name} — needs 없음")
+                continue
+            missing = [n for n in names if n not in jobs]
+            if missing:
+                problems.append(f"{path.name}:{job_name} — 없는 잡을 needs: {missing}")
+    assert not problems, (
+        f"알림 잡의 needs 가 잘못됐다: {problems}. 존재하지 않는 잡을 기다리면 알림이 "
+        "영구 skip 되고, needs 가 없으면 감시 대상 잡의 실패와 무관하게 돈다."
+    )


### PR DESCRIPTION
fix: 연속-실패 알림의 도달 불가 분기를 살리고 오진 문구를 고친다

## 배경

#1173~#1177 로 스케줄 워크플로우 36개에 알림을 붙였다. 그런데 붙인 알림이 실제로
어딘가에 도달하는지는 확인되지 않았다. 실측해 보니 세 가지 문제가 있었다.

## 1. 전달-실패 분기가 도달 불가였다

fallback 조건에 status 함수가 없어 암묵 `success()` 가 붙는다. `post-slack` 에는
`continue-on-error` 가 없으므로 **Slack 전달이 실패하면 잡이 죽고 fallback 이 skip**
된다. 즉 "전달 실패 시 이슈로 대체" 라는 의도가 코드에 쓰여 있으면서 한 번도 실행될
수 없었다. `can_post != 'true'` 쪽만 도달 가능했다(그쪽은 Slack step 이 skip 이지
fail 이 아니라 `success()` 가 유지된다).

`!cancelled() &&` 를 추가했다. `always()` 대신인 이유는 취소된 런에서 이슈를 만들지
않기 위해서다.

## 2. can_post=false 를 "전달 실패" 로 오진했다

`investing` alias 는 현재 `can_post=false` 다 — `SLACK_CHANNEL_ID_INVESTING` 과
`SLACK_CHANNEL_ID` 가 둘 다 비어 있다. 같은 composite action 을 쓰는
`push-folder-info-to-slack` 실측(run 32440743053) step 레벨:

    push-folder-info (openclaw) :  success  Post to Slack investing channel
    push-folder-info (investing):  skipped  Post to Slack investing channel

그런데 fallback 이슈는 제목에 "(Slack notify failed)", 본문에 "토큰 로테이션 확인" 을
적었다. **실제 원인은 미설정인데 사람을 엉뚱한 곳으로 보낸다.** 두 원인을 구분해
각각 다른 진단 문구를 내도록 고쳤고, 런에서도 보이게 `::warning` 을 추가했다.

**alias 는 바꾸지 않았다.** 알림이 어느 채널로 가야 하는지는 진행 중인 Slack 네이밍
마이그레이션의 결정 사항이고, 여기서 조용히 재라우팅하면 그 결정을 앞지른다. 현재
살아 있는 alias 는 `openclaw` 하나이며, 되살리는 방법(`SLACK_CHANNEL_ID_INVESTING`
설정)을 이슈 본문과 워크플로우 주석에 명시했다.

## 3. threshold=1 이면 알림 본문의 실패 목록이 빈다

조회 대상이 현재 런 하나뿐이고 그 런은 진행 중이라 `conclusion == "failure"` 필터에서
탈락한다. `--limit` 을 늘려 채우면 안 된다 — 같은 JSON 으로 `prev_failures` 를 세므로
판정 창이 넓어져 "연속 실패" 가 "창 안에 N건" 으로 **의미가 바뀐다.** 빈 값 처리로
막았고, 가드가 limit 을 넓히는 변경도 red 로 만든다.

## 가드 — M8 구멍도 함께 닫는다

기존 `test_alerting_is_attached` 는 파일 텍스트 grep 이라 알림 잡을 `if: false` 로
만들어 도달 불가하게 해도 통과한다. `tests/test_alert_delivery_reachability_guard.py`
가 호출자 28곳을 **구조적으로** 단언한다 — `failure()` 조건, `secrets: inherit`,
`needs` 가 실제 존재하는 잡을 가리키는지.

뮤테이션 하네스 **9/9 FALSIFIABLE** (워크플로우 디렉터리 전체를 임시 복사, 실제 파일
무수정). 호출자 단언은 다른 파일을 봐야 하므로 파일 하나 바꿔치기로는 검증되지 않아
디렉터리 단위로 스테이징했다.

**여기서도 가드가 한 번 vacuous 했다.** `"can_post" in script` 로 느슨하게 걸었더니
본문의 표 라벨(`| Slack can_post | ... |`)에 그 문자열이 있어서, 판정 로직을 상수로
갈아치우는 뮤테이션이 통과했다(#1178 과 같은 실수를 반복했다). 출력을 읽는 표현식
`steps.slack.outputs.can_post` 를 앵커로 바꾸고 원인 문구 2개를 함께 단언해 red 를
확인했다.

## 남는 사실 (이 PR 이 바꾸지 않는 것)

`gh issue list --search "alert-delivery-failed in:title" --state all` → 빈 결과.
이 fallback 은 프로덕션에서 한 번도 산출물을 낸 적이 없다. 알림 배선이 2026-08-18~21
에 들어갔고 이후 threshold 를 넘긴 워크플로우가 없기 때문이다. 즉 이 경로는 여전히
**런타임 미검증**이다.
