### PR TITLE
chore(deps): coverage-comment-action v3.41 → v4.3 + ACTIVITY 명시 (#1191 대체)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -109,11 +109,18 @@ jobs:
           path: coverage.json
           retention-days: 1
 
-      - name: Coverage comment on push
+      # v4 는 `ACTIVITY` 로 무엇을 할지 명시할 수 있다. 기본값은 휴리스틱 추론인데,
+      # 이 저장소는 저장(여기) / 코멘트(coverage-comment.yml) 를 두 워크플로우로
+      # 쪼개 쓰므로 추론에 맡기지 않는다 — 추론이 틀리면 커버리지 배지가 조용히
+      # 갱신을 멈추고, CI 는 green 이라 아무도 모른다.
+      #
+      # `save_coverage_data_files` 는 `contents: write` 를 요구한다(잡 상단에 있음).
+      - name: Save coverage data on push
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: py-cov-action/python-coverage-comment-action@63f52f4fbbffada6e8dee8ec432de7e01df9ba79  # v3.41
+        uses: py-cov-action/python-coverage-comment-action@a05be3d2e8a6272d3ef5fb2840ab20368bb2eb71  # v4.3
         with:
           GITHUB_TOKEN: ${{ github.token }}
+          ACTIVITY: save_coverage_data_files
           MINIMUM_GREEN: 50
           MINIMUM_ORANGE: 40
           COVERAGE_DATA_BRANCH: python-coverage-comment-action-data

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -32,10 +32,13 @@ jobs:
         with:
           python-version: '3.11'
 
+      # `post_comment` — 이 잡은 앞선 런의 artifact 만 읽어 PR 에 코멘트한다.
+      # `pull-requests: write` 를 요구한다(워크플로우 상단에 있음).
       - name: Post coverage comment
-        uses: py-cov-action/python-coverage-comment-action@63f52f4fbbffada6e8dee8ec432de7e01df9ba79  # v3.41
+        uses: py-cov-action/python-coverage-comment-action@a05be3d2e8a6272d3ef5fb2840ab20368bb2eb71  # v4.3
         with:
           GITHUB_TOKEN: ${{ github.token }}
+          ACTIVITY: post_comment
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
           MINIMUM_GREEN: 50
           MINIMUM_ORANGE: 40

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 159 |
+| 테스트 파일 (tests/test_*.py) | 160 |
 
 <!-- component-counts:end -->

--- a/tests/test_coverage_comment_activity_guard.py
+++ b/tests/test_coverage_comment_activity_guard.py
@@ -1,0 +1,101 @@
+"""`python-coverage-comment-action` 의 `ACTIVITY` 배선 가드.
+
+## 왜 있나
+
+v3 → v4 bump 는 `ACTIVITY` 입력을 도입했다. 지정하지 않으면 액션이 **휴리스틱으로
+추론**한다 — 업스트림 문서도 "기본 휴리스틱이 대부분의 경우 동작한다" 고만 말한다.
+
+이 저장소는 그 "대부분" 이 아니다. 커버리지 파이프라인이 두 워크플로우로 쪼개져 있다:
+
+| 워크플로우 | 트리거 | 하는 일 | 필요 activity |
+|---|---|---|---|
+| `code-quality.yml` | push → main | 데이터 브랜치에 저장 | `save_coverage_data_files` |
+| `coverage-comment.yml` | `workflow_run` + `GITHUB_PR_RUN_ID` | PR 코멘트 | `post_comment` |
+
+추론이 틀리면 **CI 는 green 인 채로** 커버리지 배지가 갱신을 멈추거나 PR 코멘트가
+사라진다. 실패가 red 로 드러나지 않는 종류라서, 명시적 배선을 테스트로 고정한다.
+
+`ACTIVITY` 를 지우고 싶어지는 순간이 이 가드가 존재하는 이유다 — "기본값으로도
+되던데" 는 관측이 아니라 추측이고, 관측하려면 배지·코멘트를 며칠 지켜봐야 한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+_ACTION = "py-cov-action/python-coverage-comment-action"
+
+# activity → 그 activity 가 요구하는 최소 권한 (업스트림 문서)
+_REQUIRED_PERMISSION = {
+    "save_coverage_data_files": ("contents", "write"),
+    "post_comment": ("pull-requests", "write"),
+    "process_pr": ("pull-requests", "write"),
+}
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load((_WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def _action_steps(wf: dict) -> list[tuple[str, dict]]:
+    """(job_id, step) for every step that uses the coverage-comment action."""
+    out: list[tuple[str, dict]] = []
+    for job_id, job in (wf.get("jobs") or {}).items():
+        for step in job.get("steps") or []:
+            if _ACTION in str(step.get("uses", "")):
+                out.append((job_id, step))
+    return out
+
+
+_CALL_SITES = [
+    ("code-quality.yml", "save_coverage_data_files"),
+    ("coverage-comment.yml", "post_comment"),
+]
+
+
+@pytest.mark.parametrize(("workflow", "expected"), _CALL_SITES, ids=lambda v: str(v))
+def test_activity_is_explicit(workflow: str, expected: str) -> None:
+    wf = _load(workflow)
+    steps = _action_steps(wf)
+    assert steps, f"{workflow} 에서 {_ACTION} 사용처를 찾지 못했다 — 가드가 no-op 이 됐다"
+
+    for job_id, step in steps:
+        activity = (step.get("with") or {}).get("ACTIVITY")
+        assert activity, (
+            f"{workflow}:{job_id} 의 {_ACTION} 스텝에 ACTIVITY 가 없다. "
+            "v4 는 지정하지 않으면 휴리스틱으로 추론하는데, 이 저장소는 저장/코멘트를 "
+            "두 워크플로우로 쪼개 쓴다. 추론이 틀리면 CI 는 green 인 채로 배지 갱신이나 "
+            "PR 코멘트가 조용히 멈춘다."
+        )
+        assert activity == expected, f"{workflow}:{job_id} 의 ACTIVITY 가 {activity!r} 다 — {expected!r} 여야 한다"
+
+
+@pytest.mark.parametrize(("workflow", "expected"), _CALL_SITES, ids=lambda v: str(v))
+def test_permissions_cover_the_activity(workflow: str, expected: str) -> None:
+    """activity 마다 요구 권한이 다르다 — 부족하면 그 잡이 조용히 실패한다."""
+    wf = _load(workflow)
+    key, value = _REQUIRED_PERMISSION[expected]
+
+    # 잡 수준 permissions 가 있으면 그것이, 없으면 워크플로우 수준이 적용된다.
+    for job_id, _step in _action_steps(wf):
+        job_perms = (wf["jobs"][job_id] or {}).get("permissions")
+        perms = job_perms if job_perms is not None else wf.get("permissions")
+        assert isinstance(perms, dict), f"{workflow}:{job_id} 에 permissions 블록이 없다"
+        assert perms.get(key) == value, (
+            f"{workflow}:{job_id} 는 ACTIVITY={expected} 를 쓰므로 `{key}: {value}` 가 필요하다(got {perms.get(key)!r})"
+        )
+
+
+def test_all_call_sites_are_covered() -> None:
+    """새 사용처가 생기면 이 가드에 등록되지 않은 채 지나가지 않게 한다."""
+    declared = {w for w, _ in _CALL_SITES}
+    found = {p.name for p in _WORKFLOWS.glob("*.yml") if _ACTION in p.read_text(encoding="utf-8")}
+    assert found == declared, (
+        f"{_ACTION} 사용처가 바뀌었다. 발견={sorted(found)} 등록={sorted(declared)}. "
+        "새 사용처에도 ACTIVITY 를 명시하고 _CALL_SITES 에 추가할 것."
+    )


### PR DESCRIPTION
#1191 을 그대로 머지하지 않은 이유: v4 에는 실제 breaking change 가 있고, 이 저장소의 사용 형태에서 **실패가 무음**이다.

## v4 의 변경 중 이 저장소에 걸리는 것

### 1. 신규 `ACTIVITY` 입력 — 이게 핵심

지정하지 않으면 액션이 휴리스틱으로 추론하고, 업스트림도 "기본 휴리스틱이 대부분의 경우 동작한다" 고만 말한다. **이 저장소는 그 "대부분" 이 아니다** — 커버리지 파이프라인이 두 워크플로우로 쪼개져 있다:

| 워크플로우 | 트리거 | 하는 일 | 명시한 activity |
|---|---|---|---|
| `code-quality.yml` | push → main | 데이터 브랜치 저장 | `save_coverage_data_files` |
| `coverage-comment.yml` | `workflow_run` + `GITHUB_PR_RUN_ID` | PR 코멘트 | `post_comment` |

추론이 틀리면 **CI 는 green 인 채로** 배지 갱신이나 PR 코멘트가 조용히 멈춘다. 그걸 관측하려면 며칠 지켜봐야 하므로, green 을 근거로 삼을 수 없다. 그래서 추론에 맡기지 않고 각 사용처에 명시했다.

### 2. 인증 방식 변경

v4 는 checkout 의 persisted credentials 를 더 이상 쓰지 않고 `GITHUB_TOKEN` 으로 커밋한다. 두 사용처 모두 이미 `GITHUB_TOKEN: ${{ github.token }}` 을 넘기므로 추가 작업이 없다.

### 3. immutable releases

`@v4` 태그 참조가 불가하고 커밋 해시 핀이 필수다. 저장소가 이미 전부 SHA 핀이므로 영향 없다.

## 권한 확인

activity 마다 요구 권한이 다르다:

| activity | 필요 권한 | 현재 |
|---|---|---|
| `save_coverage_data_files` | `contents: write` | ✅ `code-quality.yml` |
| `post_comment` | `pull-requests: write` | ✅ `coverage-comment.yml` |

부족하면 그 잡이 조용히 실패하므로 가드가 이것도 단언한다.

## 검증

**업스트림 대조** — `scripts/tools/verify_action_pins.py`:

```
OK  py-cov-action/python-coverage-comment-action@a05be3d2  # v4.3  (v4.3)
21 pins checked: 0 mismatch, 0 unverified
```

**뮤테이션 4건 전부 포착** (`tests/test_coverage_comment_activity_guard.py`):

| 뮤테이션 | 잡은 테스트 |
|---|---|
| `code-quality` 의 ACTIVITY 제거 | `test_activity_is_explicit[code-quality.yml-…]` |
| `coverage-comment` 의 ACTIVITY 제거 | `test_activity_is_explicit[coverage-comment.yml-…]` |
| 두 activity 를 서로 뒤바꿈 | `test_activity_is_explicit[code-quality.yml-…]` |
| `contents: write` → `read` | `test_permissions_cover_the_activity[…]` |

`test_all_call_sites_are_covered` 는 새 사용처가 가드 등록 없이 지나가는 것을 막는다 — 안 하면 세 번째 사용처가 생겼을 때 이 가드가 조용히 그것을 놓친다.

- `ruff check` / `format --check` — 통과 (307 files)
- `actionlint` — OK, `check_workflow_permissions.py` — OK
- 전체 스위트 — **5705 passed**, coverage 74.36%

## 머지 후 할 일

#1191 을 이 PR 로 대체됨으로 종료. 그리고 **다음 main 푸시 + PR 1건에서 배지 갱신과 코멘트가 실제로 동작하는지 확인**할 것 — 이 부분은 정적으로 증명할 수 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
