### PR TITLE
chore(deps): yfinance 1.6.0 + boto3 >=1.43.76 bump + 락 재생성 (#1185 #1184 대체)

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 155 |
+| 테스트 파일 (tests/test_*.py) | 157 |
 
 <!-- component-counts:end -->

--- a/scripts/requirements.lock
+++ b/scripts/requirements.lock
@@ -805,6 +805,7 @@ lxml[html-clean]==6.1.1 \
     #   -r scripts/requirements.txt
     #   lxml-html-clean
     #   readability-lxml
+    #   yfinance
 lxml-html-clean==0.4.5 \
     --hash=sha256:c76fcadd1e5bfb9b8bafc2200d51e4e78eb0dad67f56881c21dfb6484c7e7746 \
     --hash=sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560
@@ -1401,7 +1402,7 @@ websockets==16.0 \
     --hash=sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da \
     --hash=sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4
     # via yfinance
-yfinance==1.5.2 \
-    --hash=sha256:197fc03485c246547a5a9184956c60150ea33b6f740d877e02a97f123d5cd2b9 \
-    --hash=sha256:5935d457fc62cf2f7e9bf1b2d019a8fec8fb0072f58a095eb53740b70a6a06ed
+yfinance==1.6.0 \
+    --hash=sha256:2ced6339a90e5721269a18d245757c7592163c897a7cd2b9a2dfd1d8fd30590e \
+    --hash=sha256:c32c45b42480d64981e89d65da3f480fd6910fe1972d7e78f1e2d91b45d9ee1b
     # via -r scripts/requirements.txt

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -14,7 +14,7 @@ readability-lxml==0.8.4.1
 # 전이 의존성(readability-lxml → lxml[html_clean])을 명시 핀:
 # 0.4.4 는 CVE-2026-49825(javascript: URL 미제거, XSS) 취약 → 0.4.5 에서 수정.
 lxml-html-clean>=0.4.5
-yfinance==1.5.2
+yfinance==1.6.0
 matplotlib~=3.11.1
 Pillow>=12.3.0
 numpy~=2.4.4
@@ -24,4 +24,4 @@ googlenewsdecoder==0.1.7
 langdetect==1.0.9
 # Optional: external image mirroring to Cloudflare R2 (scripts/common/asset_storage.py).
 # Pipeline degrades gracefully to local-only when boto3 or R2 credentials are absent.
-boto3>=1.43.71,<2
+boto3>=1.43.76,<2


### PR DESCRIPTION
정체돼 있던 #1185(yfinance) 와 #1184(boto3) 를 하나로 합쳐 락까지 재생성한다.

Dependabot 은 `scripts/requirements.txt` 만 바꾸고 `scripts/requirements.lock` 을 갱신할 수 없다(커밋백 PAT/App 토큰 미등록 — `requirements-lock-sync.yml` 상단 주석 §5.1). 그래서 두 PR 이 sync/verify 게이트에 계속 걸려 있었다.

## 락 변경은 yfinance 한 줄뿐

```diff
-yfinance==1.5.2
+yfinance==1.6.0
```

**boto3 는 락 변경이 필요 없다** — 락이 이미 `boto3==1.43.77` 을 핀하고 있어 `>=1.43.76,<2` 를 충족한다. 그래서 #1184 의 `sync` 잡은 **이미 pass(1m2s)** 상태였고, 유일한 red 는 concurrency 버그로 취소된 `verify` 였다(#1199 에서 수정). 즉 #1184 는 실제로 막혀 있지 않았다.

in-place 재생성(`--upgrade` 없음)이라 앵커가 유지돼 무관 패키지의 상류 drift 는 0이다 — 실측 **4 insertions / 3 deletions**.

## yfinance 1.6.0 API 표면 실측 검증

`tests/test_generate_market_summary.py` 는 `monkeypatch.setitem(sys.modules, "yfinance", yf_stub)` 로 yfinance 를 **완전히 스텁**한다. 즉 이 스위트는 상류 API 파괴를 **원리적으로 감지할 수 없다** — 테스트 green 은 이 bump 의 안전성에 대해 아무것도 증명하지 않는다.

그래서 격리 venv 에 1.6.0 을 실제 설치해 프로덕션이 쓰는 표면을 확인했다:

| 확인 대상 | 결과 |
|---|---|
| `Ticker.fast_info` | 존재 |
| `FastInfo.last_price` | `property=True` |
| `FastInfo.previous_close` | `property=True` |

`generate_market_summary.py` 는 이 셋만 쓰고(`yf.Ticker(sym).fast_info` → `getattr(info, "last_price", None)` / `getattr(info, "previous_close", None)`), 전부 try/except + `getattr` 기본값으로 감싸져 있다. 상류가 바뀌어도 크래시가 아니라 `logger.warning` 후 graceful degradation 이다.

boto3 사용처는 `scripts/common/asset_storage.py` 한 곳이며 patch bump 다.

## 함께 포함 — `docs/component-counts.md` 155→157

이 브랜치의 base 가 #1202 이전이라 이 수정이 없으면 이 PR 의 CI 가 red 다. #1202 와 **동일한 변경**이므로 어느 쪽이 먼저 머지돼도 충돌 없이 나머지가 no-op 이 된다.

## 검증

- `ruff check` / `ruff format --check` — 통과 (304 files)
- `python3 -m basedpyright` — 0 errors, 0 warnings, 0 notes
- `check_workflow_permissions.py` — OK
- `refresh_requirements_lock.sh` 내부 가드 — 커버리지/해시 가드 통과 + `require-hashes` dry-run 무결성 통과
- `test_requirements_lock_version_sync` + `test_requirements_lock_coverage` — **13 passed**
- 전체 스위트 — **5687 passed**, 1 skipped

> 락은 로컬 python **3.11.15** 로 생성했고 CI 는 3.11.16 이다. patch 차이로 내용이 달라지면 이 PR 의 `sync` 잡이 in-place 재생성으로 잡아낸다 — 그게 그 잡의 존재 이유다.

## 머지 후 할 일

#1185, #1184 를 이 PR 로 대체됨으로 종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
