### PR TITLE
chore(deps-dev): ruff 0.16.1 → 0.16.4 (3곳 동기 bump, #1188 대체)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -53,7 +53,7 @@ jobs:
           # ruff는 핀 고정: floating(unpinned) 시 새 릴리스의 format 규칙 변경으로
           # 코드 변경 없이 main이 갑자기 red가 될 수 있음. .pre-commit-config.yaml의
           # ruff-pre-commit rev(v0.16.1) 및 requirements-dev.txt와 반드시 동기화할 것.
-          pip install -r scripts/requirements.txt ruff==0.16.1 yamllint basedpyright pytest pytest-cov pytest-xdist pre-commit
+          pip install -r scripts/requirements.txt ruff==0.16.4 yamllint basedpyright pytest pytest-cov pytest-xdist pre-commit
           curl -sSL "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
           tar -xzf /tmp/actionlint.tgz -C /tmp
           install /tmp/actionlint /usr/local/bin/actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,9 @@ repos:
   # ruff lint + format — CI(code-quality.yml)의 `ruff check`/`ruff format --check
   # scripts/ tests/`를 로컬 커밋 단계에서 미리 잡는다. 2026-06-10 R2 세션이 미포맷
   # 파일을 push해 Code Quality가 이틀간 silently red였던 회귀(ruff format 누락) 재발 방지.
-  # rev는 로컬/CI ruff 버전(0.16.1)에 맞춤 — CI ruff가 floating이므로 버전 갱신 시 함께 올릴 것.
+  # rev는 로컬/CI ruff 버전(0.16.4)에 맞춤 — CI ruff가 floating이므로 버전 갱신 시 함께 올릴 것.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.4
     hooks:
       - id: ruff
         name: ruff lint (scripts/ tests/)

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 155 |
+| 테스트 파일 (tests/test_*.py) | 157 |
 
 <!-- component-counts:end -->

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pytest-timeout>=2.3
 # Lint/format — CI(code-quality.yml)와 .pre-commit-config.yaml(ruff-pre-commit rev)이
 # 동일 버전을 써야 format 규칙 불일치로 인한 spurious CI red를 막을 수 있음.
 # 세 곳(여기 / code-quality.yml / .pre-commit-config.yaml)을 항상 함께 갱신할 것.
-ruff==0.16.1
+ruff==0.16.4
 
 # Type check — CI(code-quality.yml)가 `python -m basedpyright`(include=["scripts"])를
 # 실행한다. .pre-commit-config.yaml 의 local basedpyright 훅이 로컬 커밋 단계에서


### PR DESCRIPTION
정체돼 있던 #1188 을 대체한다.

## #1188 이 red 였던 이유는 코드가 아니다

#1188 은 `requirements-dev.txt` 만 바꿨고, `tests/test_ruff_version_pin_sync.py` 가 **설계대로** red 를 냈다 (run [32678981973](https://github.com/Twodragon0/investing/actions/runs/32678981973)):

```
AssertionError: ruff 버전 핀이 3곳에서 불일치한다:
  code-quality.yml=0.16.1, requirements-dev.txt=0.16.4,
  pre-commit ruff-pre-commit rev=0.16.1
```

Dependabot 은 `requirements-dev.txt` 밖의 두 핀을 볼 수 없다. 그래서 ruff bump PR 은 **구조적으로 항상 red** 이고, 사람이 3곳을 함께 올려야 한다. 이 PR 이 그 작업이다.

| 파일 | 변경 |
|---|---|
| `requirements-dev.txt` | `ruff==0.16.1` → `0.16.4` |
| `.github/workflows/code-quality.yml` | `ruff==0.16.1` → `0.16.4` |
| `.pre-commit-config.yaml` | `rev: v0.16.1` → `v0.16.4` (+ 주석의 버전 표기) |

## 0.16.4 를 실제로 돌려서 확인

format 규칙은 ruff 버전마다 다르므로 bump 는 대량 재포맷이나 새 lint 위반을 유발할 수 있다. 로컬 ruff 는 0.16.1 이라 그걸로는 검증이 안 된다 — 격리 venv 에 **0.16.4 를 실제 설치**해 측정했다:

```
$ ruff --version
ruff 0.16.4
$ ruff check scripts/ tests/
All checks passed!
$ ruff format --check scripts/ tests/
304 files already formatted
```

**새 lint 발견 0건, 재포맷 0건.** 코드 변경이 필요 없는 bump다.

## 검증

- `tests/test_ruff_version_pin_sync.py` — **3 passed** (3곳 일치 확인)
- 전체 스위트 — **5687 passed**, 1 skipped, coverage 74.36%

## 함께 포함 — `docs/component-counts.md` 155→157

base 가 #1202 이전이라 이 수정이 없으면 이 PR 의 CI 가 red 다. #1202 / #1203 과 **동일한 변경**이므로 머지 순서와 무관하게 충돌 없이 no-op 이 된다.

## 머지 후 할 일

#1188 을 이 PR 로 대체됨으로 종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
