### PR TITLE
fix(ci): supply-chain-lock 의 concurrency 그룹을 ref 스코프로 (런 58% 취소)

### DIFF
--- a/.github/workflows/supply-chain-lock.yml
+++ b/.github/workflows/supply-chain-lock.yml
@@ -51,8 +51,21 @@ permissions:
   actions: read
   issues: write
 
+# ref/PR 스코프 필수. 전역 상수 그룹 + `cancel-in-progress: true` 는 **서로 무관한
+# 런끼리 서로를 취소**한다. 이 워크플로우는 `push` 와 `pull_request` 를 모두 받으므로
+# 동시에 여러 ref 가 하나의 슬롯을 다툰다 — 최근 60런 실측(2026-08-24):
+#
+#   push          : 취소 25 / 성공 9 / 실패 1   → 71% 취소
+#   pull_request  : 취소 10 / 성공 10 / 실패 3  → 43% 취소
+#   전체          : 35/60 = 58% 취소
+#
+# 이건 공급망 무결성 게이트다(락 해시 ↔ requirements.txt 검증, 상류 yank/tamper 탐지).
+# 절반 이상이 취소되면 게이트가 대부분 **돌지 않는다**. 게다가 PR 브랜치에 푸시하면
+# push 런과 pull_request 런이 같은 슬롯을 다퉈 서로를 죽이므로, 어느 쪽도 완주하지
+# 못한 채 PR 에는 red X 만 남는다. #1184 가 실제로 그 상태였다 — `sync` 는 통과했는데
+# 취소된 `verify` 때문에 막힌 PR 처럼 보였다.
 concurrency:
-  group: supply-chain-lock
+  group: supply-chain-lock-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 54 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 154 |
+| 테스트 파일 (tests/test_*.py) | 155 |
 
 <!-- component-counts:end -->

--- a/tests/test_workflow_concurrency_scope_guard.py
+++ b/tests/test_workflow_concurrency_scope_guard.py
@@ -1,0 +1,122 @@
+"""워크플로우 concurrency 그룹 스코프 가드.
+
+## 왜 있나
+
+`concurrency.group` 에 `${{ }}` 표현식이 없으면 그 그룹은 **저장소 전역 상수**다.
+`cancel-in-progress: true` 와 합쳐지면, 새 런이 시작될 때 **어느 ref 의 런이든**
+진행 중인 것을 취소한다.
+
+트리거가 `schedule` / `workflow_dispatch` / `workflow_run` 뿐이라면 이건 의도된
+동작이다 — 실질적으로 ref 가 하나뿐이고, "최신 것만 돌면 된다" 가 맞다.
+
+`push` 나 `pull_request` 가 섞이면 이야기가 달라진다. 브랜치·PR 마다 런이 생기는데
+슬롯이 하나뿐이라 서로를 죽인다. 2026-08-24 에 `supply-chain-lock.yml` 에서 실측된
+결과:
+
+| 이벤트 | 취소 | 성공 | 실패 | 취소율 |
+|---|---|---|---|---|
+| `push` | 25 | 9 | 1 | **71%** |
+| `pull_request` | 10 | 10 | 3 | **43%** |
+| 전체 | 35 | 21 | 4 | **58%** |
+
+그건 공급망 무결성 게이트였다(락 해시 ↔ `requirements.txt`, 상류 yank/tamper).
+절반 이상 취소되면 게이트가 **대부분 돌지 않는데도 아무도 모른다** — 취소는 실패
+알림을 울리지 않는다. 게다가 PR 브랜치 푸시는 `push` 런과 `pull_request` 런이 같은
+슬롯을 다퉈 서로를 죽이므로, PR 에는 완주하지 못한 red X 만 남아 **막히지 않은 PR 이
+막힌 것처럼 보인다**. #1184 가 그 상태였다.
+
+## 이 가드가 지키는 것
+
+`push` 또는 `pull_request` 를 받는 워크플로우가 `cancel-in-progress: true` 를 쓰면
+그룹이 ref/PR 로 스코프돼 있어야 한다. 취소는 조용하므로 이 회귀는 런타임에
+드러나지 않는다 — 정적으로 잡는 수밖에 없다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+
+# ref 가 여러 개 동시에 존재할 수 있는 트리거. 이들이 있으면 전역 상수 그룹은
+# 교차-ref 취소를 뜻한다.
+_MULTI_REF_TRIGGERS = frozenset({"push", "pull_request", "pull_request_target"})
+
+
+def _workflow_files() -> list[Path]:
+    if not _WORKFLOWS_DIR.is_dir():
+        return []
+    return sorted(p for p in _WORKFLOWS_DIR.glob("*.yml") if p.is_file())
+
+
+def _triggers(wf: dict) -> set[str]:
+    """PyYAML 1.1 은 bare `on:` 을 boolean True 로 읽는다 — 두 키를 모두 본다."""
+    raw = wf.get("on", wf.get(True))
+    if isinstance(raw, dict):
+        return set(raw)
+    if isinstance(raw, list):
+        return set(raw)
+    if isinstance(raw, str):
+        return {raw}
+    return set()
+
+
+@pytest.mark.parametrize(
+    "yaml_path",
+    _workflow_files(),
+    ids=lambda p: p.name,
+)
+def test_cancelling_workflows_scope_concurrency_by_ref(yaml_path: Path) -> None:
+    wf = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    if not isinstance(wf, dict):
+        pytest.skip(f"{yaml_path.name} is not a mapping")
+
+    concurrency = wf.get("concurrency")
+    if not isinstance(concurrency, dict):
+        return
+    if concurrency.get("cancel-in-progress") is not True:
+        return
+
+    triggers = _triggers(wf)
+    if not (triggers & _MULTI_REF_TRIGGERS):
+        return
+
+    group = str(concurrency.get("group", ""))
+    assert "${{" in group, (
+        f"{yaml_path.name} 은 {sorted(triggers & _MULTI_REF_TRIGGERS)} 를 받으면서 "
+        f"concurrency group 이 전역 상수({group!r})이고 cancel-in-progress: true 다. "
+        "서로 무관한 브랜치/PR 의 런이 서로를 취소한다 — supply-chain-lock.yml 에서 "
+        "런 58%가 취소돼 게이트가 대부분 돌지 않았고, 취소는 실패 알림을 울리지 않아 "
+        "조용히 넘어갔다. "
+        "해소: group 에 ${{ github.event.pull_request.number || github.ref }} 를 포함할 것."
+    )
+
+
+def test_guard_covers_at_least_one_workflow() -> None:
+    """가드가 아무것도 검사하지 않는 상태로 통과하지 않게 한다.
+
+    조건(`cancel-in-progress: true` + multi-ref 트리거)에 해당하는 워크플로우가
+    0개면 위 테스트는 전부 no-op 으로 green 이다. 그럼 나중에 조건 판정이 깨져도
+    아무도 모른다 — 커버 대상이 실제로 존재함을 단언한다.
+    """
+    covered = []
+    for path in _workflow_files():
+        wf = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(wf, dict):
+            continue
+        concurrency = wf.get("concurrency")
+        if not isinstance(concurrency, dict):
+            continue
+        if concurrency.get("cancel-in-progress") is not True:
+            continue
+        if _triggers(wf) & _MULTI_REF_TRIGGERS:
+            covered.append(path.name)
+
+    assert covered, (
+        "cancel-in-progress + push/pull_request 조합의 워크플로우가 하나도 없다. "
+        "가드가 no-op 이 됐거나 트리거 파싱이 깨졌다 — _triggers()/_MULTI_REF_TRIGGERS 를 확인할 것."
+    )


### PR DESCRIPTION
## 문제

```yaml
concurrency:
  group: supply-chain-lock     # ← 저장소 전역 상수. ref/PR 구분 없음
  cancel-in-progress: true
```

그룹에 `${{ }}` 가 없으면 **저장소 전역 상수**다. `cancel-in-progress: true` 와 합쳐지면 새 런이 시작될 때 **어느 ref 의 런이든** 진행 중인 것을 취소한다. 이 워크플로우는 `push` 와 `pull_request` 를 모두 받으므로 브랜치·PR 마다 런이 생기는데 슬롯이 하나뿐이라 서로를 죽인다.

**최근 60런 실측 (2026-08-24):**

| 이벤트 | 취소 | 성공 | 실패 | 취소율 |
|---|---|---|---|---|
| `push` | 25 | 9 | 1 | **71%** |
| `pull_request` | 10 | 10 | 3 | **43%** |
| `schedule` | 0 | 2 | 0 | 0% |
| **전체** | **35** | **21** | **4** | **58%** |

이건 공급망 무결성 게이트다 — 락 해시 ↔ `requirements.txt` 검증, 상류 yank/tamper 탐지(주간 cron 주석에 명시). 절반 이상이 취소되면 게이트가 **대부분 돌지 않는데도 아무도 모른다**: 취소는 실패 알림을 울리지 않는다.

두 번째 증상이 이걸 발견하게 했다. PR 브랜치에 푸시하면 `push` 런과 `pull_request` 런이 같은 슬롯을 다퉈 어느 쪽도 완주하지 못하고, PR 에는 완주 실패한 red X 만 남는다. **막히지 않은 PR 이 막힌 것처럼 보인다** — #1184 가 정확히 그 상태였다: `sync` 는 pass(1m2s) 인데 취소된 `verify` 때문에 blocked 로 읽혔다.

## 수정

`requirements-lock-sync.yml` 이 이미 쓰는 패턴과 동일하게 맞췄다:

```yaml
group: supply-chain-lock-${{ github.event.pull_request.number || github.ref }}
```

## 범위 — 왜 이 파일만

전수 조사 결과 「전역 상수 그룹 + `cancel-in-progress: true`」 조합은 7개 워크플로우다:

| 워크플로우 | 트리거 | 판정 |
|---|---|---|
| `supply-chain-lock` | push, pull_request, schedule, dispatch | **수정** |
| `dependency-check` | schedule, dispatch | 정상 |
| `push-folder-info-to-slack` | schedule, dispatch | 정상 |
| `respond-ai-mentions` | schedule, dispatch | 정상 |
| `site-health-check` | schedule, dispatch | 정상 |
| `gsc-sitemap-submit` | workflow_run, dispatch | 정상 |
| `indexnow-submit` | workflow_run, dispatch | 정상 |

나머지 6개는 실질적으로 ref 가 하나뿐이라 상수 그룹이 **의도된 동작**이다("최신 것만 돌면 된다"). `push`/`pull_request` 가 섞인 것은 `supply-chain-lock.yml` 뿐이었다.

## 검증

`tests/test_workflow_concurrency_scope_guard.py` 가 인스턴스가 아니라 **클래스 전체**를 지킨다: `push`/`pull_request`/`pull_request_target` 을 받으면서 `cancel-in-progress: true` 를 쓰는 워크플로우는 그룹이 ref/PR 스코프여야 한다. 취소는 조용하므로 이 회귀는 런타임에 드러나지 않고 정적으로만 잡힌다.

뮤테이션 2건:

| 뮤테이션 | 잡은 테스트 |
|---|---|
| 그룹을 상수로 되돌림 | `test_cancelling_workflows_scope_concurrency_by_ref[supply-chain-lock.yml]` |
| `_MULTI_REF_TRIGGERS` 를 비워 가드 no-op 화 | `test_guard_covers_at_least_one_workflow` |

두 번째는 메타가드다 — 커버 대상이 0건이면 파라미터화 테스트가 전부 no-op green 이 되어, 조건 판정이 깨져도 아무도 모르는 상태가 된다.

- `python3 -m ruff check/format --check` — 통과
- `actionlint .github/workflows/supply-chain-lock.yml` — OK
- `python3 -m pytest tests/` — **5640 passed, 1 skipped**, coverage **74.36%** (게이트 70%)

## 남은 관련 이슈 (이 PR 범위 밖)

`push` 와 `pull_request` 가 같은 paths 를 받으므로 PR 브랜치 푸시는 여전히 **두 런**을 만든다. 이제는 서로 취소하지 않고 둘 다 완주하므로 red 는 사라지지만, 중복 실행은 남는다. `push: branches: [main]` 으로 좁히면 해소되는데, PR 없는 브랜치의 커버리지가 사라지므로 별건으로 판단할 문제다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
