### PR TITLE
feat(ci): stale ci-failure 이슈 자동 종료 + dedupe 페이지네이션

### DIFF
--- a/.github/workflows/close-stale-ci-failure-issues.yml
+++ b/.github/workflows/close-stale-ci-failure-issues.yml
@@ -1,0 +1,207 @@
+# `classify-workflow-failures.yml` 은 코드 실패마다 이슈를 만들지만 **닫지 않는다**.
+# 종료 경로가 없어서 트래커가 자동 이슈로 포화됐다 — 2026-08-24 실측:
+#
+#   open 이슈 378건 중 363건(96%)이 `ci-failure` 라벨 자동 생성
+#   월별: 2026-04 197건 / 05 116건 / 06 20건 / 07 7건 / 08 22건
+#   워크플로우별: Code Quality 267건 / Security Scan 25건 / 수집기 합계 ~60건
+#
+# 4월·5월분 313건은 이미 해결된 실패의 잔해다. 그 결과 사람이 다뤄야 하는
+# 이슈 15건이 노이즈에 묻혀 트래커가 관측 수단으로 기능하지 못한다.
+#
+# ## 왜 "해결됐는지" 를 확인하지 않고 나이로 닫나
+#
+# 이상적으로는 같은 워크플로우의 후속 run 이 성공했는지 보고 닫아야 한다. 그런데
+# 이슈 본문의 `Dedupe Key` 는 `workflow|run|sha` 라서 특정 커밋에 묶여 있고, 그
+# 커밋은 대개 이미 main 에서 사라졌다(스쿼시 머지·강제 정리). 즉 "이 실패가 지금도
+# 재현되는가" 를 이슈 하나만 보고 판정할 수 없다.
+#
+# 대신 나이 + **사람 개입 흔적**으로 판정한다. 코멘트가 하나라도 달렸거나 `keep`
+# 라벨이 붙었으면 누군가 트리아지한 것이므로 건드리지 않는다. 아직 유효한 실패라면
+# 분류기가 다음 실패에서 새 이슈를 만든다 — 정보가 영구히 사라지는 구조가 아니다.
+#
+# ## 상한을 두고, 그 사실을 로그에 남긴다
+#
+# 한 번에 `max_close` 건까지만 닫는다(기본 200). 초회 실행은 363건이라 두 번에
+# 걸쳐 소화된다. 상한에 걸려 남긴 건수를 step summary 에 반드시 적는다 —
+# 조용히 잘린 상한은 "전부 처리했다" 로 읽혀서 다음 사람을 속인다.
+name: Close Stale CI-Failure Issues
+
+on:
+  schedule:
+    - cron: '0 5 * * *'  # 매일 05:00 UTC (14:00 KST)
+  workflow_dispatch:
+    inputs:
+      age_days:
+        description: '이 일수보다 오래 갱신되지 않은 ci-failure 이슈를 닫는다'
+        required: false
+        default: '30'
+      max_close:
+        description: '한 실행에서 닫을 최대 건수 (레이트리밋 보호)'
+        required: false
+        default: '200'
+      dry_run:
+        description: 'true 면 닫지 않고 대상만 보고한다 (초회 실행 시 권장)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  # ref 스코프. 전역 상수 그룹 + cancel-in-progress 는 서로 무관한 런을 취소해
+  # 게이트를 조용히 건너뛰게 만든다(supply-chain-lock.yml 에서 실측된 실패 모드).
+  group: close-stale-ci-failure-issues-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  close-stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Close stale ci-failure issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          AGE_DAYS: ${{ inputs.age_days || '30' }}
+          MAX_CLOSE: ${{ inputs.max_close || '200' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const ageDays = Number(process.env.AGE_DAYS);
+            const maxClose = Number(process.env.MAX_CLOSE);
+            const dryRun = process.env.DRY_RUN === 'true';
+
+            if (!Number.isFinite(ageDays) || ageDays < 1) {
+              core.setFailed(`age_days must be a positive number, got "${process.env.AGE_DAYS}"`);
+              return;
+            }
+            if (!Number.isFinite(maxClose) || maxClose < 1) {
+              core.setFailed(`max_close must be a positive number, got "${process.env.MAX_CLOSE}"`);
+              return;
+            }
+
+            const cutoff = new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000);
+
+            // paginate 필수 — `listForRepo` 는 기본 30건만 준다. 363건 상태에서
+            // 페이지네이션 없이 돌면 매 실행이 같은 최신 30건만 보고 끝난다.
+            const all = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci-failure',
+              per_page: 100,
+            });
+
+            // PR 은 issues API 에도 나온다. 라벨 조합상 거의 없지만 배제한다.
+            const issues = all.filter(i => !i.pull_request);
+
+            const kept = [];
+            const candidates = [];
+            for (const issue of issues) {
+              const labels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name));
+              if (labels.includes('keep')) {
+                kept.push({ number: issue.number, why: 'keep 라벨' });
+                continue;
+              }
+              if ((issue.comments || 0) > 0) {
+                kept.push({ number: issue.number, why: `코멘트 ${issue.comments}건 (사람 트리아지)` });
+                continue;
+              }
+              if (new Date(issue.updated_at) >= cutoff) {
+                kept.push({ number: issue.number, why: `최근 갱신 (${issue.updated_at.slice(0, 10)})` });
+                continue;
+              }
+              candidates.push(issue);
+            }
+
+            // 오래된 것부터. 상한에 걸리면 가장 최근 것들이 다음 실행으로 넘어간다.
+            candidates.sort((a, b) => new Date(a.updated_at) - new Date(b.updated_at));
+            const target = candidates.slice(0, maxClose);
+            const deferred = candidates.length - target.length;
+
+            const closed = [];
+            const failed = [];
+            for (const issue of target) {
+              if (dryRun) {
+                closed.push(issue.number);
+                continue;
+              }
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    `자동 종료: ${ageDays}일 이상 갱신되지 않은 \`ci-failure\` 자동 생성 이슈입니다.`,
+                    '',
+                    '이 이슈는 `classify-workflow-failures.yml` 이 만든 것이고, 코멘트가 없어',
+                    '트리아지되지 않은 상태입니다. 해당 실패가 지금도 재현된다면 분류기가',
+                    '다음 실패에서 새 이슈를 만듭니다 — 정보는 사라지지 않습니다.',
+                    '',
+                    '자동 종료를 원하지 않으면 `keep` 라벨을 붙이거나 코멘트를 남기세요.',
+                    '',
+                    `닫은 워크플로우: \`${context.workflow}\` (run ${context.runId})`,
+                  ].join('\n'),
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                });
+                closed.push(issue.number);
+              } catch (error) {
+                // 한 건 실패가 나머지를 막지 않게 한다. 단, 반드시 집계에 남긴다.
+                failed.push({ number: issue.number, message: error.message });
+                core.warning(`#${issue.number} 종료 실패: ${error.message}`);
+              }
+            }
+
+            const lines = [
+              `## Stale \`ci-failure\` 이슈 종료${dryRun ? ' (DRY RUN — 실제로 닫지 않음)' : ''}`,
+              '',
+              `- 기준: ${ageDays}일 이상 미갱신, 코멘트 0건, \`keep\` 라벨 없음`,
+              `- open \`ci-failure\` 이슈: **${issues.length}**건`,
+              `- 종료 대상: **${candidates.length}**건`,
+              `- ${dryRun ? '종료 예정' : '종료 완료'}: **${closed.length}**건`,
+              `- 보존: **${kept.length}**건`,
+            ];
+
+            // 상한으로 남긴 건수를 절대 침묵시키지 않는다.
+            if (deferred > 0) {
+              lines.push(
+                `- ⚠️ 상한(\`max_close=${maxClose}\`)으로 **${deferred}건 이월** — 다음 실행에서 처리됩니다.`
+              );
+              core.notice(`max_close=${maxClose} 상한으로 ${deferred}건을 이월했습니다.`);
+            }
+            if (failed.length > 0) {
+              lines.push(`- ❌ 종료 실패: **${failed.length}**건`);
+              lines.push('', '<details><summary>실패 상세</summary>', '');
+              for (const f of failed) lines.push(`- #${f.number}: ${f.message}`);
+              lines.push('', '</details>');
+            }
+            if (kept.length > 0) {
+              lines.push('', '<details><summary>보존 사유</summary>', '');
+              for (const k of kept.slice(0, 50)) lines.push(`- #${k.number}: ${k.why}`);
+              if (kept.length > 50) lines.push(`- … 외 ${kept.length - 50}건`);
+              lines.push('', '</details>');
+            }
+
+            await core.summary.addRaw(lines.join('\n')).write();
+
+            if (failed.length > 0 && closed.length === 0) {
+              core.setFailed('종료 대상이 있었지만 한 건도 닫지 못했습니다 — 권한/레이트리밋을 확인하세요.');
+            }
+
+  # 일 1회. 이 잡이 조용히 죽으면 트래커가 다시 포화된다 — 애초에 이 워크플로우를
+  # 만들게 한 상태로 되돌아가는데, 그 사실을 알려주는 것이 아무것도 없다.
+  # `tests/test_workflow_alerting_coverage_guard.py` 가 이 등록을 강제한다.
+  alert-consecutive-failures:
+    needs: close-stale
+    if: failure()
+    uses: ./.github/workflows/alert-consecutive-failures.yml
+    with:
+      workflow-name: 'Close Stale CI-Failure Issues'
+      threshold: 2
+    secrets: inherit

--- a/.github/workflows/close-stale-ci-failure-issues.yml
+++ b/.github/workflows/close-stale-ci-failure-issues.yml
@@ -47,6 +47,10 @@ on:
 permissions:
   contents: read
   issues: write
+  # `alert-consecutive-failures` 재사용 워크플로우가 요구한다 — 재사용 워크플로우는
+  # 호출자 권한을 상속하므로 여기서 주지 않으면 그 잡이 실행조차 못 한다.
+  # `scripts/tools/check_workflow_permissions.py` 가 이 관계를 강제한다.
+  actions: read
 
 concurrency:
   # ref 스코프. 전역 상수 그룹 + cancel-in-progress 는 서로 무관한 런을 취소해

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -11,8 +11,8 @@
 | 수집기 (scripts/collect_*.py) | 13 |
 | 생성기 (scripts/generate_*.py) | 6 |
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
-| GitHub Actions 워크플로우 (.github/workflows/*.yml) | 54 |
+| GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 154 |
+| 테스트 파일 (tests/test_*.py) | 155 |
 
 <!-- component-counts:end -->

--- a/tests/test_close_stale_ci_failure_issues_guard.py
+++ b/tests/test_close_stale_ci_failure_issues_guard.py
@@ -139,6 +139,20 @@ class TestWorkflowWiring:
         assert perms.get("issues") == "write"
         assert perms.get("contents") == "read", "this workflow must not need write access to the tree"
 
+    def test_grants_actions_read_for_the_reusable_alert(self, parsed: dict) -> None:
+        """A reusable workflow inherits the *caller's* permissions.
+
+        `alert-consecutive-failures.yml` reads run history, so it declares
+        `actions: read`. Omitting it here does not fail loudly at author time —
+        `actionlint` passes, the YAML is valid — the alert job simply cannot run.
+        Caught in CI by `scripts/tools/check_workflow_permissions.py`; asserted
+        here so the reason lives next to the workflow it constrains.
+        """
+        assert parsed["permissions"].get("actions") == "read", (
+            "the alert-consecutive-failures call needs `actions: read` from its "
+            "caller; without it the failure alerting silently cannot run"
+        )
+
     def test_concurrency_group_is_ref_scoped(self, parsed: dict) -> None:
         """A constant group cancels unrelated runs — measured on supply-chain-lock.yml.
 

--- a/tests/test_close_stale_ci_failure_issues_guard.py
+++ b/tests/test_close_stale_ci_failure_issues_guard.py
@@ -1,0 +1,170 @@
+"""Invariant guard for `close-stale-ci-failure-issues.yml`.
+
+## Why this needs a guard at all
+
+The workflow closes issues in bulk. Three of its properties are the difference
+between "housekeeping" and "silent data loss", and none of them is visible from
+the workflow's name:
+
+1. **Pagination.** `listForRepo` caps at 30 without `github.paginate`. The
+   backlog this workflow exists to drain was 363 issues on 2026-08-24 — an
+   unpaginated version would look like it ran fine while touching only the
+   newest 30, forever.
+2. **Human-intervention opt-out.** An issue somebody commented on, or labelled
+   `keep`, has been triaged. Closing it discards that work.
+3. **No silent cap.** `max_close` bounds each run. If the deferred count is not
+   reported, a partial sweep reads as a complete one — the next person believes
+   the backlog is drained when it is not.
+
+These are exactly the properties a well-meaning simplification deletes, because
+each looks like defensive clutter in isolation. The assertions below are pinned
+to the *mechanism*, not the wording, so a rewrite that keeps the behaviour still
+passes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "close-stale-ci-failure-issues.yml"
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def parsed() -> dict:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _squash(text: str) -> str:
+    """Collapse runs of whitespace so assertions survive reindentation."""
+    return " ".join(text.split())
+
+
+def _script(parsed: dict) -> str:
+    """The github-script body — the only place the closing logic lives."""
+    for step in parsed["jobs"]["close-stale"]["steps"]:
+        script = (step.get("with") or {}).get("script")
+        if script:
+            return script
+    pytest.fail("close-stale job has no github-script step")
+
+
+class TestPagination:
+    def test_issue_listing_paginates(self, parsed: dict) -> None:
+        assert "github.paginate(github.rest.issues.listForRepo" in _script(parsed), (
+            "must page through all open ci-failure issues; a bare `listForRepo` "
+            "silently caps at 30 and the backlog (363 on 2026-08-24) never drains"
+        )
+
+    def test_requests_full_pages(self, parsed: dict) -> None:
+        assert "per_page: 100" in _script(parsed)
+
+
+class TestHumanOptOut:
+    def test_keep_label_is_honoured(self, parsed: dict) -> None:
+        assert "'keep'" in _script(parsed), "a `keep` label must exempt an issue from closing"
+
+    def test_commented_issues_are_exempt(self, parsed: dict) -> None:
+        """A comment means a human engaged — closing it discards triage."""
+        script = _script(parsed)
+        assert "(issue.comments || 0) > 0" in _squash(script), (
+            "issues with comments must be exempt via an explicit gate; a mere "
+            "mention of `issue.comments` in a log message is not the exemption. "
+            "Without it, triaged issues get closed alongside untouched noise"
+        )
+
+    def test_age_threshold_is_applied(self, parsed: dict) -> None:
+        """Closing must be gated on staleness, not run unconditionally.
+
+        Asserted on the comparison itself: `updated_at` and `cutoff` also appear
+        in log/summary strings, so their mere presence proves nothing.
+        """
+        squashed = _squash(_script(parsed))
+        assert "const cutoff = new Date(Date.now() - ageDays" in squashed, (
+            "the staleness cutoff must be derived from the age_days input"
+        )
+        assert "if (new Date(issue.updated_at) >= cutoff)" in squashed, (
+            "recently-updated issues must be exempted by an explicit comparison "
+            "against the cutoff — without it every open ci-failure issue is closed "
+            "on the first run regardless of age"
+        )
+
+
+class TestNoSilentCap:
+    def test_cap_exists(self, parsed: dict) -> None:
+        assert "maxClose" in _script(parsed), "each run must bound how many issues it closes"
+
+    def test_deferred_count_is_reported(self, parsed: dict) -> None:
+        """A cap that is not reported turns a partial sweep into a false 'done'."""
+        script = _script(parsed)
+        squashed = _squash(script)
+        assert "const deferred = candidates.length - target.length" in squashed, (
+            "the count left behind by the cap must be computed"
+        )
+        assert "if (deferred > 0)" in squashed, (
+            "the deferred count must be reported through an explicit branch — a "
+            "silent cap reads as full coverage to the next person"
+        )
+        assert "이월" in script, "the deferred count must appear in the job summary text"
+
+    def test_writes_a_job_summary(self, parsed: dict) -> None:
+        assert "core.summary" in _script(parsed), "bulk issue closure must leave an auditable per-run record"
+
+
+class TestFailureHandling:
+    def test_per_issue_errors_do_not_abort_the_sweep(self, parsed: dict) -> None:
+        script = _script(parsed)
+        assert "catch" in script, "one unclosable issue must not strand the rest"
+
+    def test_total_failure_is_surfaced(self, parsed: dict) -> None:
+        """Catching every error without ever failing is a fail-open sweep."""
+        assert "if (failed.length > 0 && closed.length === 0)" in _squash(_script(parsed)), (
+            "if nothing could be closed the job must fail — otherwise a "
+            "permissions or rate-limit outage looks like an empty backlog. "
+            "The `core.setFailed` calls that validate inputs do not cover this."
+        )
+
+
+class TestWorkflowWiring:
+    def test_permissions_are_least_privilege(self, parsed: dict) -> None:
+        perms = parsed["permissions"]
+        assert perms.get("issues") == "write"
+        assert perms.get("contents") == "read", "this workflow must not need write access to the tree"
+
+    def test_concurrency_group_is_ref_scoped(self, parsed: dict) -> None:
+        """A constant group cancels unrelated runs — measured on supply-chain-lock.yml.
+
+        There, `group: supply-chain-lock` with `cancel-in-progress: true` meant
+        16 of 25 recent runs were cancelled, so the gate mostly did not run.
+        """
+        group = parsed["concurrency"]["group"]
+        assert "${{" in group, f"concurrency group must be ref/PR-scoped, got {group!r}"
+
+    def test_dry_run_is_available(self, parsed: dict) -> None:
+        """Bulk closure needs a preview mode before the first real sweep."""
+        # PyYAML 1.1 은 bare `on:` 을 boolean True 로 읽는다 — 저장소 관례와 동일하게
+        # 두 키를 모두 본다 (tests/test_workflow_alerting_coverage_guard.py:81).
+        triggers = parsed.get("on", parsed.get(True))
+        inputs = triggers["workflow_dispatch"]["inputs"]
+        assert "dry_run" in inputs
+        squashed = _squash(_script(parsed))
+        assert "const dryRun = process.env.DRY_RUN === 'true'" in squashed, (
+            "the dry_run input must be read into the script"
+        )
+        assert "if (dryRun)" in squashed, "the dry_run flag must actually gate the close calls, not merely exist"
+
+    def test_has_failure_alerting(self, parsed: dict) -> None:
+        """Enforced repo-wide by test_workflow_alerting_coverage_guard; asserted
+        here too so the reason travels with this workflow: if this job dies
+        quietly the tracker refills to the state that motivated it."""
+        jobs = parsed["jobs"]
+        assert "alert-consecutive-failures" in jobs
+        assert jobs["alert-consecutive-failures"]["uses"] == ("./.github/workflows/alert-consecutive-failures.yml")


### PR DESCRIPTION
## 문제

`classify-workflow-failures.yml` 은 코드 실패마다 이슈를 만들지만 **닫지 않는다**. 종료 경로가 없어 트래커가 자동 이슈로 포화됐다 — 2026-08-24 실측:

| | 건수 |
|---|---|
| open 이슈 전체 | 378 |
| 그중 `ci-failure` 자동 생성 | **363 (96%)** |
| 사람이 다뤄야 하는 나머지 | 15 |

월별: 2026-04 **197** / 05 **116** / 06 20 / 07 7 / 08 22
워크플로우별: Code Quality **267** / Security Scan 25 / 수집기 합계 ~60

4~5월분 313건은 이미 해결된 실패의 잔해다. 그 결과 실제 이슈 15건이 노이즈에 묻혀 트래커가 관측 수단으로 기능하지 못한다.

## 판정 기준 — 왜 "해결됐는지" 대신 나이인가

이상적으로는 후속 run 성공 여부로 닫아야 한다. 그런데 이슈 본문의 `Dedupe Key` 는 `workflow|run|sha` 로 특정 커밋에 묶여 있고, 그 커밋은 대개 스쿼시 머지로 main 에서 사라졌다. "이 실패가 지금도 재현되는가" 를 이슈 하나만 보고 판정할 수 없다.

대신 **나이(기본 30일) + 사람 개입 흔적**으로 판정한다:

- `keep` 라벨 → 보존
- 코멘트 1건 이상 → 보존 (누군가 트리아지함)
- 30일 내 갱신 → 보존

아직 유효한 실패라면 분류기가 다음 실패에서 새 이슈를 만든다 — 정보가 영구히 사라지는 구조가 아니다.

## 머지하면 실제로 일어날 일 (실데이터 시뮬레이션)

367건 기준으로 계산:

| | 건수 |
|---|---|
| 종료 대상 | **340** |
| 보존 (30일 내 갱신) | 27 |
| 1회차 종료 (`max_close=200`) | 200 |
| 1회차 이월 → 2회차 | 140 |
| **최종 잔존 open `ci-failure`** | **27** |

가장 오래된 대상 #566 (2026-03-31), 가장 최근 #1060 (2026-07-22).
`keep` 라벨·코멘트 보유 이슈는 현재 0건이므로 두 예외는 향후를 위한 안전판이다.

**초회 실행 전에** `workflow_dispatch` 에서 `dry_run=true` 로 대상만 미리 확인할 수 있다.

## 안전장치

- **`github.paginate`** — `listForRepo` 는 기본 30건 캡이다. 페이지네이션 없이는 매 실행이 최신 30건만 보고 끝나 백로그가 영구히 안 빠진다.
- **상한을 침묵시키지 않는다** — `max_close` 로 이월한 건수를 step summary + `core.notice` 에 남긴다. 조용히 잘린 상한은 "전부 처리했다" 로 읽혀 다음 사람을 속인다.
- **fail-open 방지** — 개별 종료 실패는 나머지를 막지 않되 집계에 남기고, 한 건도 못 닫았으면 잡을 실패시킨다. 그러지 않으면 권한/레이트리밋 장애가 "백로그가 비었다" 로 위장한다.
- **concurrency ref 스코프** — 전역 상수 그룹 + `cancel-in-progress` 는 무관한 런을 취소한다 (`supply-chain-lock.yml` 에서 실측된 실패 모드, 별건 PR 로 수정).
- **`alert-consecutive-failures` 등록** — 이 잡이 조용히 죽으면 트래커가 다시 포화되는데 그걸 알려줄 것이 없다. 저장소의 `KNOWN_UNCOVERED` 는 0건 상태이므로 그 불변식을 유지했다.
- 권한은 `issues: write` + `contents: read` 로 최소화.

## 함께 고친 것 — dedupe 가 30건 창에서 잘림

`classify-workflow-failures.yml` 의 중복 판정도 페이지네이션이 없어, open `ci-failure` 이슈 363건 상태에서 **최신 30건만** 검사하고 있었다. 31번째 이후로 밀려난 이슈와 같은 실패가 재발하면 중복 이슈가 새로 생긴다 — 분류기 자신의 출력이 자신이 보고하는 백로그를 부풀렸다.

> 이 hunk 는 #1196 과 같은 파일을 건드린다. #1196 이 먼저 머지되면 이 커밋은 no-op 이 된다.

## 검증

`tests/test_close_stale_ci_failure_issues_guard.py` 가 8개 불변식을 고정하고, **각각을 무력화하는 뮤테이션 8건 전부 자기 단언으로 red 확인**:

| 뮤테이션 | 잡은 테스트 |
|---|---|
| `paginate` 제거 | `test_issue_listing_paginates` |
| `keep` 라벨 무시 | `test_keep_label_is_honoured` |
| 코멘트 예외 제거 | `test_commented_issues_are_exempt` |
| 나이 게이트 제거 | `test_age_threshold_is_applied` |
| 이월 보고 제거 | `test_deferred_count_is_reported` |
| 최종 실패 fail-open | `test_total_failure_is_surfaced` |
| concurrency 상수화 | `test_concurrency_group_is_ref_scoped` |
| `dry_run` 게이트 제거 | `test_dry_run_is_available` |

1차 작성에서는 이 중 **4건이 생존**했다 — 단언이 게이트가 아니라 로그 문자열의 우연한 일치(`issue.comments` 가 보존 메시지에도 등장 등)를 잡고 있었다. 게이트 표현식 자체를 앵커로 바꿔 해소했다.

- `python3 -m ruff check/format --check scripts/ tests/` — 통과
- `actionlint .github/workflows/close-stale-ci-failure-issues.yml` — OK
- `python3 -m pytest tests/` — **5601 passed, 1 skipped**, coverage **74.36%** (게이트 70%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
