### PR TITLE
fix(ci): 실패 분류기가 pytest 성공을 네트워크 장애로 오독하는 문제 수정

### DIFF
--- a/.github/workflows/classify-workflow-failures.yml
+++ b/.github/workflows/classify-workflow-failures.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
+      # 분류와 근거 추출은 `scripts/tools/classify_failure_log.py` 가 한다.
+      #
+      # 인라인 grep 이었을 때의 결함: pytest 로그는 대부분 *테스트 이름*이고, 이
+      # 저장소의 테스트 이름에 `timeout`/`exception` 이 들어 있다
+      # (`test_wait_for_with_timeout`, `test_fetch_exception_propagates`).
+      # 실측(run 32456925989 → issue #1181): failed.log 의 `timeout` 매치 20건 중
+      # 16건이 `PASSED` 라인, 나머지는 PytestConfigWarning. 진짜 네트워크 신호는 0건.
+      # 그런데도 raw=network 로 분류돼 ~13분 quality 잡을 무의미하게 rerun 하고,
+      # attempt 2 에서 code 로 escalate 해 신호가 늦게, 잘못된 라벨로 도착했다.
+      #
+      # 이 파일에 로직을 다시 인라인하지 말 것 —
+      # `tests/test_classify_failure_log.py` 가 배선까지 검증한다.
       - name: Classify failure type
         id: classify
         env:
@@ -52,48 +64,9 @@ jobs:
         run: |
           set -euo pipefail
           gh run view "$RUN_ID" --log-failed > failed.log 2>&1 || gh run view "$RUN_ID" > failed.log 2>&1 || true
-
-          network_pattern='(timed out|timeout|couldn.t connect|connection reset|connection refused|temporary failure|name resolution|502 bad gateway|503 service unavailable|504 gateway timeout|429 too many requests|failed to connect|tls handshake timeout|ssl connect error)'
-
-          if grep -Eqi "$network_pattern" failed.log; then
-            classification="network"
-          else
-            classification="code"
-          fi
-
-          echo "classification=$classification" >> "$GITHUB_OUTPUT"
-
-          evidence_snippet=$(python3 - <<'PY'
-          import re
-          from pathlib import Path
-
-          log_path = Path("failed.log")
-          if not log_path.exists():
-              print("failed.log not found")
-              raise SystemExit(0)
-
-          lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
-          pattern = re.compile(
-              r"(timed out|timeout|couldn.t connect|connection reset|connection refused|temporary failure|name resolution|502 bad gateway|503 service unavailable|504 gateway timeout|429 too many requests|failed to connect|tls handshake timeout|ssl connect error|traceback|error:|exception)",
-              re.IGNORECASE,
-          )
-
-          indexed = [(idx + 1, line.strip()) for idx, line in enumerate(lines)]
-          matches = [f"L{idx}: {line}" for idx, line in indexed if line and pattern.search(line)]
-          selected = matches[:12] if matches else [f"L{idx}: {line}" for idx, line in indexed[:12] if line]
-
-          if not selected:
-              print("no relevant log lines captured")
-          else:
-              print("\n".join(selected))
-          PY
-          )
-
-          {
-            echo "evidence_snippet<<EOF"
-            printf '%s\n' "$evidence_snippet"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python3 scripts/tools/classify_failure_log.py \
+            --log failed.log \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Finalize classification with escalation
         id: classify_final

--- a/.github/workflows/classify-workflow-failures.yml
+++ b/.github/workflows/classify-workflow-failures.yml
@@ -140,11 +140,17 @@ jobs:
               'Action: investigate code or configuration changes in this run.'
             ].join('\n');
 
-            const { data: issues } = await github.rest.issues.listForRepo({
+            // `github.paginate` 필수 — `listForRepo` 는 기본 30건만 준다.
+            // 2026-08-24 실측으로 open `ci-failure` 이슈가 363건이었고, 그 상태에서
+            // dedupe 창은 최신 30건으로 잘려 있었다. 즉 31번째 이후로 밀려난
+            // 이슈와 같은 실패가 재발하면 중복 이슈가 새로 생긴다.
+            // `per_page: 100` 이므로 363건은 4요청. 실패 경로에서만 도는 호출이다.
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'ci-failure'
+              labels: 'ci-failure',
+              per_page: 100
             });
 
             const exists = issues.some(

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 54 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 154 |
+| 테스트 파일 (tests/test_*.py) | 155 |
 
 <!-- component-counts:end -->

--- a/scripts/tools/classify_failure_log.py
+++ b/scripts/tools/classify_failure_log.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+r"""Classify a GitHub Actions failed-job log as `network` (transient, retry) or
+`code` (real, open an issue), and extract the log lines worth reading.
+
+## Why this is a module and not an inline grep
+
+`classify-workflow-failures.yml` used to do both jobs inline: a
+`grep -Eqi "$network_pattern"` over the whole `gh run view --log-failed` output,
+plus a heredoc'd Python snippet that took the *first* 12 keyword matches as
+"evidence". Neither was testable, and both were wrong in the same way.
+
+A pytest log is overwhelmingly **test names**, and this repo's test names contain
+the exact keywords the classifier searched for:
+
+    tests/test_browser.py::TestBrowserSessionWaitFor::test_wait_for_with_timeout PASSED
+    tests/test_base_collector.py::TestErrorHandling::test_fetch_exception_propagates PASSED
+
+Measured on run 32456925989 (→ issue #1181): 20 `timeout` matches in the failed
+log — 16 on `PASSED` lines, the remainder a `PytestConfigWarning`. **Zero**
+genuine network indicators. The one real signal was
+`test_lock_pins_satisfy_requirements_specifiers FAILED`.
+
+Every code failure in the pytest-running workflows therefore took this path:
+
+    raw=network → `gh run rerun` (a full ~13min quality job) → attempt 2
+    → escalate to code → issue filed late, mislabelled, with 12 PASSED lines
+      as its "evidence"
+
+## The two defences
+
+**1. Drop outcome-noise lines.** `PASSED`/`SKIPPED`/`XFAIL`/`XPASS` progress
+lines cannot carry failure signal — a passing test's name is not evidence of
+anything. `FAILED`/`ERROR` lines are kept: those *are* signal.
+
+**2. Anchor on shapes that only errors have.** Bare `timeout` is ambiguous — it
+appears in `test_wait_for_with_timeout`, `timeout_method`, `--timeout=300`. So
+the network patterns are either multi-word phrases (`timed out`, `connection
+refused`, `tls handshake timeout`) or CamelCase exception classes
+(`ReadTimeout`, `TimeoutError`) — neither shape occurs in snake_case
+identifiers or CLI flags. Word boundaries (`(?<!\w)…(?!\w)`) make `_timeout`
+and `timeout_` non-matches by construction.
+
+## Fail direction
+
+Absent transient evidence the answer is `code`: report the failure rather than
+retry it. A false `code` costs one issue a human closes; a false `network` costs
+a rerun *and* delays the true signal — and, on attempt 2, mislabels it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Line-level noise filter
+# ---------------------------------------------------------------------------
+
+# pytest progress/summary outcomes that prove something *worked*. Deliberately
+# excludes FAILED and ERROR — those are the lines we most want to keep.
+_PASSING_OUTCOME_RE = re.compile(r"\b(PASSED|SKIPPED|XFAIL|XPASS|no tests ran)\b")
+
+# `job<TAB>step<TAB>2026-08-21T07:12:42.2940521Z message` — the shape
+# `gh run view --log-failed` emits. Stripped for readability: inside a 12-line
+# evidence budget the timestamp is pure overhead.
+_LOG_PREFIX_RE = re.compile(r"^(?:[^\t]*\t){0,2}\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+")
+
+
+def _strip_prefix(line: str) -> str:
+    return _LOG_PREFIX_RE.sub("", line).strip()
+
+
+def _is_noise(line: str) -> bool:
+    """True when the line reports a *successful* test and so cannot be evidence."""
+    return bool(_PASSING_OUTCOME_RE.search(line))
+
+
+def _signal_lines(text: str) -> list[tuple[int, str]]:
+    """(1-based line number, prefix-stripped text) for lines that may carry signal."""
+    out: list[tuple[int, str]] = []
+    for idx, raw in enumerate(text.splitlines(), start=1):
+        if _is_noise(raw):
+            continue
+        stripped = _strip_prefix(raw)
+        if stripped:
+            out.append((idx, stripped))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Network (transient) detection
+# ---------------------------------------------------------------------------
+
+# Multi-word phrases and HTTP statuses. None of these can appear inside a
+# snake_case identifier, so they need no further disambiguation.
+_NETWORK_PHRASES = (
+    r"timed out",
+    r"could ?n[o']?t connect",
+    r"could not connect",
+    r"failed to connect",
+    r"connection reset",
+    r"connection refused",
+    r"connection aborted",
+    r"connection closed",
+    r"remote end closed connection",
+    r"temporary failure in name resolution",
+    r"could not resolve host",
+    r"name or service not known",
+    r"network is unreachable",
+    r"no route to host",
+    r"max retries exceeded",
+    r"tls handshake timeout",
+    r"ssl connect error",
+    r"eof occurred in violation of protocol",
+    r"gateway timeout",
+    r"502 bad gateway",
+    r"503 service unavailable",
+    r"504 gateway timeout",
+    r"429 too many requests",
+    r"server misbehaving",
+    r"operation timed out",
+)
+
+# CamelCase exception classes only. `ReadTimeout`, `ConnectTimeoutError`,
+# `TimeoutError` match; `timeout_method` and `test_x_timeout` cannot, because a
+# capital letter is required at the class-name boundary.
+_NETWORK_EXCEPTION_RE = re.compile(
+    r"(?<![\w.])(?:[A-Z][A-Za-z]*)?"
+    r"(?:Timeout|ConnectionError|ConnectionReset|ConnectTimeout|ReadTimeout|"
+    r"NewConnectionError|ProtocolError|SSLError|ProxyError)"
+    r"(?:Error|Exception)?(?![\w])"
+)
+
+_NETWORK_PHRASE_RE = re.compile("|".join(rf"(?<!\w){p}(?!\w)" for p in _NETWORK_PHRASES), re.IGNORECASE)
+
+
+def _looks_transient(line: str) -> bool:
+    return bool(_NETWORK_PHRASE_RE.search(line) or _NETWORK_EXCEPTION_RE.search(line))
+
+
+def classify(text: str) -> str:
+    """Return `"network"` if the log shows transient failure, else `"code"`.
+
+    `code` is the default: see "Fail direction" in the module docstring.
+    """
+    return "network" if any(_looks_transient(line) for _, line in _signal_lines(text)) else "code"
+
+
+# ---------------------------------------------------------------------------
+# Evidence extraction
+# ---------------------------------------------------------------------------
+
+# Tier 1 — the lines a human opens the log to find.
+_PRIMARY_RE = re.compile(
+    r"(?:##\[error\]|\bFAILED\b|\bERROR\b|Traceback \(most recent call last\)|"
+    r"^E\s{2,}|(?<![\w.])[A-Z][A-Za-z]*(?:Error|Exception)(?![\w]))"
+)
+
+# Tier 2 — weaker but still failure-shaped context.
+_SECONDARY_RE = re.compile(
+    r"(?:(?<!\w)error:|(?<!\w)fatal:|(?<!\w)assert(?!\w)|exit code|"
+    r"(?<!\w)warning:|(?<!\w)exception(?!\w))",
+    re.IGNORECASE,
+)
+
+_NO_EVIDENCE = "no failure-shaped log lines captured"
+
+
+def extract_evidence(text: str, limit: int = 12) -> list[str]:
+    """Return up to `limit` `L<n>: <line>` strings, failure-shaped lines first.
+
+    Ordering matters as much as selection. The old snippet took the *first* N
+    matches, which in a pytest log means the earliest lines — i.e. setup and
+    warnings, never the failure. Here tier-1 matches win, and within a tier the
+    lines closest to the end are kept: on GitHub Actions the failure summary is
+    always at the tail.
+    """
+    lines = _signal_lines(text)
+    if not lines:
+        return [_NO_EVIDENCE]
+
+    primary = [(n, ln) for n, ln in lines if _PRIMARY_RE.search(ln)]
+    secondary = [
+        (n, ln) for n, ln in lines if (n, ln) not in primary and (_SECONDARY_RE.search(ln) or _looks_transient(ln))
+    ]
+
+    selected: list[tuple[int, str]] = primary[-limit:]
+    if len(selected) < limit:
+        room = limit - len(selected)
+        chosen = set(selected)
+        selected = [item for item in secondary[-room:] if item not in chosen] + selected
+
+    if not selected:
+        selected = lines[-limit:]
+
+    selected.sort(key=lambda item: item[0])
+    return [f"L{n}: {ln}" for n, ln in selected[:limit]] or [_NO_EVIDENCE]
+
+
+# ---------------------------------------------------------------------------
+# GITHUB_OUTPUT rendering
+# ---------------------------------------------------------------------------
+
+
+def render_github_output(classification: str, evidence: list[str]) -> str:
+    """Render `$GITHUB_OUTPUT` lines, with a delimiter the payload cannot contain.
+
+    A log line equal to the heredoc delimiter would terminate the value early and
+    let the rest of the log be parsed as further outputs. The delimiter is
+    therefore derived from the payload's own digest — deterministic (so it is
+    testable) and, since it embeds a hash of the text it delimits, never present
+    inside it.
+    """
+    body = "\n".join(evidence)
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()[:16]
+    delimiter = f"EVIDENCE_EOF_{digest}"
+    # Belt and braces: a line that somehow equals the delimiter is dropped.
+    safe = [line for line in evidence if line.strip() != delimiter]
+    return f"classification={classification}\nevidence_snippet<<{delimiter}\n" + "\n".join(safe) + f"\n{delimiter}\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", required=True, type=Path, help="failed-job log file")
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="append classification + evidence here (defaults to stdout)",
+    )
+    parser.add_argument("--limit", type=int, default=12, help="max evidence lines")
+    args = parser.parse_args(argv)
+
+    # A missing or unreadable log must not fail the classify job — it would
+    # replace a real failure signal with a meta-failure. Report `code` so the
+    # issue still gets filed and a human sees it.
+    try:
+        text = args.log.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        print(f"could not read {args.log}: {exc}", file=sys.stderr)
+        text = ""
+
+    rendered = render_github_output(classify(text), extract_evidence(text, limit=args.limit))
+
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as handle:
+            handle.write(rendered)
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_classify_failure_log.py
+++ b/tests/test_classify_failure_log.py
@@ -1,0 +1,302 @@
+"""Regression guard: the CI failure classifier must not read pytest *successes*
+as network errors.
+
+## The defect this closes
+
+`classify-workflow-failures.yml` used to grep the whole failed-job log for a bare
+keyword set (`timeout`, `timed out`, `connection refused`, ...). A pytest log is
+mostly *test names*, and this repo's test names contain those very words:
+
+    tests/test_browser.py::TestBrowserSessionWaitFor::test_wait_for_with_timeout PASSED
+    tests/test_base_collector.py::TestErrorHandling::test_fetch_exception_propagates PASSED
+
+Measured on real run 32456925989 (issue #1181): 20 `timeout` matches in the
+failed log, **16 of them on `PASSED` lines** and the rest a
+`PytestConfigWarning`. Zero genuine network indicators. The single real signal
+was `test_lock_pins_satisfy_requirements_specifiers FAILED`.
+
+The consequences compounded:
+
+1. `classification=network` on a pure code failure.
+2. → `gh run rerun` burned a full ~13min quality job before reporting anything.
+3. → attempt 2 escalated back to `code`, so the issue arrived late and labelled
+   "escalated from network" — a lie about the failure's nature.
+4. → the issue's "Classifier evidence" block held 12 `PASSED` lines, i.e. zero
+   debugging value.
+
+## What the tests assert
+
+The fixtures below are *shaped like the real log* (tab-separated
+`job<TAB>step<TAB>timestamp message` prefix, pytest progress lines, a
+`##[error]` tail). Two directions are checked, because a classifier that always
+answers `code` would pass a one-sided suite:
+
+* a code failure whose log is full of timeout-ish **test names** → `code`
+* a genuine transient failure → `network`
+
+Evidence extraction is asserted to surface the *failure* lines, never the
+`PASSED` noise.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TOOL = _REPO_ROOT / "scripts" / "tools" / "classify_failure_log.py"
+
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "tools"))
+
+from classify_failure_log import (  # noqa: E402
+    classify,
+    extract_evidence,
+    render_github_output,
+)
+
+
+def _log(*lines: str) -> str:
+    """Wrap bare messages in the real `job<TAB>step<TAB>timestamp ` prefix."""
+    return "\n".join(
+        f"quality\tRun tests with coverage\t2026-08-21T07:12:{idx:02d}.0000000Z {line}"
+        for idx, line in enumerate(lines)
+    )
+
+
+# Verbatim shape of run 32456925989 — the failure that was misclassified.
+CODE_FAILURE_LOG = _log(
+    "tests/test_base_collector.py::TestErrorHandling::test_fetch_exception_propagates PASSED [  3%]",
+    "tests/test_browser.py::TestIsPlaywrightAvailable::test_never_raises_exception PASSED [  6%]",
+    "tests/test_browser.py::TestBrowserSessionWaitFor::test_wait_for_without_timeout PASSED [  6%]",
+    "tests/test_browser.py::TestBrowserSessionWaitFor::test_wait_for_with_timeout PASSED [  6%]",
+    "tests/test_browser.py::TestExtractGoogleNewsLinks::test_exception_in_link_parse_is_swallowed PASSED [  7%]",
+    "tests/test_browser.py::TestScrapePage::test_timeout_passed_to_session PASSED [  7%]",
+    "tests/test_collector_integration.py::TestStockNewsCollectorRun::test_run_completes_without_exception_when_items_present PASSED [ 17%]",
+    "/opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages/_pytest/config/__init__.py:1464: "
+    "PytestConfigWarning: Unknown config option: timeout_method",
+    "tests/test_requirements_lock_version_sync.py::test_lock_pins_satisfy_requirements_specifiers FAILED [ 71%]",
+    "FAILED tests/test_requirements_lock_version_sync.py::test_lock_pins_satisfy_requirements_specifiers",
+    "##[error]Process completed with exit code 1.",
+)
+
+NETWORK_FAILURE_LOG = _log(
+    "tests/test_browser.py::TestScrapePage::test_timeout_passed_to_session PASSED [  7%]",
+    "Traceback (most recent call last):",
+    "requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.example.com', port=443): "
+    "Max retries exceeded with url: /v1/quotes (Caused by NewConnectionError('Connection refused'))",
+    "##[error]Process completed with exit code 1.",
+)
+
+GATEWAY_FAILURE_LOG = _log(
+    "tests/test_crypto_api.py::test_fetch_handles_timeout PASSED [ 12%]",
+    "curl: (22) The requested URL returned error: 503 Service Unavailable",
+    "##[error]Process completed with exit code 22.",
+)
+
+
+class TestClassify:
+    def test_pytest_test_names_are_not_network_evidence(self) -> None:
+        """The regression: timeout-shaped *test names* must not read as network."""
+        assert classify(CODE_FAILURE_LOG) == "code"
+
+    def test_genuine_connection_error_is_network(self) -> None:
+        """Counter-direction: a real transient failure must still be caught."""
+        assert classify(NETWORK_FAILURE_LOG) == "network"
+
+    def test_gateway_status_is_network(self) -> None:
+        assert classify(GATEWAY_FAILURE_LOG) == "network"
+
+    def test_empty_log_is_code(self) -> None:
+        """No evidence of transience → do not retry. Fail toward reporting."""
+        assert classify("") == "code"
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "def test_wait_for_with_timeout(self):",
+            "timeout_method = 'thread'",
+            "self.connection_reset_count += 1",
+            "--timeout=300",
+        ],
+    )
+    def test_snake_case_identifiers_do_not_trip_network(self, identifier: str) -> None:
+        """Word-boundary anchoring: `_timeout`/`timeout_` are identifiers, not errors."""
+        assert classify(_log(identifier, "##[error]Process completed with exit code 1.")) == "code"
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "ReadTimeout: HTTPSConnectionPool(host='x')",
+            "socket.timeout: timed out",
+            "TimeoutError: [Errno 60] Operation timed out",
+            "fatal: unable to access 'https://github.com/x': Failed to connect to github.com port 443",
+            "urllib3.exceptions.NewConnectionError: Temporary failure in name resolution",
+            "HTTP 429 Too Many Requests",
+            "net/http: TLS handshake timeout",
+        ],
+    )
+    def test_real_transient_phrases_are_network(self, phrase: str) -> None:
+        assert classify(_log(phrase)) == "network"
+
+    def test_passing_parametrized_test_ids_are_not_network(self) -> None:
+        """The one false positive word-boundary anchoring *cannot* catch.
+
+        Anchoring works because network phrases never occur inside snake_case
+        identifiers. A pytest **parametrized node id** breaks that assumption —
+        the param value is echoed verbatim, spaces and all:
+
+            ...::test_real_transient_phrases_are_network[socket.timeout: timed out] PASSED
+
+        `timed out` there is fully word-bounded, so only the `PASSED`-noise
+        filter can reject it. This is not hypothetical: the parametrize block
+        directly above emits exactly these ids into every CI log for the
+        Code Quality workflow, which `classify-workflow-failures.yml` watches.
+        Drop the noise filter and this repo's own passing suite reads as an
+        outage.
+        """
+        node_ids = [
+            "tests/test_classify_failure_log.py::TestClassify::"
+            f"test_real_transient_phrases_are_network[{phrase}] PASSED [ 42%]"
+            for phrase in (
+                "socket.timeout: timed out",
+                "HTTP 429 Too Many Requests",
+                "net/http: TLS handshake timeout",
+            )
+        ]
+        log = _log(*node_ids, "##[error]Process completed with exit code 1.")
+        assert classify(log) == "code"
+
+
+class TestExtractEvidence:
+    def test_evidence_prefers_failure_lines_over_passed_noise(self) -> None:
+        evidence = extract_evidence(CODE_FAILURE_LOG, limit=12)
+        assert evidence, "a failing log must yield evidence"
+        assert not any("PASSED" in line for line in evidence), (
+            "PASSED lines carry no failure signal and must never reach the issue body:\n" + "\n".join(evidence)
+        )
+
+    def test_evidence_includes_the_actual_failing_test(self) -> None:
+        evidence = "\n".join(extract_evidence(CODE_FAILURE_LOG, limit=12))
+        assert "test_lock_pins_satisfy_requirements_specifiers" in evidence
+        assert "##[error]" in evidence
+
+    def test_evidence_includes_the_transient_cause(self) -> None:
+        evidence = "\n".join(extract_evidence(NETWORK_FAILURE_LOG, limit=12))
+        assert "Connection refused" in evidence
+
+    def test_evidence_respects_limit(self) -> None:
+        assert len(extract_evidence(CODE_FAILURE_LOG, limit=2)) <= 2
+
+    def test_evidence_reaches_the_failure_past_a_long_preamble(self) -> None:
+        """Selection must be failure-shaped *and* tail-biased, not first-N.
+
+        The real log for run 32456925989 was 6772 lines with the failure at
+        L4761–6666. The old snippet took the first 12 matches, so no budget
+        ever reached the failure — a small fixture cannot expose that, because
+        first-N and last-N coincide. Hence the realistic preamble: pip resolver
+        chatter and deprecation warnings, all of which match the weaker
+        secondary tier and would monopolise a first-N budget.
+        """
+        preamble = [
+            f"WARNING: pip is looking at multiple versions of package-{i}; this could take a while (error: retrying)"
+            for i in range(40)
+        ]
+        log = _log(
+            *preamble,
+            "tests/test_requirements_lock_version_sync.py::test_lock_pins_satisfy_requirements_specifiers FAILED",
+            "E   AssertionError: matplotlib: txt '~=3.11.1' -> lock '3.10.9'",
+            "##[error]Process completed with exit code 1.",
+        )
+        evidence = "\n".join(extract_evidence(log, limit=12))
+        assert "##[error]" in evidence, f"failure tail not reached:\n{evidence}"
+        assert "test_lock_pins_satisfy_requirements_specifiers" in evidence, (
+            f"the failing test never made the evidence budget:\n{evidence}"
+        )
+
+    def test_evidence_strips_timestamp_prefix(self) -> None:
+        """The ISO timestamp is pure noise in a 12-line budget."""
+        for line in extract_evidence(CODE_FAILURE_LOG, limit=12):
+            assert "2026-08-21T07:12:" not in line
+
+    def test_empty_log_yields_explicit_marker_not_silence(self) -> None:
+        evidence = extract_evidence("", limit=12)
+        assert len(evidence) == 1
+        assert "no" in evidence[0].lower()
+
+
+class TestGithubOutput:
+    def test_heredoc_delimiter_cannot_collide_with_payload(self) -> None:
+        """A log line equal to the delimiter would break GITHUB_OUTPUT parsing."""
+        rendered = render_github_output("code", ["EOF", "##[error]boom"])
+        delimiter = rendered.split("evidence_snippet<<", 1)[1].splitlines()[0]
+        payload = rendered.split(f"evidence_snippet<<{delimiter}\n", 1)[1]
+        body = payload.rsplit(f"{delimiter}\n", 1)[0]
+        assert delimiter not in body.splitlines()
+
+    def test_output_contains_classification_key(self) -> None:
+        assert "classification=code\n" in render_github_output("code", ["x"])
+
+
+class TestCli:
+    def test_cli_writes_github_output_file(self, tmp_path: Path) -> None:
+        """Exercise the production entrypoint, not just the library functions."""
+        log_file = tmp_path / "failed.log"
+        log_file.write_text(CODE_FAILURE_LOG, encoding="utf-8")
+        out_file = tmp_path / "gh_output"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_TOOL),
+                "--log",
+                str(log_file),
+                "--github-output",
+                str(out_file),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        written = out_file.read_text(encoding="utf-8")
+        assert "classification=code" in written
+        assert "PASSED" not in written
+
+    def test_cli_tolerates_missing_log(self, tmp_path: Path) -> None:
+        """A missing log must not crash the classify job — it must report `code`."""
+        out_file = tmp_path / "gh_output"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_TOOL),
+                "--log",
+                str(tmp_path / "absent.log"),
+                "--github-output",
+                str(out_file),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "classification=code" in out_file.read_text(encoding="utf-8")
+
+
+class TestWorkflowWiring:
+    """The fix is only real if the workflow actually calls this tool."""
+
+    def test_workflow_invokes_the_tool(self) -> None:
+        workflow = (_REPO_ROOT / ".github" / "workflows" / "classify-workflow-failures.yml").read_text(encoding="utf-8")
+        assert "scripts/tools/classify_failure_log.py" in workflow
+
+    def test_workflow_no_longer_greps_bare_keywords(self) -> None:
+        """The inline grep is what produced the false positives — it must be gone."""
+        workflow = (_REPO_ROOT / ".github" / "workflows" / "classify-workflow-failures.yml").read_text(encoding="utf-8")
+        assert "network_pattern=" not in workflow, (
+            "the inline keyword grep is back — classification must go through "
+            "scripts/tools/classify_failure_log.py so it stays under test"
+        )

--- a/tests/test_classify_failure_log.py
+++ b/tests/test_classify_failure_log.py
@@ -300,3 +300,18 @@ class TestWorkflowWiring:
             "the inline keyword grep is back — classification must go through "
             "scripts/tools/classify_failure_log.py so it stays under test"
         )
+
+    def test_issue_dedupe_paginates(self) -> None:
+        """`listForRepo` returns 30 by default — the dedupe window must not truncate.
+
+        Measured 2026-08-24: 363 open `ci-failure` issues. An unpaginated
+        `listForRepo` checked only the newest 30, so any failure whose issue had
+        aged past that window got a *duplicate* issue on recurrence — the
+        classifier's own output was inflating the backlog it reports into.
+        """
+        workflow = (_REPO_ROOT / ".github" / "workflows" / "classify-workflow-failures.yml").read_text(encoding="utf-8")
+        assert "github.paginate(github.rest.issues.listForRepo" in workflow, (
+            "issue dedupe must page through all open ci-failure issues; a bare "
+            "`github.rest.issues.listForRepo` silently caps at 30"
+        )
+        assert "per_page: 100" in workflow, "paginated dedupe should request full pages"


### PR DESCRIPTION
## 문제

`classify-workflow-failures.yml` 은 `failed.log` **전체**를 bare keyword 로 grep 했다.
pytest 로그는 대부분 *테스트 이름*이고, 이 저장소의 테스트 이름에 그 단어가 그대로 들어 있다:

```
tests/test_browser.py::TestBrowserSessionWaitFor::test_wait_for_with_timeout PASSED
tests/test_base_collector.py::TestErrorHandling::test_fetch_exception_propagates PASSED
```

**실측** (run [32456925989](https://github.com/Twodragon0/investing/actions/runs/32456925989) → #1181):
`failed.log` 의 `timeout` 매치 20건 중 **16건이 `PASSED` 라인**, 나머지는 `PytestConfigWarning`.
진짜 네트워크 신호는 **0건**. 실제 원인은 `test_lock_pins_satisfy_requirements_specifiers FAILED` 였다.

결함이 연쇄했다:

1. `classification=network` — 순수 코드 실패인데.
2. → `gh run rerun` 이 ~13분 quality 잡을 무의미하게 태움.
3. → attempt 2 에서 `code` 로 escalate → 신호가 늦게, `escalated from network` 라는 **거짓 라벨**로 도착.
4. → 이슈 본문 "Classifier evidence" 12줄이 전부 `PASSED` — 디버깅 가치 0.

## 수정

분류/근거추출을 테스트 가능한 `scripts/tools/classify_failure_log.py` 로 추출하고 두 계층 방어를 넣었다.

**1. 노이즈 라인 제거** — `PASSED`/`SKIPPED`/`XFAIL`/`XPASS` 는 어떤 실패의 근거도 될 수 없다.
`FAILED`/`ERROR` 는 유지(그게 신호다).

**2. 식별자에 나타날 수 없는 형태로만 매칭** — 다어절 문구(`timed out`, `connection refused`,
`tls handshake timeout`) 또는 CamelCase 예외 클래스(`ReadTimeout`, `TimeoutError`).
워드 경계 `(?<!\w)…(?!\w)` 로 `_timeout` / `timeout_` / `--timeout=300` 은 **구조적으로** 비매치.

근거 추출도 first-N → 실패형태 우선 + tail 편향으로 바꿨다. 실제 로그는 6772줄에 실패가
L4761~6666 이라 first-N 예산은 실패에 애초에 도달하지 못했다.

`$GITHUB_OUTPUT` heredoc 구분자는 payload 의 sha256 에서 파생시켜, 로그 한 줄이 구분자와
같아 값이 조기 종료되는 경로를 없앴다.

## 실제 로그 대조 (같은 입력)

| | 구 로직 | 신 로직 |
|---|---|---|
| 분류 | `network` → 무의미한 rerun | `code` |
| 근거 | `PASSED` 12줄 | ``matplotlib: txt '~=3.11.1' ↛ lock '3.10.9'`` + 해결 명령 |

## 검증

**뮤테이션 4건 전부 계층별 단언으로 포착** (통과하는 가드는 가드가 아니므로 각각 주입해 확인):

| 뮤테이션 | 잡은 테스트 |
|---|---|
| 노이즈 필터 제거 | `test_passing_parametrized_test_ids_are_not_network` |
| 앵커링 제거(구 bare keyword) | `test_pytest_test_names_are_not_network_evidence` 외 4건 |
| evidence first-N 회귀 | `test_evidence_reaches_the_failure_past_a_long_preamble` |
| primary 티어 무시 | 위 + `test_evidence_includes_the_actual_failing_test` |

검증 중 **노이즈 필터가 load-bearing** 임을 발견했다: 이 PR 이 추가한 parametrized 테스트 ID
(`...[socket.timeout: timed out] PASSED`)가 그 문구를 로그에 그대로 찍으므로, 워드 경계만으로는
막을 수 없고 `PASSED` 필터만이 막는다. 해당 케이스를 테스트로 고정했다.

- `python3 -m ruff check scripts/ tests/` — All checks passed
- `python3 -m ruff format --check scripts/ tests/` — 302 files already formatted
- `python3 -m basedpyright` — 0 errors, 0 warnings, 0 notes
- `actionlint .github/workflows/classify-workflow-failures.yml` — OK
- `python3 -m pytest tests/` — **5614 passed, 1 skipped**, coverage **74.36%** (게이트 70%)

## 범위 밖 — 별건으로 보고

- `Mark no rerun` 스텝(`classify-workflow-failures.yml`)은 `id` 가 없어 출력이 `steps.rerun` 에
  닿지 않는 데드 코드다. 조건이 우연히 동작해 무해하지만 오독을 유발한다.
- 이슈 생성 dedupe 의 `listForRepo` 에 페이지네이션이 없어 open `ci-failure` 이슈가 30건을
  넘으면 dedupe 창이 잘린다(현재 363건).
- `pyproject.toml` 의 `timeout_method` 가 code-quality 잡에서 `Unknown config option` 경고
  — 그 잡은 `pytest-timeout` 을 설치하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

