### PR TITLE
chore(deps-dev): pytest-playwright >=0.9.0 + pytest-cov >=7.1.0 (#1186 #1145 통합)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -51,8 +51,11 @@ jobs:
       - name: Install dependencies
         run: |
           # ruff는 핀 고정: floating(unpinned) 시 새 릴리스의 format 규칙 변경으로
-          # 코드 변경 없이 main이 갑자기 red가 될 수 있음. .pre-commit-config.yaml의
-          # ruff-pre-commit rev(v0.16.1) 및 requirements-dev.txt와 반드시 동기화할 것.
+          # 코드 변경 없이 main이 갑자기 red가 될 수 있음. 아래 핀은
+          # .pre-commit-config.yaml 의 ruff-pre-commit `rev` 및 requirements-dev.txt 의
+          # `ruff==` 와 반드시 같아야 하며, `tests/test_ruff_version_pin_sync.py` 가
+          # 세 곳의 일치를 강제한다. (여기에 버전 숫자를 다시 적지 말 것 — bump 마다
+          # 낡는다. 2026-08-24 에 0.16.1→0.16.4 bump 후 실제로 낡은 채 남았다.)
           pip install -r scripts/requirements.txt ruff==0.16.4 yamllint basedpyright pytest pytest-cov pytest-xdist pre-commit
           curl -sSL "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
           tar -xzf /tmp/actionlint.tgz -C /tmp

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,8 +9,8 @@
 #                  (also requires:  playwright install --with-deps chromium)
 
 pytest>=9.1.1
-pytest-cov>=5.0
-pytest-playwright>=0.8.0
+pytest-cov>=7.1.0
+pytest-playwright>=0.9.0
 pytest-timeout>=2.4.0
 
 # Lint/format — CI(code-quality.yml)와 .pre-commit-config.yaml(ruff-pre-commit rev)이


### PR DESCRIPTION
#1186 과 #1145 를 통합한다. #1187(pytest-timeout) 머지 직후 두 PR 이 같은 파일에서 충돌했고, base 가 각각 16 / 98 커밋 뒤처져 있어 순차 리베이스해도 서로 다시 충돌한다.

## 위험도 — 메인 quality 잡에는 영향이 없다

`code-quality.yml` 은 **`requirements-dev.txt` 를 쓰지 않는다**:

```
pip install -r scripts/requirements.txt ruff==0.16.4 yamllint basedpyright pytest pytest-cov pytest-xdist pre-commit
```

pytest 계열을 unpinned 로 설치하므로 이미 최신을 받고 있었다. 이 두 bump 는 **로컬 개발용 하한만** 올린다.

이 파일을 실제로 소비하는 것은 `i18n-e2e.yml` (`pip install -r requirements-dev.txt`) 뿐이다. 그리고 원본 PR 에서 `e2e` 잡이 각각 통과했다:

| PR | bump | `e2e` |
|---|---|---|
| #1186 | pytest-playwright >=0.8.0 → >=0.9.0 | **pass** (7m17s) |
| #1145 | pytest-cov >=5.0 → >=7.1.0 | **pass** (6m4s) |

즉 두 버전이 실제 Playwright E2E 스위트에서 동작한다는 직접 증거가 있다 — 하한만 올리는 변경이라 CI 는 이미 그 버전을 쓰고 있었던 셈이다.

## 함께: ruff 주석 탈버전화

`code-quality.yml` 의 주석이 버전 숫자를 박아두고 있었다:

```diff
-          # ruff-pre-commit rev(v0.16.1) 및 requirements-dev.txt와 반드시 동기화할 것.
```

#1204 에서 0.16.1 → 0.16.4 로 올렸을 때 **핀은 0.16.4, 주석은 0.16.1** 로 어긋난 채 남았다. `test_ruff_version_pin_sync.py` 는 세 곳의 *핀* 일치를 강제하지만 주석은 보지 않는다.

숫자를 제거하고, 다시 적지 말라는 지시 + 그 근거(실제로 낡았다는 사실)를 주석에 남겼다. 가드가 주석까지 검사하게 만드는 것은 과적합이라 택하지 않았다.

## 검증

- `ruff check` / `ruff format --check` — 통과 (305 files)
- `test_ruff_version_pin_sync.py` — 3 passed
- `actionlint .github/workflows/code-quality.yml` — OK
- `component_counts --check` — OK
- 전체 스위트 — **5690 passed**, 1 skipped, coverage 74.36%

## 머지 후 할 일

#1186, #1145 를 이 PR 로 대체됨으로 종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
