### PR TITLE
fix(docs): component-counts 테스트 파일 수 동기화 (155 → 157) — main red 해소

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 155 |
+| 테스트 파일 (tests/test_*.py) | 157 |
 
 <!-- component-counts:end -->


### PR DESCRIPTION
## 문제

**main 이 red 다.** `Code Quality` / `test_generated_doc_in_sync` 실패 (run [496e6143](https://github.com/Twodragon0/investing/actions/runs/32690391655)):

```
DRIFT: docs/component-counts.md — --write 로 갱신 필요
E   AssertionError: component-counts.md 드리프트 — --write 로 갱신 필요
E   assert 1 == 0
```

`docs/component-counts.md` 는 테스트 파일 **155**건이라고 적고 있지만 실제는 **157**건이다.

## 원인

#1196 / #1199 / #1198 이 각각 테스트 파일을 추가하면서 생성 문서를 **자기 브랜치 기준으로** 갱신했다:

| PR | 추가한 테스트 | 그 브랜치에서 기록한 값 |
|---|---|---|
| #1196 | `test_classify_failure_log.py` | 155 |
| #1198 | `test_close_stale_ci_failure_issues_guard.py` | 155 |
| #1199 | `test_workflow_concurrency_scope_guard.py` | 155 |

각 PR 의 CI 는 자기 브랜치에서 **정직하게 green** 이었다. 세 개가 머지되니 실제는 157인데 문서는 마지막 머지가 쓴 155 로 남았다.

## 이 실패 모드의 성질

생성 문서를 건드리는 PR 을 병렬로 열면 재발한다:

- **텍스트 충돌이 나지 않는다** — 같은 줄을 같은 값(155)으로 쓰므로 git 도 GitHub 도 경고하지 않는다.
- **PR 단위 CI 로는 잡히지 않는다** — 각 브랜치에서는 값이 실제로 맞다.
- 머지 순서상 마지막 PR 만 맞고 나머지는 어긋나는데, 그 "마지막" 도 다른 PR 들의 파일을 모르므로 결국 전부 어긋난다.

`bundle` 류 락 파일과 달리 이 문서는 **저장소 전체를 스캔해서 생성**되므로 브랜치-로컬 진실이 존재하지 않는다.

## 수정

`python3 scripts/tools/component_counts.py --write` 재생성. diff 는 한 줄이다:

```diff
-| 테스트 파일 (tests/test_*.py) | 155 |
+| 테스트 파일 (tests/test_*.py) | 157 |
```

## 검증

- `python3 -m pytest tests/test_component_counts.py tests/test_component_counts_drift_hook_guard.py` — **33 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
