### PR TITLE
feat(ci): supply-chain-lock 에 required-check 게이트 추가 (조치 B-2)

### DIFF
--- a/.github/workflows/supply-chain-lock.yml
+++ b/.github/workflows/supply-chain-lock.yml
@@ -36,11 +36,13 @@ on:
       - 'scripts/requirements.txt'
       - 'scripts/requirements.lock'
       - '.github/workflows/supply-chain-lock.yml'
+  # paths 필터 없음 — 의도적이다. required status check 로 걸려면 이 워크플로우가
+  # **모든 PR 에서 리포트**해야 한다. paths 로 걸러진 워크플로우를 required 로 지정하면
+  # 무관 PR 에서는 체크가 아예 생성되지 않아 영구 대기가 된다.
+  #
+  # 비용은 들지 않는다: 무거운 `verify` 잡은 `changes` 판정에 따라 skip 되고, 항상 도는
+  # 것은 가벼운 `changes` + `gate` 뿐이다(guard-falsifiability.yml 과 동일한 형태).
   pull_request:
-    paths:
-      - 'scripts/requirements.txt'
-      - 'scripts/requirements.lock'
-      - '.github/workflows/supply-chain-lock.yml'
   schedule:
     - cron: '0 4 * * 1'  # Monday 04:00 UTC — catch upstream yanks/tampering
   workflow_dispatch:
@@ -69,7 +71,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # 변경 판정. `gh api pulls/{n}/files` 를 쓰는 이유는 guard-falsifiability.yml 과 같다 —
+  # 추가 액션 의존 없이, fetch-depth 1 로 끝난다.
+  #
+  # 경로 목록은 아래 `push:` 트리거의 paths 와 **같아야 한다**.
+  # `tests/test_supply_chain_lock_gate_guard.py` 가 두 목록의 일치를 강제한다.
+  changes:
+    name: Detect lock-relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - name: Detect
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # schedule / push / workflow_dispatch: 판정 대상이 없으므로 전수 실행.
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "PR 컨텍스트 아님 → 전수 실행"
+            exit 0
+          fi
+          cat > targets.txt <<'TARGETS'
+          scripts/requirements.txt
+          scripts/requirements.lock
+          .github/workflows/supply-chain-lock.yml
+          TARGETS
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' > changed.txt
+          # -x: 부분일치 금지(경로 전체 일치), -F: 정규식 아님.
+          matched=$(grep -Fxf targets.txt changed.txt || true)
+          if [ -n "${matched}" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "해당 변경:"; echo "${matched}"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "락 관련 파일 변경 없음 → verify skip"
+          fi
+
   verify:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -204,6 +250,45 @@ jobs:
           PY
 
   # 주 1회 + push/PR. PR 실패는 작성자가 이미 본다.
+  # required status check 대상. 이 잡만 모든 PR 에서 리포트한다.
+  #
+  # fail-closed: `changes` 가 실패하면 "관련 변경 없음" 을 신뢰할 수 없으므로 통과시키지
+  # 않는다. skip 된 `verify` 는 통과로 본다 — 그게 paths 필터의 의미다.
+  gate:
+    name: Supply-chain lock gate
+    if: always()
+    needs: [changes, verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Evaluate upstream results
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        run: |
+          set -euo pipefail
+          echo "changes=${CHANGES_RESULT} verify=${VERIFY_RESULT}"
+          if [ "${CHANGES_RESULT}" != "success" ]; then
+            echo "::error::변경 판정 잡이 ${CHANGES_RESULT} — verify 실행 여부를 판정할 수 없다"
+            exit 1
+          fi
+          case "${VERIFY_RESULT}" in
+            failure|cancelled)
+              echo "::error::락 무결성 검증이 ${VERIFY_RESULT}"
+              exit 1
+              ;;
+            skipped)
+              echo "락 관련 변경 없음 — verify skip (통과)"
+              ;;
+            success)
+              echo "락 무결성 검증 통과"
+              ;;
+            *)
+              echo "::error::예상하지 못한 결과 '${VERIFY_RESULT}'"
+              exit 1
+              ;;
+          esac
+
   alert-consecutive-failures:
     needs: verify
     if: failure() && github.event_name == 'schedule'

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 158 |
+| 테스트 파일 (tests/test_*.py) | 159 |
 
 <!-- component-counts:end -->

--- a/docs/devsecops/branch-protection.md
+++ b/docs/devsecops/branch-protection.md
@@ -104,6 +104,44 @@ changes (항상 실행, 변경 파일 판정)
 이 배선은 `tests/test_required_check_aggregator_guard.py` 가 강제한다(5케이스:
 `needs:` 완결성, `always()` 존재, `paths:` 부재, 스캐너 양방향).
 
+### 조치 B-2 — `supply-chain-lock.yml` (2026-08-24, 누락 보완)
+
+조치 A·B 는 `security-scan`·`dependency-review`·`guard-falsifiability` 를 다뤘지만
+**`supply-chain-lock.yml` 은 빠져 있었다.** 하필 §5.3(stale 락이 auto-merge 로
+들어가는 구멍)이 가리키는 게이트가 그것이다 — 후보 표에도 없었으니 Phase 2 를
+열어도 락 검증은 required 가 되지 않는 상태였다.
+
+조치 B 와 동일한 형태로 바꿨다:
+
+```
+changes (항상 실행, 변경 파일 판정)
+  └─ verify (if: needs.changes.outputs.relevant == 'true', --require-hashes 검증)
+       └─ gate (if: always(), needs: [changes, verify])   ← required check 대상
+```
+
+- `pull_request` 트리거의 `paths:` 를 제거했다. `push` 트리거의 필터는 유지 —
+  main 푸시는 required check 대상이 아니고 주간 스케줄이 전수를 덮는다.
+- `changes` 는 `gh api pulls/{n}/files` 로 판정한다(조치 B 와 동일, 추가 액션 의존
+  없음). PR 컨텍스트가 아니면 전수 실행.
+- `gate` 는 `skipped` 를 통과, `failure`/`cancelled` 를 실패로 본다. `cancelled` 를
+  포함시킨 것은 이 워크플로우에서 **실제로 발생했던** 실패 모드이기 때문이다
+  (concurrency 전역 상수 그룹으로 런 58%가 취소 — #1199 에서 수정).
+
+`tests/test_supply_chain_lock_gate_guard.py` 가 8개 불변식을 고정한다(각각 뮤테이션
+확인). 경로 목록이 `push:` 트리거와 `changes` 잡 두 곳에 있으므로 그 드리프트도
+단언 대상이다 — 조치 B 가 파생으로 없앤 그 문제와 같은 종류이며, 여기서는 목록이
+3개뿐이라 파생 도구 대신 동등성 단언을 택했다.
+
+#### 실측: §5.3 의 위험은 아직 잠재 상태다 (2026-08-24)
+
+`dependabot-auto-merge.yml` 의 `Enable auto-merge` 스텝이 **한 번도 실행된 적
+없다** — 최근 12개 런 전부 `skipped`(`update-type` 이 `version-update:semver-patch`
+가 아니었다. 범위 제약 bump 는 `fetch-metadata` 가 patch 로 분류하지 않는다).
+
+즉 구멍은 구조적으로 실재하지만 **관측된 발생은 0건**이다. 위 "결정을 다시 열어야
+하는 신호" 중 "required check 를 우회한 회귀가 실제로 발생한다" 는 아직 충족되지
+않았다. 준비 작업만 완비해 두고 룰셋은 그대로 둔다.
+
 ### required check 후보 (Phase 2 적용 시)
 
 전 PR 무조건 생성되는 체크만 등록할 수 있다.
@@ -115,6 +153,7 @@ changes (항상 실행, 변경 파일 판정)
 | `Python SAST (Bandit)` · `Secret Detection` · `Workflow Permissions Audit` | `security-scan.yml` | ✅ 조치 A 이후 |
 | `Dependency Review` | `dependency-review.yml` | ✅ 조치 A 이후 |
 | `Falsifiability gate` | `guard-falsifiability.yml` | ✅ 조치 B 이후 |
+| `Supply-chain lock gate` | `supply-chain-lock.yml` | ✅ 조치 B-2 이후(2026-08-24) |
 
 **등록하지 않을 것:**
 
@@ -205,8 +244,9 @@ third-party 앱은 허용된다.
 - 저장소를 조직으로 옮길 다른 이유가 생긴다(그러면 경로 3이 공짜가 된다)
 - required check 를 우회한 회귀가 실제로 발생한다
 
-준비 작업(조치 A·B, required check 후보 9종, 집계 잡)은 **이미 머지돼 있으므로**
-경로를 고르는 순간 룰셋 생성만 남는다.
+준비 작업(조치 A·B·B-2, required check 후보 **10종**, 집계 잡)은 **이미 머지돼
+있으므로** 경로를 고르는 순간 룰셋 생성만 남는다. 2026-08-24 에 마지막 누락이었던
+`supply-chain-lock.yml` 까지 채웠다(조치 B-2).
 
 ### 어느 경로를 택하든 남는 트레이드오프
 

--- a/tests/test_supply_chain_lock_gate_guard.py
+++ b/tests/test_supply_chain_lock_gate_guard.py
@@ -1,0 +1,166 @@
+"""`supply-chain-lock.yml` 의 required-check 게이트 불변식 가드.
+
+## 왜 있나
+
+main 룰셋(`20539046`)에는 required status check 가 **하나도 없다**(2026-08-24 실측:
+`deletion`, `non_fast_forward` 뿐). 그래서 `dependabot-auto-merge.yml` 의
+`gh pr merge --auto` 는 기다릴 대상이 없고, stale 락이 사람 리뷰 없이 들어갈 수 있다
+(설계 §5.3).
+
+그 구멍을 막으려면 락 검증을 required 로 걸어야 하는데, `paths:` 필터가 걸린
+워크플로우는 required 로 지정할 수 없다 — 무관 PR 에서는 체크가 **아예 생성되지 않아**
+영구 대기가 된다. 그래서 구조를 바꿨다:
+
+    changes (항상)  →  verify (관련 변경 시에만)  →  gate (항상, required 대상)
+
+`guard-falsifiability.yml` 이 이미 쓰는 형태이며, 무거운 잡은 여전히 skip 된다.
+
+## 이 가드가 지키는 것
+
+세 가지가 동시에 성립해야 이 구조가 작동한다. 하나라도 깨지면 **조용히** 무력해진다:
+
+1. `pull_request` 트리거에 `paths` 가 없을 것 — 있으면 required 지정 시 무관 PR 이
+   영구 대기한다. 이건 CI 가 red 로 알려주지 않고 PR 이 그냥 멈춘다.
+2. `gate` 가 `if: always()` 이고 `changes`·`verify` 를 모두 `needs` 할 것 — 아니면
+   `verify` 실패가 `gate` 를 통과시킬 수 있다.
+3. `gate` 가 fail-closed 일 것 — `changes` 가 실패하면 "관련 변경 없음" 을 신뢰할 수
+   없다. 그걸 통과시키면 판정 잡 장애가 락 검증 면제로 위장한다.
+
+추가로 경로 목록이 `push:` 트리거와 `changes` 잡 두 곳에 존재하므로 그 **드리프트**도
+막는다. 드리프트는 텍스트 충돌을 만들지 않아 리뷰에서 놓치기 쉽고, 결과는 "락이
+바뀌었는데 verify 가 skip" 이라는 최악의 방향이다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "supply-chain-lock.yml"
+
+
+@pytest.fixture(scope="module")
+def raw() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def parsed() -> dict:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _triggers(parsed: dict) -> dict:
+    # PyYAML 1.1 은 bare `on:` 을 boolean True 로 읽는다(저장소 관례).
+    return parsed.get("on", parsed.get(True))
+
+
+def _gate_script(parsed: dict) -> str:
+    for step in parsed["jobs"]["gate"]["steps"]:
+        if step.get("run"):
+            return step["run"]
+    pytest.fail("gate 잡에 run 스텝이 없다")
+
+
+class TestAlwaysReports:
+    def test_pull_request_has_no_paths_filter(self, parsed: dict) -> None:
+        pr = _triggers(parsed)["pull_request"]
+        # `pull_request:` 만 있으면 값이 None 이다 — 그게 정상 상태.
+        paths = (pr or {}).get("paths") if isinstance(pr, dict) else None
+        assert not paths, (
+            "pull_request 에 paths 필터가 생겼다. paths 로 걸러진 워크플로우를 required "
+            "status check 로 지정하면 무관 PR 에서 체크가 생성되지 않아 **영구 대기** 한다. "
+            "무거운 잡을 아끼려면 paths 대신 `changes` 잡의 판정으로 verify 를 skip 할 것."
+        )
+
+    def test_gate_job_exists(self, parsed: dict) -> None:
+        assert "gate" in parsed["jobs"], "required check 대상인 gate 잡이 사라졌다"
+
+    def test_gate_runs_unconditionally(self, parsed: dict) -> None:
+        gate = parsed["jobs"]["gate"]
+        assert str(gate.get("if")).strip() == "always()", (
+            f"gate 는 if: always() 여야 한다(got {gate.get('if')!r}). 아니면 upstream 이 "
+            "skip/fail 일 때 체크가 리포트되지 않아 required 로서 무의미해진다."
+        )
+
+    def test_gate_needs_both_upstream_jobs(self, parsed: dict) -> None:
+        needs = parsed["jobs"]["gate"]["needs"]
+        needs = [needs] if isinstance(needs, str) else list(needs)
+        assert set(needs) == {"changes", "verify"}, (
+            f"gate 의 needs 가 {needs} 다. changes·verify 를 모두 봐야 한다 — verify 만 "
+            "보면 판정 잡 장애를 놓치고, changes 만 보면 검증 실패를 놓친다."
+        )
+
+
+class TestFailClosed:
+    def test_changes_failure_blocks(self, parsed: dict) -> None:
+        script = " ".join(_gate_script(parsed).split())
+        assert 'if [ "${CHANGES_RESULT}" != "success" ]' in script, (
+            "changes 가 성공하지 않았을 때 gate 가 실패해야 한다 — 판정 잡이 죽으면 "
+            "'관련 변경 없음' 을 신뢰할 수 없고, 통과시키면 장애가 검증 면제로 위장한다."
+        )
+
+    def test_verify_failure_blocks(self, parsed: dict) -> None:
+        script = " ".join(_gate_script(parsed).split())
+        assert "failure|cancelled)" in script, (
+            "verify 가 failure/cancelled 일 때 gate 가 실패해야 한다. cancelled 를 빼면 "
+            "취소된 런이 통과로 읽힌다(이 워크플로우에서 이미 한 번 발생한 실패 모드)."
+        )
+
+    def test_skipped_verify_passes(self, parsed: dict) -> None:
+        """skip 은 통과다 — 그게 조건부 실행의 의미다."""
+        assert "skipped)" in " ".join(_gate_script(parsed).split())
+
+    def test_unknown_result_blocks(self, parsed: dict) -> None:
+        """새 결과 문자열이 생기면 통과가 아니라 실패로 떨어져야 한다."""
+        script = " ".join(_gate_script(parsed).split())
+        assert "예상하지 못한 결과" in script, (
+            "case 의 기본 분기가 fail 이어야 한다. 기본이 통과면 GitHub 이 새 result 값을 "
+            "도입할 때 게이트가 조용히 열린다."
+        )
+
+
+class TestVerifyStaysConditional:
+    def test_verify_gated_on_changes(self, parsed: dict) -> None:
+        verify = parsed["jobs"]["verify"]
+        assert "changes" in ([verify["needs"]] if isinstance(verify["needs"], str) else verify["needs"])
+        assert "needs.changes.outputs.relevant" in str(verify.get("if")), (
+            "verify 가 changes 판정에 걸려 있지 않으면 모든 PR 에서 무거운 무결성 검증이 "
+            "돌아 paths 필터 제거가 순수 비용 증가가 된다"
+        )
+
+
+class TestPathListDoesNotDrift:
+    def test_push_paths_match_detect_targets(self, parsed: dict, raw: str) -> None:
+        """경로 목록이 두 곳에 있다 — 어긋나면 락 변경이 skip 될 수 있다."""
+        push_paths = set(_triggers(parsed)["push"]["paths"])
+
+        # `changes` 잡 heredoc 안의 목록을 추출한다.
+        detect = _gate_targets(raw)
+        assert detect, "changes 잡의 TARGETS heredoc 을 찾지 못했다 — 추출 로직 확인"
+
+        assert push_paths == detect, (
+            "push 트리거의 paths 와 changes 잡의 판정 목록이 어긋난다.\n"
+            f"  push 에만: {sorted(push_paths - detect)}\n"
+            f"  detect 에만: {sorted(detect - push_paths)}\n"
+            "detect 에서 빠진 경로는 그 파일만 바꾼 PR 에서 verify 가 skip 된다 — "
+            "즉 락이 바뀌었는데 검증이 돌지 않는다."
+        )
+
+
+def _gate_targets(raw: str) -> set[str]:
+    """`changes` 잡의 `TARGETS` heredoc 내용을 파싱한다."""
+    lines = raw.splitlines()
+    try:
+        start = next(i for i, ln in enumerate(lines) if ln.strip().endswith("<<'TARGETS'"))
+    except StopIteration:
+        return set()
+    out: set[str] = set()
+    for ln in lines[start + 1 :]:
+        if ln.strip() == "TARGETS":
+            break
+        if ln.strip():
+            out.add(ln.strip())
+    return out


### PR DESCRIPTION
## 결론 먼저

**룰셋(Phase 2)은 건드리지 않는다.** 2026-08-07 의 보류 결정은 실측 근거가 확실하고(아래), 그 결정을 뒤집을 신호는 아직 없다. 이 PR 은 그 결정이 남겨둔 **준비 작업의 마지막 누락**을 채운다.

## 무엇이 빠져 있었나

`docs/devsecops/branch-protection.md` 의 Phase 2 준비 작업은 이미 상당히 진행돼 있었다 — 조치 A(`security-scan`, `dependency-review` 의 paths 제거), 조치 B(`guard-falsifiability` 집계 잡). 그런데 **`supply-chain-lock.yml` 이 빠져 있었다.**

하필 설계 §5.3(stale 락이 auto-merge 로 들어가는 구멍)이 가리키는 게이트가 그것이다. required check 후보 표에도 없었으니, **Phase 2 를 열어도 락 무결성 검증은 required 가 되지 않는** 상태였다.

## 구조 — 조치 B 와 동일 형태

```
changes (항상 실행, 변경 파일 판정)
  └─ verify (if: needs.changes.outputs.relevant == 'true', --require-hashes 검증)
       └─ gate (if: always(), needs: [changes, verify])   ← required check 대상
```

`paths:` 필터가 걸린 워크플로우는 required 로 지정할 수 없다 — 무관 PR 에서 체크가 **아예 생성되지 않아** 영구 대기가 된다. 그래서 `pull_request` 트리거의 필터를 걷고, 무거운 `verify` 는 `changes` 판정으로 skip 한다. 비용은 늘지 않는다: 항상 도는 것은 가벼운 `changes` + `gate` 뿐이다.

`push` 트리거의 필터는 **유지**했다 — main 푸시는 required 대상이 아니고 주간 스케줄이 전수를 덮는다.

`changes` 는 `gh api pulls/{n}/files` 로 판정한다(조치 B 와 동일, 추가 액션 의존 없음).

`gate` 는 `skipped` 를 통과, `failure`/`cancelled` 를 실패로 본다. **`cancelled` 를 포함시킨 건 이 워크플로우에서 실제로 발생했던 실패 모드이기 때문이다** — concurrency 전역 상수 그룹으로 런 58%가 취소됐고(#1199 에서 수정), 취소를 통과로 읽으면 그 상태가 그대로 게이트 우회가 된다.

## 실측 — §5.3 의 위험은 아직 잠재 상태다

`dependabot-auto-merge.yml` 의 `Enable auto-merge` 스텝이 **한 번도 실행된 적 없다**. 최근 12개 런 전부 `skipped`:

```
run=32697485753  enable-auto-merge=skipped  dependabot/pip/pytest-playwright-gte-0.9.0
run=32696287346  enable-auto-merge=skipped  dependabot/pip/numpy-approx-eq-2.5.2
run=32696279586  enable-auto-merge=skipped  dependabot/pip/lxml-6.1.2
...
```

`update-type` 이 `version-update:semver-patch` 가 아니었다 — 범위 제약(`>=`, `~=`) bump 를 `fetch-metadata` 가 patch 로 분류하지 않는다. 구멍은 구조적으로 실재하지만 **관측된 발생은 0건**이다.

## 왜 룰셋을 안 건드리나 (기존 결정 재확인)

문서에 실측이 남아 있다 — `github-actions[bot]` 은 이 저장소에서 bypass actor 가 **될 수 없다**:

```
bypass_actors: [{actor_id: 15368, actor_type: "Integration"}]
-> 422 "Actor GitHub Actions integration must be part of the ruleset source or owner organization"
```

그리고 Phase 2 의 `required_status_checks` 는 직접 푸시를 막는다. 최근 3일 main 커밋 **98건 중 82건이 직접 푸시**(github-actions[bot] 79건)이므로, bypass 없이 켜면 수집 파이프라인이 멈춘다.

문서의 "결정을 다시 열어야 하는 신호"(협업자 증가 / 조직 이전 / **required 우회 회귀 실제 발생**) 중 어느 것도 아직 충족되지 않았다. 경로를 고르는 순간 룰셋 생성만 남도록 준비만 완비한다.

## 검증

`tests/test_supply_chain_lock_gate_guard.py` — 8개 불변식, **뮤테이션 8건 전부 자기 단언으로 포착**:

| 뮤테이션 | 잡은 테스트 |
|---|---|
| `pull_request` 에 paths 재도입 | `test_pull_request_has_no_paths_filter` |
| `gate` 의 `if: always()` 제거 | `test_gate_runs_unconditionally` |
| `gate` needs 에서 verify 제거 | `test_gate_needs_both_upstream_jobs` |
| `changes` fail-closed 제거 | `test_changes_failure_blocks` |
| `cancelled` 를 통과로 | `test_verify_failure_blocks` |
| `case` 기본 분기를 통과로 | `test_unknown_result_blocks` |
| `verify` 조건 제거 | `test_verify_gated_on_changes` |
| 경로 목록 드리프트 | `test_push_paths_match_detect_targets` |

마지막 것이 특히 필요하다: 경로 목록이 `push:` 트리거와 `changes` 잡 **두 곳**에 있고, 드리프트는 텍스트 충돌을 만들지 않으며 결과는 "락이 바뀌었는데 verify 가 skip" 이라는 최악의 방향이다.

- `actionlint` — OK
- `check_workflow_permissions.py` — OK
- `ruff check` / `format --check` — 통과 (306 files)
- 전체 스위트 — **5700 passed**, 1 skipped, coverage 74.36%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
