### PR TITLE
chore(ci): dependabot pip 이중 설정 통합 (중복 PR 7건 유발)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,40 +4,38 @@ version: 2
 registries: {}
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/scripts"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      timezone: "Asia/Seoul"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "python"
-    commit-message:
-      prefix: "chore(deps):"
-    groups:
-      security-patches:
-        applies-to: security-updates
-        update-types:
-          - "patch"
-          - "minor"
-
-  # 루트의 `requirements-dev.txt` 는 `/scripts` 항목이 커버하지 않는다. Dependabot
-  # 의 pip 디렉토리는 정확히 그 경로의 매니페스트만 읽으므로, 개발 도구(ruff,
-  # pytest, playwright 등)가 취약점 알림 밖에 있었다.
+  # pip — 저장소의 두 매니페스트를 **이 항목 하나가** 커버한다:
+  #   scripts/requirements.txt  (런타임)
+  #   requirements-dev.txt      (ruff, pytest, playwright, basedpyright)
+  #
+  # 이전에는 `/scripts` 와 `/` 두 항목이었다. 그 분리는 "Dependabot 의 pip
+  # 디렉토리는 정확히 그 경로의 매니페스트만 읽는다" 는 전제 위에 있었는데,
+  # **그 전제가 틀렸다**. `/` 는 하위 `requirements*.txt` 를 재귀 탐색한다 —
+  # 2026-08-24 실측으로 `/` 항목이 `scripts/requirements.txt` 를 바꾼 PR 이
+  # 7건이었다: #1097 #1098 #1100 #1106 #1143 #1144 #1189.
+  #
+  # 결과는 체계적 중복이었다. 같은 bump 가 두 브랜치(`dependabot/pip/<pkg>` 와
+  # `dependabot/pip/scripts/<pkg>`)로 두 번 열렸고, 둘 다 락 게이트에 걸려
+  # 정체 PR 을 두 배로 만들었다. #1184 와 #1189 가 그 쌍이다 — 동일한 boto3
+  # bump, 동일한 파일.
+  #
+  # 통합의 대가: prefix 로 런타임/개발을 구분하던 신호가 사라진다. 중립적인
+  # `chore(deps):` 로 통일했다 — 어차피 `/` 항목의 `chore(deps-dev):` 는 런타임
+  # 의존성 bump 에도 붙어서(#1189) 이미 신뢰할 수 없는 신호였다.
+  #
+  # limit 은 두 항목분(5+5)을 합쳐 8 로 둔다. 중복이 사라지므로 10 은 불필요하다.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
       timezone: "Asia/Seoul"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 8
     labels:
       - "dependencies"
       - "python"
     commit-message:
-      prefix: "chore(deps-dev):"
+      prefix: "chore(deps):"
     groups:
       security-patches:
         applies-to: security-updates

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 155 |
+| 테스트 파일 (tests/test_*.py) | 158 |
 
 <!-- component-counts:end -->

--- a/tests/test_dependabot_pip_scope_guard.py
+++ b/tests/test_dependabot_pip_scope_guard.py
@@ -1,0 +1,124 @@
+"""Dependabot pip 설정의 중복 커버리지 가드.
+
+## 왜 있나
+
+`.github/dependabot.yml` 에는 pip 항목이 둘 있었다 — `directory: "/scripts"` 와
+`directory: "/"`. 그 분리는 다음 전제 위에 있었고, 주석으로도 그렇게 적혀 있었다:
+
+> Dependabot 의 pip 디렉토리는 정확히 그 경로의 매니페스트만 읽으므로 …
+
+**그 전제가 틀렸다.** `/` 는 하위 `requirements*.txt` 를 재귀 탐색한다. 2026-08-24
+에 브랜치 접두사(`dependabot/pip/<pkg>` = `/` 출처, `dependabot/pip/scripts/<pkg>`
+= `/scripts` 출처)와 실제 변경 파일을 대조한 결과:
+
+| 출처 설정 | `requirements-dev.txt` 변경 | `scripts/requirements.txt` 변경 |
+|---|---|---|
+| `/` | 7건 | **7건** ← 중복 |
+| `/scripts` | 0건 | 11건 |
+
+`/` 가 `scripts/requirements.txt` 를 바꾼 PR: #1097 #1098 #1100 #1106 #1143
+#1144 #1189.
+
+증상은 정체 PR 이 두 배가 되는 것이었다. 같은 bump 가 두 브랜치로 열리고 둘 다
+락 게이트에 걸린다 — #1184 와 #1189 가 그 쌍이다(동일 boto3 bump, 동일 파일,
+서로 다른 prefix). prefix 로 런타임/개발을 구분하던 신호도 이미 깨져 있었다:
+#1189 는 런타임 의존성을 바꾸면서 `chore(deps-dev):` 를 달았다.
+
+## 이 가드가 지키는 것
+
+pip 항목의 디렉토리 스코프가 서로 겹치지 않을 것. `/` 는 재귀적이므로 `/` 와 함께
+다른 pip 디렉토리를 두면 정의상 중복이다.
+
+이 회귀는 **조용하다** — 설정은 유효하고, Dependabot 은 경고하지 않으며, 중복 PR
+각각은 정상적으로 보인다. 중복이라는 사실은 브랜치 접두사와 변경 파일을 대조해야
+드러난다. 그래서 정적으로 잡는다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CONFIG = _REPO_ROOT / ".github" / "dependabot.yml"
+
+
+@pytest.fixture(scope="module")
+def updates() -> list[dict]:
+    parsed = yaml.safe_load(_CONFIG.read_text(encoding="utf-8"))
+    return parsed["updates"]
+
+
+def _pip_directories(updates: list[dict]) -> list[str]:
+    dirs: list[str] = []
+    for entry in updates:
+        if entry.get("package-ecosystem") != "pip":
+            continue
+        # `directory` (단수) 또는 `directories` (복수, 신 문법) 둘 다 지원.
+        if "directory" in entry:
+            dirs.append(entry["directory"])
+        for d in entry.get("directories", []):
+            dirs.append(d)
+    return dirs
+
+
+def _normalize(directory: str) -> str:
+    return "/" + directory.strip("/")
+
+
+def test_pip_directory_scopes_do_not_overlap(updates: list[dict]) -> None:
+    """`/` 는 재귀적이다 — 다른 pip 디렉토리와 공존하면 중복 커버리지다."""
+    dirs = [_normalize(d) for d in _pip_directories(updates)]
+    assert dirs, "pip 항목이 하나도 없다 — 파이썬 의존성이 Dependabot 커버리지 밖이다"
+
+    overlaps: list[str] = []
+    for outer in dirs:
+        for inner in dirs:
+            if outer == inner:
+                continue
+            # outer 가 inner 의 조상이면 outer 의 재귀 탐색이 inner 를 삼킨다.
+            prefix = "/" if outer == "/" else outer + "/"
+            if inner.startswith(prefix):
+                overlaps.append(f"{outer!r} ⊇ {inner!r}")
+
+    assert not overlaps, (
+        "pip 항목의 디렉토리 스코프가 겹친다: "
+        + ", ".join(sorted(set(overlaps)))
+        + ". Dependabot 의 pip 은 하위 requirements*.txt 를 재귀 탐색하므로 "
+        "상위 디렉토리 항목이 하위 항목을 삼켜 같은 bump 가 두 브랜치로 열린다 "
+        "(2026-08-24 실측 7건: #1097 #1098 #1100 #1106 #1143 #1144 #1189). "
+        "겹치는 항목 중 하나를 지울 것."
+    )
+
+
+def test_pip_entry_covers_every_requirements_manifest(updates: list[dict]) -> None:
+    """중복을 없애다가 매니페스트를 커버리지 밖으로 떨어뜨리지 않게 한다.
+
+    `/scripts` 항목을 지운 통합의 전제는 "`/` 가 재귀적이라 둘 다 커버한다" 다.
+    그 전제가 깨지면(Dependabot 이 비재귀로 바뀌면) `scripts/requirements.txt`
+    가 조용히 취약점 알림 밖으로 나간다. 여기서는 최소한 **선언된 스코프가 모든
+    매니페스트를 포함하는지** 를 단언한다.
+    """
+    dirs = [_normalize(d) for d in _pip_directories(updates)]
+    manifests = sorted(
+        "/" + p.relative_to(_REPO_ROOT).as_posix() for p in _REPO_ROOT.glob("requirements*.txt") if p.is_file()
+    ) + sorted(
+        "/" + p.relative_to(_REPO_ROOT).as_posix()
+        for p in (_REPO_ROOT / "scripts").glob("requirements*.txt")
+        if p.is_file() and p.suffix == ".txt" and "lock" not in p.name
+    )
+    assert manifests, "requirements 매니페스트를 하나도 못 찾았다 — 글롭을 확인할 것"
+
+    uncovered = []
+    for manifest in manifests:
+        parent = "/" + manifest.rsplit("/", 1)[0].strip("/")
+        covered = any(parent == d or (d == "/" or parent.startswith(d + "/")) for d in dirs)
+        if not covered:
+            uncovered.append(manifest)
+
+    assert not uncovered, (
+        f"Dependabot pip 스코프 {dirs} 가 커버하지 않는 매니페스트: {uncovered}. "
+        "그 파일의 의존성은 취약점 알림 밖에 있다."
+    )


### PR DESCRIPTION
## 문제

`.github/dependabot.yml` 에 pip 항목이 둘 있었다 — `directory: "/scripts"` 와 `directory: "/"`. 그 분리는 주석에 적힌 전제 위에 있었다:

> Dependabot 의 pip 디렉토리는 정확히 그 경로의 매니페스트만 읽으므로, 개발 도구(ruff, pytest, playwright 등)가 취약점 알림 밖에 있었다.

**그 전제가 틀렸다.** `/` 는 하위 `requirements*.txt` 를 재귀 탐색한다.

브랜치 접두사로 출처 설정을 식별해(`dependabot/pip/<pkg>` = `/`, `dependabot/pip/scripts/<pkg>` = `/scripts`) 실제 변경 파일과 대조했다 — 최근 pip PR 25건:

| 출처 설정 | `requirements-dev.txt` | `scripts/requirements.txt` |
|---|---|---|
| `/` | 7건 | **7건 ← 중복** |
| `/scripts` | 0건 | 11건 |

`/` 가 `scripts/requirements.txt` 를 바꾼 PR: #1097 #1098 #1100 #1106 #1143 #1144 #1189.

## 왜 이게 아팠나

같은 bump 가 **두 브랜치로 두 번** 열리고, 둘 다 락 게이트(`sync`/`verify`)에 걸려 정체 PR 을 두 배로 만들었다. #1184 와 #1189 가 정확히 그 쌍이다 — 동일한 boto3 `>=1.43.76` bump, 동일한 파일, 서로 다른 prefix. 앞선 정체 PR 정리에서 #1189 를 중복으로 닫았고, 이 PR 이 그 재발을 막는다.

prefix 로 런타임/개발을 구분하던 신호도 **이미 깨져 있었다**: #1189 는 런타임 의존성(`scripts/requirements.txt` 의 boto3)을 바꾸면서 `chore(deps-dev):` 를 달았다.

## 수정

pip 항목을 `/` 하나로 통합. 재귀 탐색이 두 매니페스트를 모두 커버한다.

```diff
-  - package-ecosystem: "pip"
-    directory: "/scripts"
-    ...
-    prefix: "chore(deps):"
-
   - package-ecosystem: "pip"
     directory: "/"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 8
-    prefix: "chore(deps-dev):"
+    prefix: "chore(deps):"
```

**대가**: prefix 의 런타임/개발 구분이 사라진다. 위에 적은 대로 그 신호는 이미 신뢰할 수 없었으므로, 잘못된 구분보다 중립적인 `chore(deps):` 가 정직하다고 판단했다.

`limit` 은 두 항목분(5+5)을 합쳐 8. 중복이 사라지므로 10 은 불필요하다.

## 검증

`tests/test_dependabot_pip_scope_guard.py` — 뮤테이션 3건 전부 포착:

| 뮤테이션 | 잡은 테스트 |
|---|---|
| `/scripts` 항목 재도입 (중복 회귀) | `test_pip_directory_scopes_do_not_overlap` |
| 스코프를 `/scripts` 만으로 (dev 커버리지 상실) | `test_pip_entry_covers_every_requirements_manifest` |
| pip 항목 전체 제거 | 둘 다 |

두 번째 테스트가 왜 필요한가: 중복을 없애다가 매니페스트를 커버리지 밖으로 떨어뜨리면 그 의존성이 **조용히** 취약점 알림에서 빠진다. 겹침만 단언하면 "pip 항목 0개" 도 통과한다 — 그래서 반대 방향도 함께 고정했다.

이 회귀 자체가 조용한 종류다: 설정은 유효하고, Dependabot 은 경고하지 않고, 중복 PR 각각은 정상적으로 보인다. 중복이라는 사실은 브랜치 접두사와 변경 파일을 대조해야 드러난다.

- `ruff check` / `ruff format --check` — 통과 (305 files)
- 전체 스위트 — **5690 passed**, 1 skipped, coverage 74.36%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
