### PR TITLE
chore(ci): 커버리지 하한 70 → 73 + mutation 앵커를 현재 값에서 파생

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          python3 -m coverage report --fail-under=70
+          python3 -m coverage report --fail-under=73
           python3 -m coverage html -d coverage-html
           python3 -m coverage json -o coverage.json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ quote-style = "double"
 relative_files = true
 
 [tool.pytest.ini_options]
-addopts = "--cov=scripts --cov-fail-under=70"
+addopts = "--cov=scripts --cov-fail-under=73"
 # 베어 `pytest` 가 Jekyll 빌드 산출물(_site/) 내 복사된 테스트를 수집해
 # ImportError 로 깨지던 문제 방지. CI 는 명시적으로 `pytest tests/` 를 호출하므로 영향 없음.
 testpaths = ["tests"]

--- a/scripts/tools/guard_falsifiability.py
+++ b/scripts/tools/guard_falsifiability.py
@@ -133,6 +133,32 @@ def _probe_steps(*refs: str) -> str:
 # 모듈은 `pathlib` 을 import 하지 않아 autouse fixture 의 dedup import 가 NameError
 # 로 죽었다 — 테스트 본문은 실행조차 되지 않았는데 rc!=0 이라 FALSIFIABLE 로 보였다.
 # 주입은 대상 모듈에 이미 있는 이름만 쓸 것(또는 import 불필요한 리터럴).
+# 커버리지 하한 케이스의 앵커는 **현재 값에서 파생**시킨다. 하드코딩하면 하한을
+# ratchet 할 때마다(55 -> 65 -> 70 -> 73 ...) 이 하네스가 AMBIGUOUS-ANCHOR 로
+# 죽는다 — 2026-08-25 에 70 -> 73 상향에서 실제로 5개 앵커가 한꺼번에 깨졌다.
+# 가드는 "하한이 내려가는 것"을 막으라고 있는 것이지, 올라갈 때 손이 가라고 있는
+# 게 아니다.
+_COV_FLOOR_RE = re.compile(r"--cov-fail-under=(\d+)")
+
+
+def _current_coverage_floor() -> int:
+    """`pyproject.toml` 의 현재 커버리지 하한. 못 찾으면 조용히 넘어가지 않는다."""
+    src = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    found = _COV_FLOOR_RE.findall(src)
+    if len(found) != 1:
+        raise RuntimeError(
+            f"pyproject.toml 에서 --cov-fail-under 를 정확히 1개 찾지 못했다 (found={found}). "
+            "커버리지 하한 mutation 케이스의 앵커를 만들 수 없다."
+        )
+    return int(found[0])
+
+
+#: 현재 하한과, 그 아래로 끌어내리는 mutation 목표값. 목표값은 어떤 합리적 하한보다도
+#: 낮아야 `test_*_coverage_floor_enforced` 가 red 가 된다.
+_FLOOR = _current_coverage_floor()
+_FLOOR_LOWERED = 50
+_WORKFLOW_FLOOR_LOWERED = 40
+
 STATIC_CASES: tuple[StaticCase, ...] = (
     StaticCase(
         "AST 스캔: 스크립트에 cwd-상대 _state 주입 (form A)",
@@ -191,24 +217,24 @@ STATIC_CASES: tuple[StaticCase, ...] = (
         "tests/test_hermetic_test_writes_guard.py::test_detector_flags_all_banned_forms",
     ),
     StaticCase(
-        "커버리지 하한 하향 (70 -> 50)",
+        f"커버리지 하한 하향 ({_FLOOR} -> {_FLOOR_LOWERED})",
         "pyproject.toml",
-        "--cov-fail-under=70",
-        "--cov-fail-under=50",
+        f"--cov-fail-under={_FLOOR}",
+        f"--cov-fail-under={_FLOOR_LOWERED}",
         "tests/test_coverage_floor_guard.py::test_pyproject_coverage_floor_enforced",
     ),
     StaticCase(
         "커버리지 게이트 제거 (addopts)",
         "pyproject.toml",
-        " --cov-fail-under=70",
+        f" --cov-fail-under={_FLOOR}",
         "",
         "tests/test_coverage_floor_guard.py::test_pyproject_coverage_floor_enforced",
     ),
     StaticCase(
-        "워크플로우 전역 커버리지 하한 하향 (70 -> 40)",
+        f"워크플로우 전역 커버리지 하한 하향 ({_FLOOR} -> {_WORKFLOW_FLOOR_LOWERED})",
         ".github/workflows/code-quality.yml",
-        "--fail-under=70",
-        "--fail-under=40",
+        f"--fail-under={_FLOOR}",
+        f"--fail-under={_WORKFLOW_FLOOR_LOWERED}",
         "tests/test_coverage_floor_guard.py::test_workflow_global_coverage_floor_enforced",
     ),
     # ---------------------------------------------------------------------
@@ -255,8 +281,8 @@ STATIC_CASES: tuple[StaticCase, ...] = (
     StaticCase(
         "커버리지 측정 범위 축소 (pyproject --cov)",
         "pyproject.toml",
-        '"--cov=scripts --cov-fail-under=70"',
-        '"--cov=scripts/common/summary_sections.py --cov-fail-under=70"',
+        f'"--cov=scripts --cov-fail-under={_FLOOR}"',
+        f'"--cov=scripts/common/summary_sections.py --cov-fail-under={_FLOOR}"',
         "tests/test_coverage_floor_guard.py::test_pyproject_coverage_scope_not_narrowed",
     ),
     StaticCase(
@@ -276,8 +302,8 @@ STATIC_CASES: tuple[StaticCase, ...] = (
     StaticCase(
         "커버리지 게이트에서 모듈 제외 (--omit)",
         ".github/workflows/code-quality.yml",
-        "python3 -m coverage report --fail-under=70",
-        'python3 -m coverage report --fail-under=70 --omit="*/collect_*.py"',
+        f"python3 -m coverage report --fail-under={_FLOOR}",
+        f'python3 -m coverage report --fail-under={_FLOOR} --omit="*/collect_*.py"',
         "tests/test_coverage_floor_guard.py::test_workflow_coverage_gate_omits_nothing",
     ),
     StaticCase(

--- a/tests/test_coverage_floor_guard.py
+++ b/tests/test_coverage_floor_guard.py
@@ -9,13 +9,30 @@ at or above :data:`_MIN_FLOOR`:
 * ``.github/workflows/code-quality.yml`` — a dedicated
   ``coverage report --fail-under=NN`` step re-checks the same data in CI.
 
-Total ``scripts`` coverage sits ~70% (2026-07); the floor was ratcheted
-55 -> 65 (P3-1/P3-2) -> 70 (P3-3) to lock the existing coverage as a regression
-baseline. Without this guard the floor could be quietly dropped back —
-re-opening the gap between "tests deleted" and "build still green".
+The floor was ratcheted 55 -> 65 (P3-1/P3-2) -> 70 (P3-3) -> 73 (2026-08-25) to
+lock existing coverage as a regression baseline. Without this guard the floor
+could be quietly dropped back — re-opening the gap between "tests deleted" and
+"build still green".
 
-Direction: floor is ``>=`` — ratcheting UP (70 -> 75 ...) stays green; only
-removing a gate or lowering it below 70 trips this test. If the floor is lowered
+The 73 step was measured, not guessed. Actual total is **74.36%**
+(18413/24761 statements), and the measurement is deterministic:
+
+* local, same tree, 5 consecutive runs -> ``24761 6348 74%`` every time, spread 0
+* CI, 25 runs over 2026-08-18..08-25 (``python-coverage-comment-action-data``
+  branch ``data.json``) -> 74.304 .. 74.309, spread **0.005pt**
+
+So the 1.36pt headroom at 73 is ~270x the observed measurement noise; this floor
+cannot go red from noise. What it *does* cost: a new fully-untested script is
+allowed only up to ~462 statements before the gate trips (for scale, the largest
+existing 0%-covered script is ``scripts/backfill_images.py`` at 317). That is the
+intended ratchet — past that point, write tests or lower the floor deliberately.
+
+An earlier note claimed a ~1.3pt run-to-run swing (2026-07-27, when the total was
+~71%). That is no longer reproducible; the hermetic-test hardening since then
+removed it. Re-measure before citing it again.
+
+Direction: floor is ``>=`` — ratcheting UP (73 -> 75 ...) stays green; only
+removing a gate or lowering it below 73 trips this test. If the floor is lowered
 intentionally, update ``_MIN_FLOOR`` here AND both ``--fail-under`` values
 together.
 
@@ -25,11 +42,11 @@ by ``test_summary_sections_coverage_floor.py``.
 
 ## A floor number is not a gate
 
-A number alone proves nothing: four edits leave ``--fail-under=70`` untouched
+A number alone proves nothing: four edits leave ``--fail-under=NN`` untouched
 while making the gate meaningless, so each is asserted separately below.
 
 * **Measurement scope** — narrowing ``--cov=scripts`` to a single well-tested
-  module keeps the floor at 70 while measuring almost nothing.
+  module keeps the floor number intact while measuring almost nothing.
 * **Omission** — ``coverage report --omit=...``, or an ``omit`` key under
   ``[tool.coverage.run]`` / ``[tool.coverage.report]``, silently drops the
   weakest modules out of the denominator.
@@ -50,7 +67,7 @@ _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "code-quality.yml"
 
 # The global scripts coverage floor both gates must enforce.
-_MIN_FLOOR = 70
+_MIN_FLOOR = 73
 
 # The measurement scope the floor is meaningful against. `--cov=scripts` in
 # pyproject addopts applies to every pytest run; the CI step additionally names
@@ -143,7 +160,7 @@ def test_workflow_global_coverage_floor_enforced() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Gate *validity*: the four edits that keep `--fail-under=70` intact while
+# Gate *validity*: the four edits that keep `--fail-under=NN` intact while
 # making it prove nothing. A floor is only as strong as what it measures.
 # ---------------------------------------------------------------------------
 
@@ -152,7 +169,7 @@ def test_pyproject_coverage_scope_not_narrowed() -> None:
     """pytest addopts must measure the whole ``scripts`` tree.
 
     Narrowing to ``--cov=scripts/common/summary_sections.py`` leaves the floor
-    reading 70 while measuring one already-well-tested module — every other
+    number intact while measuring one already-well-tested module — every other
     script could lose its tests and the gate would stay green.
     """
     addopts = _pytest_addopts()


### PR DESCRIPTION
## 왜 지금

실측 총계가 **74.36%** 인데 게이트는 **70** 이었다. 4.36pt 헤드룸은 "테스트를 지워도 green" 구간이 그만큼 넓다는 뜻이다.

상향을 막고 있던 근거는 **커버리지 측정이 런마다 ~1.3pt 흔들린다**는 2026-07-27 관측(71.20 ↔ 70.72 ↔ 71.06)이었다. **재측정 결과 현재 코드베이스에서는 재현되지 않는다.**

| 측정 | n | 범위 | 스프레드 |
|---|---|---|---|
| 로컬, 동일 트리 반복 | 5 | `24761 6348 74%` / 74.36% ×5 | **0** (자릿수까지 동일) |
| CI, main (`python-coverage-comment-action-data` 의 `data.json`) | 25 (08-18~08-25) | 74.304 ~ 74.309 | **0.005pt** (stdev 0.002) |

그 사이의 hermetic 하드닝(골든마스터 고정 · DNS 스텁 · 트리-쓰기 탐지)이 원인이던 비결정성을 제거한 것으로 보인다.

## 73 인 이유

헤드룸 1.36pt 는 관측 노이즈(0.005pt)의 **약 270배**다. 노이즈로 red 가 날 수 없다.

대신 지는 비용: covered=18413 / base=24771 기준, 새로 추가하는 **완전 미커버 스크립트**가 약 **462 statement** 를 넘으면 게이트가 걸린다.

| 게이트 | 헤드룸 | 허용 미커버 statement |
|---|---|---|
| 70 (기존) | 4.36pt | 1543 |
| **73** | **1.36pt** | **462** |
| 74 | 0.36pt | 121 |

참고로 기존 0% 스크립트 최대치는 `scripts/backfill_images.py` 317 stmts — 그만한 파일 하나는 받아주고, 그 이상은 "테스트를 쓰거나 하한을 의도적으로 내리거나"를 강제한다. 그게 ratchet 의 목적이다. 72(2.36pt / 813 stmts)도 검토했으나 노이즈가 사실상 0인 이상 보수적으로 갈 이유가 약하다.

세 지점을 함께 옮겼다 — `pyproject.toml` addopts · `code-quality.yml` 의 `coverage report --fail-under` · `tests/test_coverage_floor_guard.py` 의 `_MIN_FLOOR`.

## 앵커 하드코딩 제거 (이번에 실제로 밟은 함정)

`scripts/tools/guard_falsifiability.py` 의 STATIC_CASES 5건이 하한 숫자를 문자열로 박아 두고 있었다:

```python
StaticCase("커버리지 하한 하향 (70 -> 50)", "pyproject.toml",
           "--cov-fail-under=70", "--cov-fail-under=50", ...)
```

70 → 73 으로 올리자 **5개 앵커가 한꺼번에 깨져** `test_static_case_anchors_are_unique_in_their_targets` 가 red 가 됐다(`앵커가 0회 발견됨`). 가드는 하한이 **내려가는 것**을 막으라고 있는 것이지, 올릴 때마다 손이 가라고 있는 게 아니다.

앵커를 `pyproject.toml` 의 현재 값에서 파생시킨다(`_current_coverage_floor()`). 파싱 결과가 정확히 1개가 아니면 조용히 넘어가지 않고 `RuntimeError` 를 던진다 — 0개를 못 보고 지나가면 mutation 이 아무것도 안 바꾸는데 VACUOUS 로 안 잡힌다.

이건 "가드 앵커에 변하는 값을 박지 말 것" 규약의 재발이다. 이전 사례는 Dependabot 액션 핀이었고 이번엔 커버리지 하한이었다.

## 검증

```
5717 passed, 5 skipped, 16 deselected
Required test coverage of 73% reached. Total coverage: 74.37%

ruff check / format --check   All checks passed / 309 files formatted
basedpyright                  0 errors, 0 warnings, 0 notes
actionlint                    rc=0
```

커버리지 게이트 STATIC_CASES **8건 전부 FALSIFIABLE** 재확인 (뮤테이션 주입 → 지정 가드 red → 원복까지 자동):

```
FALSIFIABLE  커버리지 하한 하향 (73 -> 50)
FALSIFIABLE  커버리지 게이트 제거 (addopts)
FALSIFIABLE  워크플로우 전역 커버리지 하한 하향 (73 -> 40)
FALSIFIABLE  커버리지 측정 범위 축소 (pyproject --cov)
FALSIFIABLE  커버리지 측정 범위 축소 (워크플로우 --cov)
FALSIFIABLE  커버리지 게이트 비차단화 (continue-on-error)
FALSIFIABLE  커버리지 게이트에서 모듈 제외 (--omit)
FALSIFIABLE  커버리지 설정에서 모듈 제외 ([tool.coverage.run] omit)
```

추가로 두 게이트가 서로를 가려주지 않는지 개별 확인: pyproject 만 70 으로 → `test_pyproject_coverage_floor_enforced` red / 워크플로우만 70 으로 → `test_workflow_global_coverage_floor_enforced` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
