### PR TITLE
perf(test): i18n 헬스체크 fail-fast (30.4s→2.05s) + 0% 커버리지 상위 3개 테스트 (74.37%→77.07%)

### DIFF
--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 162 |
+| 테스트 파일 (tests/test_*.py) | 163 |
 
 <!-- component-counts:end -->

--- a/docs/component-counts.md
+++ b/docs/component-counts.md
@@ -13,6 +13,6 @@
 | 공통 모듈 (scripts/common/**/*.py, __init__ 제외) | 62 |
 | GitHub Actions 워크플로우 (.github/workflows/*.yml) | 55 |
 | 카테고리 페이지 (pages/*.md) | 15 |
-| 테스트 파일 (tests/test_*.py) | 163 |
+| 테스트 파일 (tests/test_*.py) | 166 |
 
 <!-- component-counts:end -->

--- a/tests/_i18n_healthcheck.py
+++ b/tests/_i18n_healthcheck.py
@@ -1,0 +1,159 @@
+"""Jekyll 프리뷰 헬스체크 — "아무도 안 듣고 있음" 과 "듣고 있는데 준비 안 됨" 을 구분한다.
+
+## 왜 별도 모듈인가
+
+로직 자체는 `tests/i18n/conftest.py` 의 세션 fixture 안에 있었다. conftest 는 이름으로
+import 할 수 없어서 단위 테스트가 불가능했고, 그래서 30초짜리 대기 루프가 한 번도
+검증된 적이 없었다. `tests/conftest.py` 가 `tests/` 를 `sys.path` 에 올리므로 여기
+있는 밑줄 접두 헬퍼는 `tests/test_i18n_healthcheck.py` 에서 그대로 import 된다
+(`_tree_write_guard` · `_golden` 과 같은 규약).
+
+## 무엇을 고쳤나
+
+이전 구현은 실패를 한 덩어리로 잡았다:
+
+    except (urllib.error.URLError, ConnectionError, TimeoutError):
+
+그래서 **포트에 아무도 안 붙어 있는 경우**(로컬에서 `jekyll serve` 를 안 띄운
+경우)에도 30초를 꽉 채운 뒤에야 skip 했다. 실측 `16 skipped in 30.43s`.
+
+세 실패는 의미가 다르다:
+
+| 예외 | 의미 | 재시도 가치 |
+|---|---|---|
+| `ConnectionRefusedError` | 포트에 바인드된 프로세스가 **없다** | 낮음 |
+| `socket.timeout` / `TimeoutError` | 바인드는 됐는데 응답이 느리다 | 높음 |
+| `HTTPError`(상태코드 있음) | 서버가 살아 있다 | 높음 |
+
+그래서 **refused 만 연속으로 나오고** 유예 시간이 지나면 즉시 포기한다. refused 가
+아닌 결과가 한 번이라도 나오면 `only_refused` 를 내리고 전체 예산을 그대로 쓴다.
+
+즉시 포기가 아니라 유예를 두는 이유: `jekyll serve --detach` 는 셸 명령이 리턴한
+**뒤에** 포트를 바인드한다. 다른 터미널에서 serve 를 막 띄우고 바로 pytest 를 돌리는
+로컬 흐름이 실재한다.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Callable, Mapping, NamedTuple
+
+DEFAULT_BASE_URL = "http://127.0.0.1:4000"
+
+#: 서버가 준비되기를 기다리는 전체 예산.
+HEALTHCHECK_TIMEOUT_S = float(os.environ.get("I18N_E2E_HEALTHCHECK_TIMEOUT", "30"))
+
+#: 폴링 간격.
+HEALTHCHECK_INTERVAL_S = 0.5
+
+#: refused 만 연속으로 나올 때 버티는 시간. 이 시간을 넘기면 "아무도 안 듣고 있다"로
+#: 판정하고 즉시 포기한다. 기본 2.0s = 4회 시도 — `jekyll serve --detach` 가 포트를
+#: 바인드하기까지의 지연을 흡수하기에 충분하고, 서버가 아예 없을 때 30초를 태우지는
+#: 않는다. 0 이면 첫 refused 에 곧바로 포기한다.
+FAST_FAIL_GRACE_S = float(os.environ.get("I18N_E2E_FAST_FAIL_GRACE", "2.0"))
+
+#: 개별 요청 타임아웃.
+REQUEST_TIMEOUT_S = 2
+
+#: 판정 사유. skip/fail 메시지가 둘을 구분해서 말해야 로컬 개발자가 "Jekyll 을 안
+#: 띄웠다" 와 "띄웠는데 느리다" 를 헷갈리지 않는다.
+REASON_REFUSED = "refused"
+REASON_DEADLINE = "deadline"
+REASON_OK = "ok"
+
+
+class Probe(NamedTuple):
+    """헬스체크 결과."""
+
+    ok: bool
+    reason: str
+    attempts: int
+    last_error: BaseException | None = None
+
+
+def resolve_base_url(env: Mapping[str, str] | None = None) -> str:
+    source = os.environ if env is None else env
+    return source.get("I18N_E2E_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+
+def is_connection_refused(exc: BaseException) -> bool:
+    """예외가 "포트에 아무도 없음" 인지 판정한다.
+
+    `urlopen` 은 원 예외를 `URLError.reason` 에 감싸 넣는다. 다만 `HTTPError` 의
+    `reason` 은 문자열(HTTP reason phrase)이므로 `isinstance` 검사가 그대로 안전하다.
+    감싸지 않고 올라오는 경로도 있어 양쪽을 모두 본다.
+    """
+    if isinstance(exc, ConnectionRefusedError):
+        return True
+    return isinstance(getattr(exc, "reason", None), ConnectionRefusedError)
+
+
+def wait_for_server(
+    url: str,
+    timeout_s: float = HEALTHCHECK_TIMEOUT_S,
+    grace_s: float = FAST_FAIL_GRACE_S,
+    *,
+    interval_s: float = HEALTHCHECK_INTERVAL_S,
+    opener: Callable[..., object] = urllib.request.urlopen,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> Probe:
+    """홈페이지가 응답할 때까지 폴링한다. refused 만 이어지면 `grace_s` 후 포기.
+
+    `opener` / `sleep` / `monotonic` 이 주입 가능한 이유는 단위 테스트 때문이다 —
+    실제 대기 없이 유예 로직과 예산 로직을 각각 검증할 수 있어야 한다.
+    """
+    start = monotonic()
+    only_refused = True
+    attempts = 0
+    last_error: BaseException | None = None
+
+    while monotonic() - start < timeout_s:
+        attempts += 1
+        try:
+            with opener(url + "/", timeout=REQUEST_TIMEOUT_S) as resp:  # noqa: S310
+                if 200 <= resp.status < 500:
+                    return Probe(True, REASON_OK, attempts)
+            # 응답은 왔다 — 포트에 누가 있다는 뜻이므로 fast-fail 대상이 아니다.
+            only_refused = False
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError) as exc:
+            last_error = exc
+            if not is_connection_refused(exc):
+                only_refused = False
+
+        if only_refused and monotonic() - start >= grace_s:
+            return Probe(False, REASON_REFUSED, attempts, last_error)
+
+        sleep(interval_s)
+
+    return Probe(False, REASON_DEADLINE, attempts, last_error)
+
+
+def unreachable_message(url: str, probe: Probe) -> str:
+    """서버에 못 붙었을 때 사람이 읽을 메시지. 사유별로 다른 행동을 지시한다."""
+    if probe.reason == REASON_REFUSED:
+        return (
+            f"{url} 에서 연결이 거부됐다 — 포트에 아무것도 붙어 있지 않다 "
+            f"({probe.attempts}회 시도). `bundle exec jekyll serve --port 4000` 으로 "
+            "프리뷰를 띄우거나 I18N_E2E_BASE_URL 을 설정할 것."
+        )
+    return (
+        f"{url} 이 {HEALTHCHECK_TIMEOUT_S:g}s 안에 준비되지 않았다 "
+        f"({probe.attempts}회 시도, 마지막 오류: {probe.last_error!r}). 서버는 살아 있으나 "
+        "응답이 느리다 — I18N_E2E_HEALTHCHECK_TIMEOUT 으로 예산을 늘릴 수 있다."
+    )
+
+
+def should_fail_hard(env: Mapping[str, str] | None = None) -> bool:
+    """CI 에서는 서버 부재를 skip 이 아니라 **실패**로 다룬다.
+
+    `i18n-e2e.yml` 은 pytest 앞에 `curl` 루프로 서버를 보장하지만, 그 체크와 pytest
+    사이에 서버가 죽으면 16건이 skip 되고 **잡은 green 으로 끝난다.** 창은 좁지만
+    실재하고, 실패가 red 로 드러나지 않는 종류다. 로컬에서는 지금처럼 skip 이 맞다 —
+    Jekyll 을 안 띄운 채 단위 스위트를 돌리는 건 정상적인 흐름이다.
+    """
+    source = os.environ if env is None else env
+    return bool(source.get("CI"))

--- a/tests/i18n/conftest.py
+++ b/tests/i18n/conftest.py
@@ -6,63 +6,60 @@ conftest only performs a non-blocking health check so failures surface as a
 clear ``pytest.skip`` instead of an opaque Playwright timeout.
 
 Override the target URL with ``I18N_E2E_BASE_URL`` (e.g. ``http://127.0.0.1:4000``).
+
+The health-check logic itself lives in ``tests/_i18n_healthcheck.py`` so it can be
+unit-tested — a conftest is not importable by name, which is why the 30s wait loop
+had never been covered. See that module for why "nothing is listening" and
+"listening but not ready" must be told apart.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import time
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 import pytest
-
-DEFAULT_BASE_URL = "http://127.0.0.1:4000"
-HEALTHCHECK_TIMEOUT_S = float(os.environ.get("I18N_E2E_HEALTHCHECK_TIMEOUT", "30"))
-HEALTHCHECK_INTERVAL_S = 0.5
+from _i18n_healthcheck import (
+    FAST_FAIL_GRACE_S,
+    HEALTHCHECK_INTERVAL_S,
+    HEALTHCHECK_TIMEOUT_S,
+    resolve_base_url,
+    should_fail_hard,
+    unreachable_message,
+    wait_for_server,
+)
 
 # The root conftest's autouse ``sleep_calls`` fixture swaps ``time.sleep`` for a
-# no-op recorder. This poll needs real wall-clock — without it the loop below
-# spins the CPU until the 30s deadline instead of waiting between attempts — so
-# bind the real function at import, before any fixture can replace it.
+# recorder that skips any delay >= 0.25s — and ``HEALTHCHECK_INTERVAL_S`` is 0.5.
+# Without a real sleep the poll below would spin the CPU instead of waiting
+# between attempts, so bind the real function at import, before any fixture can
+# replace it.
 _REAL_SLEEP = time.sleep
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
-def _resolve_base_url() -> str:
-    return os.environ.get("I18N_E2E_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
-
-
-def _wait_for_server(url: str, timeout_s: float) -> bool:
-    """Poll the homepage until it returns any response or timeout elapses."""
-    deadline = time.monotonic() + timeout_s
-    last_error: Exception | None = None
-    while time.monotonic() < deadline:
-        try:
-            with urllib.request.urlopen(url + "/", timeout=2) as resp:  # noqa: S310
-                if 200 <= resp.status < 500:
-                    return True
-        except (urllib.error.URLError, ConnectionError, TimeoutError) as exc:
-            last_error = exc
-        _REAL_SLEEP(HEALTHCHECK_INTERVAL_S)
-    if last_error is not None:
-        print(f"[i18n-e2e] healthcheck failed for {url}: {last_error}")  # noqa: T201
-    return False
-
-
 @pytest.fixture(scope="session")
 def base_url() -> str:
     """Resolve the Jekyll preview base URL and verify the server is reachable."""
-    url = _resolve_base_url()
-    if not _wait_for_server(url, HEALTHCHECK_TIMEOUT_S):
-        pytest.skip(
-            f"Jekyll preview at {url} is unreachable; "
-            "start `bundle exec jekyll serve --port 4000` or set I18N_E2E_BASE_URL."
-        )
-    return url
+    url = resolve_base_url()
+    probe = wait_for_server(
+        url,
+        HEALTHCHECK_TIMEOUT_S,
+        FAST_FAIL_GRACE_S,
+        interval_s=HEALTHCHECK_INTERVAL_S,
+        sleep=_REAL_SLEEP,
+    )
+    if probe.ok:
+        return url
+
+    message = unreachable_message(url, probe)
+    if should_fail_hard():
+        # CI 에서 서버가 사라지면 skip 이 아니라 red 여야 한다 — 그러지 않으면 e2e 가
+        # "16 skipped" 로 조용히 통과한다.
+        pytest.fail(message)
+    pytest.skip(message)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_backfill_images.py
+++ b/tests/test_backfill_images.py
@@ -1,0 +1,598 @@
+"""tests/test_backfill_images.py — backfill_images 단위 테스트."""
+
+import importlib.util
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import backfill_images as bi
+import pytest
+
+# ---------------------------------------------------------------------------
+# get_post_type
+# ---------------------------------------------------------------------------
+
+
+class TestGetPostType:
+    def test_extracts_slug_from_standard_filename(self):
+        assert bi.get_post_type("2026-08-25-daily-crypto-news-digest.md") == "daily-crypto-news-digest"
+
+    def test_extracts_basename_from_full_path(self):
+        assert bi.get_post_type("/some/dir/2026-08-25-daily-security-report.md") == "daily-security-report"
+
+    def test_weekly_investment_digest_collapses_date_suffix(self):
+        filename = "2026-08-25-weekly-investment-digest-2026-08-18.md"
+        assert bi.get_post_type(filename) == "weekly-investment-digest"
+
+    def test_no_match_returns_none(self):
+        assert bi.get_post_type("not-a-valid-post-filename.md") is None
+
+    def test_missing_extension_returns_none(self):
+        assert bi.get_post_type("2026-08-25-daily-crypto-news-digest") is None
+
+
+# ---------------------------------------------------------------------------
+# get_date_from_filename
+# ---------------------------------------------------------------------------
+
+
+class TestGetDateFromFilename:
+    def test_extracts_date_prefix(self):
+        assert bi.get_date_from_filename("2026-08-25-test-post.md") == "2026-08-25"
+
+    def test_no_date_returns_none(self):
+        assert bi.get_date_from_filename("test-post.md") is None
+
+    def test_malformed_date_single_digit_month_returns_none(self):
+        assert bi.get_date_from_filename("2026-8-25-test-post.md") is None
+
+
+# ---------------------------------------------------------------------------
+# parse_frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrontmatter:
+    def test_parses_fields_and_body(self):
+        content = '---\ntitle: Test Post\ndescription: "A description here"\ndate: 2026-08-25\n---\nBody text.\n'
+        fm, body = bi.parse_frontmatter(content)
+        assert fm == {"title": "Test Post", "description": "A description here", "date": "2026-08-25"}
+        assert body == "Body text."
+
+    def test_strips_single_and_double_quotes(self):
+        content = "---\ntitle: 'Single'\ndescription: \"Double\"\n---\nbody"
+        fm, _ = bi.parse_frontmatter(content)
+        assert fm["title"] == "Single"
+        assert fm["description"] == "Double"
+
+    def test_no_frontmatter_returns_empty_dict_and_original_body(self):
+        content = "그냥 본문 내용입니다."
+        fm, body = bi.parse_frontmatter(content)
+        assert fm == {}
+        assert body == content
+
+    def test_unclosed_frontmatter_returns_empty_dict_and_original_body(self):
+        content = "---\ntitle: Test\n계속되는 내용, 닫는 구분자가 없음"
+        fm, body = bi.parse_frontmatter(content)
+        assert fm == {}
+        assert body == content
+
+    def test_line_without_colon_is_ignored(self):
+        content = "---\ntitle: Test\n콜론이없는줄\n---\nbody"
+        fm, _ = bi.parse_frontmatter(content)
+        assert fm == {"title": "Test"}
+
+    def test_empty_content(self):
+        fm, body = bi.parse_frontmatter("")
+        assert fm == {}
+        assert body == ""
+
+
+# ---------------------------------------------------------------------------
+# needs_image_refresh
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsImageRefresh:
+    def test_missing_file_returns_false(self, tmp_path):
+        assert bi.needs_image_refresh(str(tmp_path / "missing.md")) is False
+
+    def test_no_image_field_returns_true(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text("---\ntitle: Test\n---\nbody\n", encoding="utf-8")
+        assert bi.needs_image_refresh(str(p)) is True
+
+    def test_generic_og_prefix_returns_true(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text('---\nimage: "/assets/images/og-default.png"\n---\nbody\n', encoding="utf-8")
+        assert bi.needs_image_refresh(str(p)) is True
+
+    def test_generic_generated_og_prefix_returns_true(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text('---\nimage: "/assets/images/generated/og-briefing.png"\n---\nbody\n', encoding="utf-8")
+        assert bi.needs_image_refresh(str(p)) is True
+
+    def test_specific_generated_image_returns_false(self, tmp_path):
+        p = tmp_path / "post.md"
+        image = "/assets/images/generated/news-briefing-crypto-2026-08-25.png"
+        p.write_text(f'---\nimage: "{image}"\n---\nbody\n', encoding="utf-8")
+        assert bi.needs_image_refresh(str(p)) is False
+
+
+# ---------------------------------------------------------------------------
+# needs_image
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsImage:
+    def test_missing_file_returns_false(self, tmp_path):
+        assert bi.needs_image(str(tmp_path / "missing.md")) is False
+
+    def test_no_image_field_returns_true(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text("---\ntitle: Test\n---\nbody\n", encoding="utf-8")
+        assert bi.needs_image(str(p)) is True
+
+    def test_default_placeholder_returns_true(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text('---\nimage: "/assets/images/og-default.png"\n---\nbody\n', encoding="utf-8")
+        assert bi.needs_image(str(p)) is True
+
+    def test_missing_disk_file_returns_true(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("backfill_images.REPO_ROOT", str(tmp_path))
+        p = tmp_path / "post.md"
+        p.write_text('---\nimage: "/assets/images/generated/foo.png"\n---\nbody\n', encoding="utf-8")
+        assert bi.needs_image(str(p)) is True
+
+    def test_existing_disk_file_returns_false(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("backfill_images.REPO_ROOT", str(tmp_path))
+        img_dir = tmp_path / "assets" / "images" / "generated"
+        img_dir.mkdir(parents=True)
+        (img_dir / "foo.png").write_text("png", encoding="utf-8")
+        p = tmp_path / "post.md"
+        p.write_text('---\nimage: "/assets/images/generated/foo.png"\n---\nbody\n', encoding="utf-8")
+        assert bi.needs_image(str(p)) is False
+
+    def test_non_absolute_image_path_returns_false(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text('---\nimage: "relative/path.png"\n---\nbody\n', encoding="utf-8")
+        assert bi.needs_image(str(p)) is False
+
+
+# ---------------------------------------------------------------------------
+# extract_themes
+# ---------------------------------------------------------------------------
+
+
+class TestExtractThemes:
+    def test_extracts_section_name_count_and_emoji(self):
+        content = (
+            "intro line\n"
+            "## 비트코인 시장\n"
+            "- BTC 상승세 지속\n"
+            "- ETH 강세\n"
+            "- 알트코인 회복\n"
+            "## 규제 동향\n"
+            "- SEC 조사 발표\n"
+        )
+        themes = bi.extract_themes(content, "daily-crypto-news-digest")
+        assert themes[0]["name"] == "비트코인 시장"
+        assert themes[0]["count"] == 3
+        assert themes[0]["emoji"] == "\U0001f4b0"  # 비트코인 키워드 매칭
+        assert themes[1]["name"] == "규제 동향"
+        assert themes[1]["emoji"] == "⚖️"  # 규제 키워드 매칭
+
+    def test_default_emoji_cycle_for_unknown_post_type(self):
+        content = "## A\n- x\n## B\n- y\n"
+        themes = bi.extract_themes(content, "totally-unknown-post-type")
+        assert themes[0]["emoji"] == bi.DEFAULT_EMOJIS[0]
+        assert themes[1]["emoji"] == bi.DEFAULT_EMOJIS[1]
+
+    def test_max_themes_limits_result(self):
+        sections = "".join(f"## Section {i}\n- item\n" for i in range(7))
+        themes = bi.extract_themes(sections, "daily-news-summary", max_themes=3)
+        assert len(themes) == 3
+
+    def test_no_headings_returns_empty_list(self):
+        assert bi.extract_themes("no headings here, just text", "daily-news-summary") == []
+
+    def test_bullets_before_first_heading_are_discarded(self):
+        content = "- orphan bullet 1\n- orphan bullet 2\n## Real Section\n- real bullet\n"
+        themes = bi.extract_themes(content, "daily-news-summary")
+        assert len(themes) == 1
+        assert themes[0]["count"] == 1
+
+    def test_keywords_captured_from_bullets(self):
+        content = "## 시장 동향\n- 비트코인 급등 소식\n- 이더리움 강세 지속\n"
+        themes = bi.extract_themes(content, "daily-crypto-news-digest")
+        assert len(themes[0]["keywords"]) > 0
+
+    def test_section_count_defaults_to_one_without_bullets(self):
+        content = "## Empty Section\n\n## Next Section\n- bullet\n"
+        themes = bi.extract_themes(content, "daily-news-summary")
+        assert themes[0]["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# extract_categories_for_weekly
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCategoriesForWeekly:
+    def test_extracts_name_and_count(self):
+        content = "## 암호화폐\n- 뉴스1\n- 뉴스2\n## 주식\n- 뉴스3\n"
+        categories = bi.extract_categories_for_weekly(content)
+        assert categories == [{"name": "암호화폐", "count": 2}, {"name": "주식", "count": 1}]
+
+    def test_caps_at_eight_categories(self):
+        sections = "".join(f"## Section {i}\n- item\n" for i in range(10))
+        categories = bi.extract_categories_for_weekly(sections)
+        assert len(categories) == 8
+
+    def test_no_headings_returns_empty_list(self):
+        assert bi.extract_categories_for_weekly("no headings here") == []
+
+
+# ---------------------------------------------------------------------------
+# extract_source_data
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSourceData:
+    def test_extracts_telegram_count(self):
+        result = bi.extract_source_data("Telegram 채널에서 10건 발견")
+        assert result == [{"name": "Telegram", "count": 10}]
+
+    def test_extracts_korean_source_name(self):
+        result = bi.extract_source_data("텔레그램에서 5건 발견되었습니다")
+        assert result == [{"name": "텔레그램", "count": 5}]
+
+    def test_zero_count_excluded(self):
+        result = bi.extract_source_data("Telegram 0건 수집됨")
+        assert result == []
+
+    def test_dedups_by_name_case_insensitive(self):
+        content = "Telegram 5건 수집, 이후 telegram 3건 추가 수집"
+        result = bi.extract_source_data(content)
+        assert len(result) == 1
+
+    def test_no_match_returns_empty_list(self):
+        assert bi.extract_source_data("아무 소스 정보도 없는 문장입니다") == []
+
+
+# ---------------------------------------------------------------------------
+# _match_emoji
+# ---------------------------------------------------------------------------
+
+
+class TestMatchEmoji:
+    def test_matches_keyword_case_insensitively(self):
+        emoji_map = {"BTC": "\U0001f4b0"}
+        assert bi._match_emoji("btc 급등", emoji_map, idx=0) == "\U0001f4b0"
+
+    def test_falls_back_to_default_emoji_cycle(self):
+        assert bi._match_emoji("아무 매칭도 없는 섹션", {}, idx=0) == bi.DEFAULT_EMOJIS[0]
+        assert bi._match_emoji("아무 매칭도 없는 섹션", {}, idx=5) == bi.DEFAULT_EMOJIS[0]
+        assert bi._match_emoji("아무 매칭도 없는 섹션", {}, idx=1) == bi.DEFAULT_EMOJIS[1]
+
+    def test_first_matching_keyword_wins(self):
+        emoji_map = {"규제": "⚖️", "거래": "\U0001f4b0"}
+        assert bi._match_emoji("규제 및 거래 동향", emoji_map, idx=0) == "⚖️"
+
+
+# ---------------------------------------------------------------------------
+# _dedupe_keywords
+# ---------------------------------------------------------------------------
+
+
+class TestDedupeKeywords:
+    def test_removes_case_insensitive_duplicates(self):
+        assert bi._dedupe_keywords(["BTC", "btc", "ETH"]) == ["BTC", "ETH"]
+
+    def test_filters_single_char_keywords(self):
+        assert bi._dedupe_keywords(["a", "bb"]) == ["bb"]
+
+    def test_preserves_original_order(self):
+        assert bi._dedupe_keywords(["ETH", "BTC", "eth"]) == ["ETH", "BTC"]
+
+    def test_empty_list_returns_empty_list(self):
+        assert bi._dedupe_keywords([]) == []
+
+
+# ---------------------------------------------------------------------------
+# extract_total_count
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTotalCount:
+    def test_pattern_chong_geon(self):
+        assert bi.extract_total_count("오늘 총 42건 수집되었습니다.") == 42
+
+    def test_pattern_chong_sujip_geon(self):
+        assert bi.extract_total_count("총 수집 건수: 15건") == 15
+
+    def test_pattern_geon_ui_news(self):
+        assert bi.extract_total_count("오늘 20건의 뉴스가 있었습니다.") == 20
+
+    def test_pattern_geon_eul_jeongri(self):
+        assert bi.extract_total_count("30건을 정리했습니다.") == 30
+
+    def test_pattern_geon_eul_yosong(self):
+        assert bi.extract_total_count("30건을 요약했습니다.") == 30
+
+    def test_no_match_returns_zero(self):
+        assert bi.extract_total_count("아무 숫자도 없는 문장입니다.") == 0
+
+
+# ---------------------------------------------------------------------------
+# _load_image_generator
+# ---------------------------------------------------------------------------
+
+
+class TestLoadImageGenerator:
+    """`_load_image_generator` 는 **실제 패키지를 디스크에서 로드**하는 경로를 검증한다.
+
+    그래서 이 클래스만 `sys.modules` 복원이 필요하다. 프로덕션 코드는
+    `sys.modules["common.image_generator"] = mod` 로 **이미 import 된 모듈 객체를
+    통째로 교체**한다(`backfill_images.py:527`). conftest 의 autouse
+    `_isolate_generated_images` 는 그 시점에 존재하던 **옛 객체**에
+    `IMAGES_DIR` 를 monkeypatch 해 둔 상태이므로, 교체 이후의 `import
+    common.image_generator` 는 리다이렉트가 없는 새 객체를 받는다.
+
+    monkeypatch 의 되돌리기도 옛 객체에 적용되므로 오염이 **세션 끝까지 남는다** —
+    2026-08-25 실측으로 이 파일을 함께 돌리면 `test_image_generator_coverage.py`
+    등에서 트리-쓰기 가드가 60건 red 였다
+    (`테스트가 커밋된 레포 트리에 썼습니다: assets/images/generated/...`).
+
+    단독 실행에서는 절대 안 보인다 — 파일 하나만 돌리면 오염을 관측할 다른 테스트가
+    없기 때문이다. 그래서 격리를 이 클래스에 못박는다.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_image_generator_modules(self):
+        """교체된 `sys.modules` 엔트리를 원래 객체로 되돌린다."""
+        names = ("common.image_generator", "scripts.common.image_generator", "image_generator")
+        saved = {name: sys.modules.get(name) for name in names}
+        try:
+            yield
+        finally:
+            for name, mod in saved.items():
+                if mod is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = mod
+
+    def _reset(self, monkeypatch):
+        monkeypatch.setattr("backfill_images._IMG_GEN_LOADED", False)
+        monkeypatch.setattr("backfill_images._IMG_GEN_MOD", None)
+
+    def test_loads_real_module_with_expected_api(self, monkeypatch):
+        self._reset(monkeypatch)
+        mod = bi._load_image_generator()
+        assert mod is not None
+        assert hasattr(mod, "generate_news_briefing_card")
+        assert hasattr(mod, "generate_news_summary_card")
+
+    def test_caches_after_first_successful_call(self, monkeypatch):
+        self._reset(monkeypatch)
+        original_spec_from_file_location = importlib.util.spec_from_file_location
+        spy = MagicMock(side_effect=original_spec_from_file_location)
+        monkeypatch.setattr(importlib.util, "spec_from_file_location", spy)
+
+        first = bi._load_image_generator()
+        second = bi._load_image_generator()
+
+        assert first is second
+        assert spy.call_count == 1
+
+    def test_returns_none_when_spec_loader_missing(self, monkeypatch):
+        self._reset(monkeypatch)
+        monkeypatch.setattr(importlib.util, "spec_from_file_location", lambda *a, **kw: None)
+
+        assert bi._load_image_generator() is None
+
+
+# ---------------------------------------------------------------------------
+# generate_image_for_post
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateImageForPost:
+    def _fake_img_mod(self):
+        return SimpleNamespace(
+            generate_news_briefing_card=MagicMock(return_value="/assets/images/generated/mock-briefing.png"),
+            generate_news_summary_card=MagicMock(return_value="/assets/images/generated/mock-summary.png"),
+        )
+
+    def test_returns_none_when_generator_unavailable(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("backfill_images._load_image_generator", lambda: None)
+        result = bi.generate_image_for_post(str(tmp_path / "post.md"), "daily-crypto-news-digest", "2026-08-25", "본문")
+        assert result is None
+
+    def test_returns_existing_disk_image_without_generating(self, monkeypatch, tmp_path):
+        img_mod = self._fake_img_mod()
+        monkeypatch.setattr("backfill_images._load_image_generator", lambda: img_mod)
+        monkeypatch.setattr("backfill_images.IMAGES_DIR", str(tmp_path))
+        (tmp_path / "news-briefing-crypto-2026-08-25.png").write_text("png", encoding="utf-8")
+
+        result = bi.generate_image_for_post("unused.md", "daily-crypto-news-digest", "2026-08-25", "본문")
+
+        assert result == "/assets/images/generated/news-briefing-crypto-2026-08-25.png"
+        img_mod.generate_news_briefing_card.assert_not_called()
+
+    def test_uses_fallback_prefix_when_available_on_disk(self, monkeypatch, tmp_path):
+        img_mod = self._fake_img_mod()
+        monkeypatch.setattr("backfill_images._load_image_generator", lambda: img_mod)
+        monkeypatch.setattr("backfill_images.IMAGES_DIR", str(tmp_path))
+        (tmp_path / "market-snapshot-2026-08-25.png").write_text("png", encoding="utf-8")
+
+        result = bi.generate_image_for_post("unused.md", "daily-stock-news-digest", "2026-08-25", "본문")
+
+        assert result == "/assets/images/generated/market-snapshot-2026-08-25.png"
+
+    def test_weekly_digest_uses_summary_card_with_categories(self, monkeypatch, tmp_path):
+        img_mod = self._fake_img_mod()
+        monkeypatch.setattr("backfill_images._load_image_generator", lambda: img_mod)
+        monkeypatch.setattr("backfill_images.IMAGES_DIR", str(tmp_path))
+        body = "## 암호화폐\n- 뉴스1\n- 뉴스2\n## 주식\n- 뉴스3\n"
+
+        result = bi.generate_image_for_post("unused.md", "weekly-investment-digest", "2026-08-25", body)
+
+        assert result == "/assets/images/generated/mock-summary.png"
+        img_mod.generate_news_summary_card.assert_called_once()
+        call_kwargs = img_mod.generate_news_summary_card.call_args.kwargs
+        assert call_kwargs["date_str"] == "2026-08-25"
+        assert call_kwargs["filename"] == "news-summary-weekly-2026-08-25.png"
+
+    def test_default_type_uses_briefing_card_with_extracted_themes(self, monkeypatch, tmp_path):
+        img_mod = self._fake_img_mod()
+        monkeypatch.setattr("backfill_images._load_image_generator", lambda: img_mod)
+        monkeypatch.setattr("backfill_images.IMAGES_DIR", str(tmp_path))
+        body = "## 비트코인 소식\n- BTC 상승\n- ETH 강세\n"
+
+        result = bi.generate_image_for_post("unused.md", "daily-crypto-news-digest", "2026-08-25", body)
+
+        assert result == "/assets/images/generated/mock-briefing.png"
+        call_kwargs = img_mod.generate_news_briefing_card.call_args.kwargs
+        assert call_kwargs["category"] == "Crypto News Briefing"
+        assert len(call_kwargs["themes"]) == 1
+
+    def test_empty_body_falls_back_to_single_category_theme(self, monkeypatch, tmp_path):
+        img_mod = self._fake_img_mod()
+        monkeypatch.setattr("backfill_images._load_image_generator", lambda: img_mod)
+        monkeypatch.setattr("backfill_images.IMAGES_DIR", str(tmp_path))
+
+        bi.generate_image_for_post("unused.md", "daily-crypto-news-digest", "2026-08-25", "")
+
+        call_kwargs = img_mod.generate_news_briefing_card.call_args.kwargs
+        themes = call_kwargs["themes"]
+        assert len(themes) == 1
+        assert themes[0]["name"] == "Crypto News Briefing"
+
+
+# ---------------------------------------------------------------------------
+# update_frontmatter_image
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFrontmatterImage:
+    def test_inserts_image_after_description_line(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text('---\ntitle: Test\ndescription: "desc here"\ndate: 2026-08-25\n---\nbody\n', encoding="utf-8")
+
+        result = bi.update_frontmatter_image(str(p), "/assets/images/generated/foo.png")
+
+        assert result is True
+        content = p.read_text(encoding="utf-8")
+        assert 'image: "/assets/images/generated/foo.png"' in content
+        lines = content.splitlines()
+        desc_idx = next(i for i, line in enumerate(lines) if line.startswith("description:"))
+        assert lines[desc_idx + 1].startswith("image:")
+
+    def test_replaces_existing_image_field(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text('---\ntitle: Test\nimage: "/old/path.png"\n---\nbody\n', encoding="utf-8")
+
+        bi.update_frontmatter_image(str(p), "/new/path.png")
+
+        content = p.read_text(encoding="utf-8")
+        assert "/old/path.png" not in content
+        assert 'image: "/new/path.png"' in content
+
+    def test_inserts_at_end_when_no_description_field(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text("---\ntitle: Test\n---\nbody\n", encoding="utf-8")
+
+        result = bi.update_frontmatter_image(str(p), "/assets/images/generated/foo.png")
+
+        assert result is True
+        assert 'image: "/assets/images/generated/foo.png"' in p.read_text(encoding="utf-8")
+
+    def test_returns_false_without_frontmatter(self, tmp_path):
+        p = tmp_path / "post.md"
+        original = "no frontmatter body text"
+        p.write_text(original, encoding="utf-8")
+
+        result = bi.update_frontmatter_image(str(p), "/foo.png")
+
+        assert result is False
+        assert p.read_text(encoding="utf-8") == original
+
+    def test_returns_false_when_frontmatter_unclosed(self, tmp_path):
+        p = tmp_path / "post.md"
+        original = "---\ntitle: Test\nno closing delimiter here"
+        p.write_text(original, encoding="utf-8")
+
+        result = bi.update_frontmatter_image(str(p), "/foo.png")
+
+        assert result is False
+        assert p.read_text(encoding="utf-8") == original
+
+    def test_preserves_korean_body_content(self, tmp_path):
+        p = tmp_path / "post.md"
+        p.write_text("---\ntitle: Test\n---\n본문 내용입니다.\n", encoding="utf-8")
+
+        bi.update_frontmatter_image(str(p), "/foo.png")
+
+        assert "본문 내용입니다." in p.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# collect_target_posts
+# ---------------------------------------------------------------------------
+
+
+class TestCollectTargetPosts:
+    def test_missing_posts_dir_returns_empty_list(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("backfill_images.POSTS_DIR", str(tmp_path / "nonexistent"))
+        assert bi.collect_target_posts() == []
+
+    def test_collects_only_posts_missing_image(self, tmp_path, monkeypatch):
+        posts_dir = tmp_path / "_posts"
+        posts_dir.mkdir()
+        monkeypatch.setattr("backfill_images.POSTS_DIR", str(posts_dir))
+        monkeypatch.setattr("backfill_images.REPO_ROOT", str(tmp_path))
+
+        no_image = posts_dir / "2026-08-25-a.md"
+        no_image.write_text("---\ntitle: A\n---\nbody\n", encoding="utf-8")
+
+        img_dir = tmp_path / "assets" / "images" / "generated"
+        img_dir.mkdir(parents=True)
+        (img_dir / "foo.png").write_text("png", encoding="utf-8")
+        has_image = posts_dir / "2026-08-25-b.md"
+        has_image.write_text('---\ntitle: B\nimage: "/assets/images/generated/foo.png"\n---\nbody\n', encoding="utf-8")
+
+        result = bi.collect_target_posts()
+
+        assert result == [str(no_image)]
+
+    def test_files_param_excludes_paths_outside_posts_dir(self, tmp_path, monkeypatch):
+        posts_dir = tmp_path / "_posts"
+        posts_dir.mkdir()
+        monkeypatch.setattr("backfill_images.POSTS_DIR", str(posts_dir))
+        monkeypatch.setattr("backfill_images.REPO_ROOT", str(tmp_path))
+
+        inside = posts_dir / "2026-08-25-a.md"
+        inside.write_text("---\ntitle: A\n---\nbody\n", encoding="utf-8")
+        outside = tmp_path / "2026-08-25-outside.md"
+        outside.write_text("---\ntitle: Outside\n---\nbody\n", encoding="utf-8")
+
+        result = bi.collect_target_posts(files=[str(inside), str(outside)])
+
+        assert result == [str(inside)]
+
+    def test_rewrite_og_flag_includes_generic_og_image_posts(self, tmp_path, monkeypatch):
+        posts_dir = tmp_path / "_posts"
+        posts_dir.mkdir()
+        monkeypatch.setattr("backfill_images.POSTS_DIR", str(posts_dir))
+        monkeypatch.setattr("backfill_images.REPO_ROOT", str(tmp_path))
+
+        img_dir = tmp_path / "assets" / "images" / "generated"
+        img_dir.mkdir(parents=True)
+        (img_dir / "og-foo.png").write_text("png", encoding="utf-8")
+
+        post = posts_dir / "2026-08-25-og.md"
+        post.write_text('---\ntitle: OG\nimage: "/assets/images/generated/og-foo.png"\n---\nbody\n', encoding="utf-8")
+
+        assert bi.collect_target_posts(rewrite_og=False) == []
+        assert bi.collect_target_posts(rewrite_og=True) == [str(post)]

--- a/tests/test_backfill_signal_history_btc_price.py
+++ b/tests/test_backfill_signal_history_btc_price.py
@@ -1,0 +1,607 @@
+"""Tests for scripts/backfill_signal_history_btc_price.py.
+
+핵심 검증 대상:
+- fetch_btc_price 3단 폴백 체인(CoinGecko → Blockchain.com → yfinance)의 순서와
+  실제로 응답한 공급자 라벨(provider) 일치 여부
+- 각 개별 fetcher(_fetch_coingecko/_fetch_blockchain_com/_fetch_yfinance)의
+  파싱/예외 처리
+- 정확도 계산(_verdict_to_direction/_price_direction/_compute_accuracy_block)
+- backfill()의 dry-run/apply 분기, predecessor accuracy 삽입, 원자적 저장
+- main()의 --apply 플래그 라우팅
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import backfill_signal_history_btc_price as bfp
+
+# ── 테스트 헬퍼 ─────────────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    """request_with_retry가 반환하는 requests.Response를 대신하는 더미."""
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeCloseSeries:
+    """yfinance DataFrame의 ``hist["Close"]`` 컬럼 대체 더미."""
+
+    def __init__(self, value: float | None) -> None:
+        self._value = value
+
+    @property
+    def iloc(self) -> list:
+        return [self._value]
+
+
+class _FakeHistFrame:
+    """yfinance ``ticker.history(...)`` 반환값 대체 더미."""
+
+    def __init__(self, empty: bool, close: float | None = None) -> None:
+        self.empty = empty
+        self._close = close
+
+    def __getitem__(self, key: str) -> _FakeCloseSeries:
+        assert key == "Close"
+        return _FakeCloseSeries(self._close)
+
+
+def _make_yf_stub(hist_frame: _FakeHistFrame | None = None, raise_on_history: bool = False):
+    """yfinance 모듈 대체 스텁 (하우스 스타일: test_generate_market_summary.py 참고)."""
+
+    def _history(start=None, end=None):
+        if raise_on_history:
+            raise RuntimeError("yfinance boom")
+        return hist_frame
+
+    ticker = type("T", (), {"history": staticmethod(_history)})()
+    return type("yf", (), {"Ticker": staticmethod(lambda sym: ticker)})()
+
+
+def _make_entry(
+    date: str,
+    verdict: str = "혼조",
+    score: float = 50.0,
+    btc_price: float | None = 60000.0,
+) -> dict[str, Any]:
+    return {
+        "date": date,
+        "composite_score": score,
+        "verdict": verdict,
+        "btc_price": btc_price,
+    }
+
+
+def _write_history(path, entries: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(entries, f, ensure_ascii=False, indent=2)
+
+
+def _load_history(path) -> list[dict]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+# ── _fetch_coingecko ─────────────────────────────────────────────────────────
+
+
+class TestFetchCoingecko:
+    def test_success_returns_price(self, monkeypatch):
+        payload = {"market_data": {"current_price": {"usd": 65000.5}}}
+        monkeypatch.setattr(bfp, "request_with_retry", lambda *a, **kw: _FakeResponse(payload))
+        price = bfp._fetch_coingecko("2026-04-15")
+        assert price == 65000.5
+        assert isinstance(price, float)
+
+    def test_missing_price_returns_none(self, monkeypatch):
+        payload = {"market_data": {"current_price": {}}}
+        monkeypatch.setattr(bfp, "request_with_retry", lambda *a, **kw: _FakeResponse(payload))
+        assert bfp._fetch_coingecko("2026-04-15") is None
+
+    def test_missing_market_data_returns_none(self, monkeypatch):
+        monkeypatch.setattr(bfp, "request_with_retry", lambda *a, **kw: _FakeResponse({}))
+        assert bfp._fetch_coingecko("2026-04-15") is None
+
+    def test_request_exception_returns_none(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise ConnectionError("network down")
+
+        monkeypatch.setattr(bfp, "request_with_retry", _raise)
+        assert bfp._fetch_coingecko("2026-04-15") is None
+
+    def test_uses_dd_mm_yyyy_date_format_in_url(self, monkeypatch):
+        captured = {}
+
+        def _capture(url, **kw):
+            captured["url"] = url
+            return _FakeResponse({"market_data": {"current_price": {"usd": 1.0}}})
+
+        monkeypatch.setattr(bfp, "request_with_retry", _capture)
+        bfp._fetch_coingecko("2026-04-15")
+        assert "date=15-04-2026" in captured["url"]
+
+
+# ── _fetch_blockchain_com ─────────────────────────────────────────────────────
+
+
+class TestFetchBlockchainCom:
+    def test_exact_date_match_returns_price(self, monkeypatch):
+        target_dt = datetime(2026, 4, 15, 12, 0, tzinfo=UTC)
+        payload = {"values": [{"x": int(target_dt.timestamp()), "y": 65000.0}]}
+        monkeypatch.setattr(bfp, "request_with_retry", lambda *a, **kw: _FakeResponse(payload))
+        price = bfp._fetch_blockchain_com("2026-04-15")
+        assert price == 65000.0
+
+    def test_no_exact_match_falls_back_to_last_value(self, monkeypatch):
+        other_dt = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
+        payload = {
+            "values": [
+                {"x": int(other_dt.timestamp()), "y": 60000.0},
+                {"x": int(other_dt.timestamp()) + 3600, "y": 61000.0},
+            ]
+        }
+        monkeypatch.setattr(bfp, "request_with_retry", lambda *a, **kw: _FakeResponse(payload))
+        price = bfp._fetch_blockchain_com("2026-04-15")
+        # 정확히 일치하는 날짜가 없으면 범위 내 마지막 값을 사용
+        assert price == 61000.0
+
+    def test_empty_values_returns_none(self, monkeypatch):
+        monkeypatch.setattr(bfp, "request_with_retry", lambda *a, **kw: _FakeResponse({"values": []}))
+        assert bfp._fetch_blockchain_com("2026-04-15") is None
+
+    def test_missing_values_key_returns_none(self, monkeypatch):
+        monkeypatch.setattr(bfp, "request_with_retry", lambda *a, **kw: _FakeResponse({}))
+        assert bfp._fetch_blockchain_com("2026-04-15") is None
+
+    def test_request_exception_returns_none(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(bfp, "request_with_retry", _raise)
+        assert bfp._fetch_blockchain_com("2026-04-15") is None
+
+
+# ── _fetch_yfinance ────────────────────────────────────────────────────────────
+
+
+class TestFetchYfinance:
+    def test_import_unavailable_returns_none(self, monkeypatch):
+        # sys.modules에 None을 넣으면 실제 설치 여부와 무관하게 ImportError 강제 발생
+        monkeypatch.setitem(sys.modules, "yfinance", None)
+        assert bfp._fetch_yfinance("2026-04-15") is None
+
+    def test_success_returns_close_price(self, monkeypatch):
+        stub = _make_yf_stub(_FakeHistFrame(empty=False, close=64500.25))
+        monkeypatch.setitem(sys.modules, "yfinance", stub)
+        price = bfp._fetch_yfinance("2026-04-15")
+        assert price == 64500.25
+        assert isinstance(price, float)
+
+    def test_empty_history_returns_none(self, monkeypatch):
+        stub = _make_yf_stub(_FakeHistFrame(empty=True))
+        monkeypatch.setitem(sys.modules, "yfinance", stub)
+        assert bfp._fetch_yfinance("2026-04-15") is None
+
+    def test_ticker_history_raises_returns_none(self, monkeypatch):
+        stub = _make_yf_stub(raise_on_history=True)
+        monkeypatch.setitem(sys.modules, "yfinance", stub)
+        assert bfp._fetch_yfinance("2026-04-15") is None
+
+
+# ── fetch_btc_price — 3단 폴백 체인 ────────────────────────────────────────────
+
+
+class TestFetchBtcPriceFallbackChain:
+    def test_coingecko_success_short_circuits_rest_of_chain(self, monkeypatch):
+        blockchain_mock = MagicMock()
+        yfinance_mock = MagicMock()
+        monkeypatch.setattr(bfp, "_fetch_coingecko", lambda d: 65000.0)
+        monkeypatch.setattr(bfp, "_fetch_blockchain_com", blockchain_mock)
+        monkeypatch.setattr(bfp, "_fetch_yfinance", yfinance_mock)
+
+        price, source = bfp.fetch_btc_price("2026-04-15")
+
+        assert price == 65000.0
+        assert source == "CoinGecko"
+        blockchain_mock.assert_not_called()
+        yfinance_mock.assert_not_called()
+
+    def test_falls_through_to_blockchain_when_coingecko_fails(self, monkeypatch):
+        yfinance_mock = MagicMock()
+        monkeypatch.setattr(bfp, "_fetch_coingecko", lambda d: None)
+        monkeypatch.setattr(bfp, "_fetch_blockchain_com", lambda d: 52000.0)
+        monkeypatch.setattr(bfp, "_fetch_yfinance", yfinance_mock)
+
+        price, source = bfp.fetch_btc_price("2026-04-15")
+
+        assert price == 52000.0
+        assert source == "Blockchain.com"
+        yfinance_mock.assert_not_called()
+
+    def test_falls_through_to_yfinance_when_first_two_fail(self, monkeypatch):
+        monkeypatch.setattr(bfp, "_fetch_coingecko", lambda d: None)
+        monkeypatch.setattr(bfp, "_fetch_blockchain_com", lambda d: None)
+        monkeypatch.setattr(bfp, "_fetch_yfinance", lambda d: 71234.5)
+
+        price, source = bfp.fetch_btc_price("2026-04-15")
+
+        assert price == 71234.5
+        assert source == "yfinance"
+
+    def test_all_providers_fail_returns_none_and_none_source(self, monkeypatch):
+        monkeypatch.setattr(bfp, "_fetch_coingecko", lambda d: None)
+        monkeypatch.setattr(bfp, "_fetch_blockchain_com", lambda d: None)
+        monkeypatch.setattr(bfp, "_fetch_yfinance", lambda d: None)
+
+        price, source = bfp.fetch_btc_price("2026-04-15")
+
+        assert price is None
+        assert source == "none"
+
+    def test_source_label_matches_provider_that_actually_answered(self, monkeypatch):
+        """세 값이 모두 다를 때 반환된 price가 실제로 응답한 provider의 값과 일치해야 한다."""
+        monkeypatch.setattr(bfp, "_fetch_coingecko", lambda d: None)
+        monkeypatch.setattr(bfp, "_fetch_blockchain_com", lambda d: 11111.0)
+        monkeypatch.setattr(bfp, "_fetch_yfinance", lambda d: 99999.0)
+
+        price, source = bfp.fetch_btc_price("2026-04-15")
+
+        # yfinance 값(99999.0)이 아니라 실제로 응답한 Blockchain.com 값이어야 함
+        assert price == 11111.0
+        assert source == "Blockchain.com"
+
+
+# ── _verdict_to_direction ─────────────────────────────────────────────────────
+
+
+class TestVerdictToDirection:
+    def test_bullish_maps_to_up(self):
+        assert bfp._verdict_to_direction("강세") == "상승"
+
+    def test_bearish_maps_to_down(self):
+        assert bfp._verdict_to_direction("약세") == "하락"
+
+    def test_mixed_maps_to_none(self):
+        assert bfp._verdict_to_direction("혼조") is None
+
+    def test_neutral_maps_to_none(self):
+        assert bfp._verdict_to_direction("중립") is None
+
+    def test_empty_string_maps_to_none(self):
+        assert bfp._verdict_to_direction("") is None
+
+
+# ── _price_direction ──────────────────────────────────────────────────────────
+
+
+class TestPriceDirection:
+    def test_above_positive_threshold_is_up(self):
+        assert bfp._price_direction(1.5) == "상승"
+
+    def test_below_negative_threshold_is_down(self):
+        assert bfp._price_direction(-1.5) == "하락"
+
+    def test_exactly_positive_threshold_is_flat(self):
+        assert bfp._price_direction(1.0) == "보합"
+
+    def test_exactly_negative_threshold_is_flat(self):
+        assert bfp._price_direction(-1.0) == "보합"
+
+    def test_zero_is_flat(self):
+        assert bfp._price_direction(0.0) == "보합"
+
+
+# ── _compute_accuracy_block ────────────────────────────────────────────────────
+
+
+class TestComputeAccuracyBlock:
+    def test_bullish_prediction_correct_when_price_rises(self):
+        prev_entry = {"btc_price": 60000.0, "verdict": "강세", "composite_score": 70.0}
+        block = bfp._compute_accuracy_block(prev_entry, today_btc_price=65000.0)
+
+        assert block["predicted_verdict"] == "강세"
+        assert block["predicted_score"] == 70.0
+        assert block["actual_direction"] == "상승"
+        assert block["correct"] is True
+
+    def test_bearish_prediction_correct_when_price_falls(self):
+        prev_entry = {"btc_price": 60000.0, "verdict": "약세", "composite_score": 30.0}
+        block = bfp._compute_accuracy_block(prev_entry, today_btc_price=55000.0)
+
+        assert block["actual_direction"] == "하락"
+        assert block["correct"] is True
+
+    def test_bullish_prediction_incorrect_when_price_falls(self):
+        prev_entry = {"btc_price": 60000.0, "verdict": "강세", "composite_score": 70.0}
+        block = bfp._compute_accuracy_block(prev_entry, today_btc_price=55000.0)
+
+        assert block["actual_direction"] == "하락"
+        assert block["correct"] is False
+
+    def test_mixed_verdict_yields_none_correct(self):
+        prev_entry = {"btc_price": 60000.0, "verdict": "혼조", "composite_score": 50.0}
+        block = bfp._compute_accuracy_block(prev_entry, today_btc_price=65000.0)
+
+        assert block["correct"] is None
+
+    def test_change_pct_rounded_to_4_decimals(self):
+        prev_entry = {"btc_price": 60000.0, "verdict": "혼조"}
+        block = bfp._compute_accuracy_block(prev_entry, today_btc_price=65000.0)
+        # (65000 - 60000) / 60000 * 100 = 8.33333...
+        assert block["actual_price_change_pct"] == round((65000.0 - 60000.0) / 60000.0 * 100, 4)
+
+    def test_missing_composite_score_defaults_to_zero(self):
+        prev_entry = {"btc_price": 60000.0, "verdict": "혼조"}
+        block = bfp._compute_accuracy_block(prev_entry, today_btc_price=61000.0)
+        assert block["predicted_score"] == 0.0
+
+    def test_evaluated_at_matches_module_now_utc(self):
+        prev_entry = {"btc_price": 60000.0, "verdict": "혼조"}
+        block = bfp._compute_accuracy_block(prev_entry, today_btc_price=61000.0)
+        assert block["evaluated_at"] == bfp._NOW_UTC
+
+
+# ── load_history / save_history ───────────────────────────────────────────────
+
+
+class TestLoadSaveHistory:
+    def test_round_trip(self, tmp_path):
+        entries = [_make_entry("2026-04-15", verdict="강세", btc_price=61000.0)]
+        target = str(tmp_path / "history.json")
+        bfp.save_history(target, entries)
+        assert bfp.load_history(target) == entries
+
+    def test_save_is_atomic_no_leftover_tmp_file(self, tmp_path):
+        target = tmp_path / "history.json"
+        bfp.save_history(str(target), [_make_entry("2026-04-15")])
+        assert target.exists()
+        assert not (tmp_path / "history.json.tmp").exists()
+
+    def test_save_preserves_korean_text(self, tmp_path):
+        target = str(tmp_path / "history.json")
+        entries = [_make_entry("2026-04-15", verdict="강세")]
+        bfp.save_history(target, entries)
+        raw = (tmp_path / "history.json").read_text(encoding="utf-8")
+        assert "강세" in raw  # ensure_ascii=False
+
+
+# ── backfill — 상태 없음/조기 반환 ─────────────────────────────────────────────
+
+
+class TestBackfillNoNullEntries:
+    def test_prints_nothing_to_backfill(self, tmp_path, monkeypatch, capsys):
+        path = tmp_path / "signal_history.json"
+        entries = [_make_entry("2026-04-14", btc_price=60000.0)]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+
+        bfp.backfill(dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "Nothing to backfill" in out
+
+    def test_apply_does_not_touch_file(self, tmp_path, monkeypatch):
+        path = tmp_path / "signal_history.json"
+        entries = [_make_entry("2026-04-14", btc_price=60000.0)]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+
+        bfp.backfill(dry_run=False)
+
+        assert _load_history(path) == entries
+
+
+# ── backfill — dry-run ────────────────────────────────────────────────────────
+
+
+class TestBackfillDryRun:
+    def test_reports_found_null_dates_and_does_not_write(self, tmp_path, monkeypatch, capsys):
+        path = tmp_path / "signal_history.json"
+        entries = [
+            _make_entry("2026-04-14", btc_price=60000.0),
+            _make_entry("2026-04-15", btc_price=None),
+        ]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (65000.0, "CoinGecko"))
+
+        bfp.backfill(dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "Found 1 null btc_price entries" in out
+        assert "2026-04-15" in out
+        assert "DRY-RUN: no changes written" in out
+        # dry-run이므로 파일은 변경되지 않아야 함
+        assert _load_history(path) == entries
+
+    def test_dry_run_shows_predecessor_accuracy_preview(self, tmp_path, monkeypatch, capsys):
+        path = tmp_path / "signal_history.json"
+        entries = [
+            _make_entry("2026-04-14", verdict="강세", score=70.0, btc_price=60000.0),
+            _make_entry("2026-04-15", btc_price=None),
+        ]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (65000.0, "CoinGecko"))
+
+        bfp.backfill(dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "BACKFILL 2026-04-15" in out
+        assert "predecessor 2026-04-14 accuracy" in out
+
+
+# ── backfill — apply ──────────────────────────────────────────────────────────
+
+
+class TestBackfillApply:
+    def test_applies_price_and_predecessor_accuracy(self, tmp_path, monkeypatch):
+        path = tmp_path / "signal_history.json"
+        entries = [
+            _make_entry("2026-04-14", verdict="강세", score=70.0, btc_price=60000.0),
+            _make_entry("2026-04-15", verdict="약세", score=20.0, btc_price=None),
+        ]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (65000.0, "CoinGecko"))
+
+        bfp.backfill(dry_run=False)
+
+        reloaded = _load_history(path)
+        assert reloaded[1]["btc_price"] == 65000.0
+        assert reloaded[1]["backfilled_at"] == bfp._NOW_UTC
+
+        acc = reloaded[0]["accuracy"]
+        assert acc["predicted_verdict"] == "강세"
+        assert acc["predicted_score"] == 70.0
+        assert acc["actual_direction"] == "상승"
+        assert acc["correct"] is True
+        assert acc["backfilled_at"] == bfp._NOW_UTC
+
+    def test_predecessor_without_btc_price_skips_accuracy(self, tmp_path, monkeypatch):
+        path = tmp_path / "signal_history.json"
+        entries = [
+            _make_entry("2026-04-14", btc_price=None),
+            _make_entry("2026-04-15", btc_price=None),
+        ]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (65000.0, "CoinGecko"))
+
+        bfp.backfill(dry_run=False)
+
+        reloaded = _load_history(path)
+        assert "accuracy" not in reloaded[0]
+        assert reloaded[1]["btc_price"] == 65000.0
+
+    def test_no_predecessor_entry_still_backfills_price(self, tmp_path, monkeypatch):
+        path = tmp_path / "signal_history.json"
+        entries = [_make_entry("2026-04-20", btc_price=None)]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (72000.0, "Blockchain.com"))
+
+        bfp.backfill(dry_run=False)
+
+        reloaded = _load_history(path)
+        assert reloaded[0]["btc_price"] == 72000.0
+
+    def test_all_providers_fail_leaves_btc_price_null(self, tmp_path, monkeypatch, capsys):
+        path = tmp_path / "signal_history.json"
+        entries = [_make_entry("2026-04-15", btc_price=None)]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (None, "none"))
+
+        bfp.backfill(dry_run=False)
+
+        out = capsys.readouterr().out
+        assert "SKIP 2026-04-15" in out
+        reloaded = _load_history(path)
+        assert reloaded[0]["btc_price"] is None
+        assert "WARNING" in out
+        assert "1 null btc_price entries remain" in out
+
+    def test_validation_reports_zero_remaining_after_full_success(self, tmp_path, monkeypatch, capsys):
+        path = tmp_path / "signal_history.json"
+        entries = [_make_entry("2026-04-15", btc_price=None)]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (65000.0, "CoinGecko"))
+
+        bfp.backfill(dry_run=False)
+
+        out = capsys.readouterr().out
+        assert "VALIDATION: 0 null btc_price entries remain." in out
+
+    def test_prints_applied_count(self, tmp_path, monkeypatch, capsys):
+        path = tmp_path / "signal_history.json"
+        entries = [
+            _make_entry("2026-04-14", btc_price=None),
+            _make_entry("2026-04-15", btc_price=None),
+        ]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (65000.0, "CoinGecko"))
+
+        bfp.backfill(dry_run=False)
+
+        out = capsys.readouterr().out
+        assert "APPLIED: 2 entries backfilled" in out
+
+    def test_mixed_success_and_failure_across_multiple_null_entries(self, tmp_path, monkeypatch, capsys):
+        path = tmp_path / "signal_history.json"
+        entries = [
+            _make_entry("2026-04-14", verdict="강세", score=70.0, btc_price=None),
+            _make_entry("2026-04-15", verdict="약세", score=20.0, btc_price=None),
+        ]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+
+        fetch_map = {
+            "2026-04-14": (58000.0, "CoinGecko"),
+            "2026-04-15": (None, "none"),
+        }
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: fetch_map[d])
+
+        bfp.backfill(dry_run=False)
+
+        reloaded = _load_history(path)
+        assert reloaded[0]["btc_price"] == 58000.0
+        assert reloaded[1]["btc_price"] is None
+
+        out = capsys.readouterr().out
+        assert "SKIP 2026-04-15" in out
+        assert "WARNING: 1 null btc_price entries remain" in out
+
+
+# ── main() ────────────────────────────────────────────────────────────────────
+
+
+class TestMain:
+    def test_default_invokes_dry_run(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["backfill_signal_history_btc_price.py"])
+        calls = {}
+        monkeypatch.setattr(bfp, "backfill", lambda dry_run: calls.setdefault("dry_run", dry_run))
+
+        bfp.main()
+
+        assert calls["dry_run"] is True
+        out = capsys.readouterr().out
+        assert "Mode: DRY-RUN" in out
+
+    def test_apply_flag_invokes_apply_mode(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["backfill_signal_history_btc_price.py", "--apply"])
+        calls = {}
+        monkeypatch.setattr(bfp, "backfill", lambda dry_run: calls.setdefault("dry_run", dry_run))
+
+        bfp.main()
+
+        assert calls["dry_run"] is False
+        out = capsys.readouterr().out
+        assert "Mode: APPLY" in out
+
+    def test_end_to_end_apply_writes_real_history_file(self, tmp_path, monkeypatch):
+        """main() → backfill() → fetch_btc_price() → save_history() 전체 경로 통합 검증."""
+        path = tmp_path / "signal_history.json"
+        entries = [_make_entry("2026-04-15", verdict="강세", score=80.0, btc_price=None)]
+        _write_history(path, entries)
+        monkeypatch.setattr(bfp, "_HISTORY_FILE", str(path))
+        monkeypatch.setattr(bfp, "fetch_btc_price", lambda d: (66000.0, "CoinGecko"))
+        monkeypatch.setattr(sys, "argv", ["backfill_signal_history_btc_price.py", "--apply"])
+
+        bfp.main()
+
+        reloaded = _load_history(path)
+        assert reloaded[0]["btc_price"] == 66000.0
+        assert reloaded[0]["backfilled_at"] == bfp._NOW_UTC

--- a/tests/test_gsc_index_audit.py
+++ b/tests/test_gsc_index_audit.py
@@ -1,0 +1,626 @@
+"""tests/test_gsc_index_audit.py — gsc_index_audit 단위 테스트.
+
+GSC URL Inspection API 결과를 버킷팅해 Markdown 리포트로 만드는 CLI.
+``_require_googleapi``의 성공/실패 분기는 ``sys.modules`` 조작으로 설치 여부와
+무관하게 결정적으로 강제하고, ``_inspect_urls``는 fake service 객체로
+성공/429 백오프/연속 실패 컷오프/max-per-state 캡을 검증한다.
+``LOCAL_SITEMAP``은 문자열 경로 기반 monkeypatch로 tmp_path 로 리다이렉트해
+프로덕션 경로 상수를 테스트에 끌어들이지 않는다.
+"""
+
+import sys
+import types
+import urllib.request
+import xml.etree.ElementTree as ET
+
+import gsc_index_audit as gia
+import pytest
+
+_SITE = "https://investing.2twodragon.com"
+
+
+def _resp(coverage_state: str, **overrides) -> dict:
+    """URL Inspection API 응답 payload를 최소 형태로 생성."""
+    isr = {
+        "coverageState": coverage_state,
+        "verdict": overrides.get("verdict", "NEUTRAL"),
+        "lastCrawlTime": overrides.get("lastCrawlTime", ""),
+        "googleCanonical": overrides.get("googleCanonical", ""),
+        "robotsTxtState": overrides.get("robotsTxtState", ""),
+        "indexingState": overrides.get("indexingState", ""),
+    }
+    return {"inspectionResult": {"indexStatusResult": isr}}
+
+
+class _ScriptedService:
+    """urlInspection().index().inspect(body=...).execute() 체인을 흉내내는 fake.
+
+    ``script`` 에 순서대로 나열된 항목을 ``execute()`` 호출마다 하나씩 소비한다.
+    ``dict`` 는 정상 응답으로 반환하고, ``Exception`` 인스턴스는 그대로 raise 한다.
+    """
+
+    def __init__(self, script: list):
+        self._script = list(script)
+        self.call_count = 0
+
+    def urlInspection(self):
+        return self
+
+    def index(self):
+        return self
+
+    def inspect(self, body):
+        assert "inspectionUrl" in body
+        return self
+
+    def execute(self):
+        effect = self._script[self.call_count]
+        self.call_count += 1
+        if isinstance(effect, Exception):
+            raise effect
+        return effect
+
+
+# ---------------------------------------------------------------------------
+# 상수 고정 (회귀 감지용 pin)
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_bucket_order(self):
+        assert gia._BUCKET_ORDER == [
+            "NOT_FOUND_404",
+            "DISCOVERED_NOT_INDEXED",
+            "CRAWLED_NOT_INDEXED",
+            "REDIRECT",
+            "BLOCKED",
+            "OTHER",
+            "INDEXED",
+        ]
+
+    def test_bucket_labels_cover_every_order_entry(self):
+        for bucket in gia._BUCKET_ORDER:
+            assert bucket in gia._BUCKET_LABELS
+
+    def test_max_consecutive_failures(self):
+        assert gia._MAX_CONSECUTIVE_FAILURES == 50
+
+    def test_quota_sleep(self):
+        assert gia._QUOTA_SLEEP == 60.0
+
+
+# ---------------------------------------------------------------------------
+# _require_googleapi
+# ---------------------------------------------------------------------------
+
+
+class TestRequireGoogleapi:
+    def test_missing_dependency_exits_2(self, monkeypatch):
+        # 설치 여부와 무관하게 ImportError 분기를 강제: sys.modules 에 None 을
+        # 심으면 import 머신이 실제 패키지 존재 여부와 상관없이 ImportError 를 낸다.
+        monkeypatch.setitem(sys.modules, "google.oauth2", None)
+        monkeypatch.setitem(sys.modules, "googleapiclient.discovery", None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gia._require_googleapi()
+        assert exc_info.value.code == 2
+
+    def test_present_returns_service_account_and_build(self, monkeypatch):
+        fake_oauth2 = types.ModuleType("google.oauth2")
+        fake_oauth2.service_account = object()
+        fake_discovery = types.ModuleType("googleapiclient.discovery")
+        fake_discovery.build = lambda *a, **kw: "sentinel-service"
+
+        monkeypatch.setitem(sys.modules, "google.oauth2", fake_oauth2)
+        monkeypatch.setitem(sys.modules, "googleapiclient.discovery", fake_discovery)
+
+        service_account, build = gia._require_googleapi()
+        assert service_account is fake_oauth2.service_account
+        assert build is fake_discovery.build
+
+
+# ---------------------------------------------------------------------------
+# _build_service
+# ---------------------------------------------------------------------------
+
+
+class TestBuildService:
+    def _clean_env(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    def test_missing_env_exits_2(self, monkeypatch):
+        self._clean_env(monkeypatch)
+        with pytest.raises(SystemExit) as exc_info:
+            gia._build_service()
+        assert exc_info.value.code == 2
+
+    def test_missing_credentials_file_exits_2(self, monkeypatch, tmp_path):
+        self._clean_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "gone.json"))
+        with pytest.raises(SystemExit) as exc_info:
+            gia._build_service()
+        assert exc_info.value.code == 2
+
+    def test_success_builds_with_credentials_and_scopes(self, monkeypatch, tmp_path):
+        self._clean_env(monkeypatch)
+        cred_file = tmp_path / "creds.json"
+        cred_file.write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(cred_file))
+
+        calls = {}
+
+        class _FakeCredentials:
+            @staticmethod
+            def from_service_account_file(path, scopes):
+                calls["path"] = path
+                calls["scopes"] = scopes
+                return "creds-object"
+
+        class _FakeServiceAccountModule:
+            Credentials = _FakeCredentials
+
+        def _fake_build(name, version, credentials, cache_discovery):
+            calls["build_args"] = (name, version, credentials, cache_discovery)
+            return "built-service"
+
+        monkeypatch.setattr(gia, "_require_googleapi", lambda: (_FakeServiceAccountModule, _fake_build))
+
+        result = gia._build_service()
+
+        assert result == "built-service"
+        assert calls["path"] == str(cred_file)
+        assert calls["scopes"] == ["https://www.googleapis.com/auth/webmasters"]
+        assert calls["build_args"] == ("searchconsole", "v1", "creds-object", False)
+
+
+# ---------------------------------------------------------------------------
+# _load_sitemap_urls
+# ---------------------------------------------------------------------------
+
+
+def _write_sitemap(path, urls, with_namespace=True):
+    if with_namespace:
+        body = "".join(f"<url><loc>{u}</loc></url>" for u in urls)
+        xml = f'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">{body}</urlset>'
+    else:
+        body = "".join(f"<url><loc>{u}</loc></url>" for u in urls)
+        xml = f"<urlset>{body}</urlset>"
+    path.write_text(xml, encoding="utf-8")
+
+
+class TestLoadSitemapUrls:
+    def test_local_file_with_namespace(self, tmp_path, monkeypatch):
+        local = tmp_path / "sitemap.xml"
+        _write_sitemap(local, [f"{_SITE}/a/", f"{_SITE}/b/"], with_namespace=True)
+        monkeypatch.setattr("gsc_index_audit.LOCAL_SITEMAP", local)
+
+        urls = gia._load_sitemap_urls()
+        assert urls == [f"{_SITE}/a/", f"{_SITE}/b/"]
+
+    def test_local_file_without_namespace_falls_back_to_unqualified_loc(self, tmp_path, monkeypatch):
+        local = tmp_path / "sitemap.xml"
+        _write_sitemap(local, [f"{_SITE}/c/"], with_namespace=False)
+        monkeypatch.setattr("gsc_index_audit.LOCAL_SITEMAP", local)
+
+        urls = gia._load_sitemap_urls()
+        assert urls == [f"{_SITE}/c/"]
+
+    def test_local_file_empty_returns_empty_list(self, tmp_path, monkeypatch):
+        local = tmp_path / "sitemap.xml"
+        _write_sitemap(local, [], with_namespace=True)
+        monkeypatch.setattr("gsc_index_audit.LOCAL_SITEMAP", local)
+
+        assert gia._load_sitemap_urls() == []
+
+    def test_missing_local_file_downloads_from_live_url(self, tmp_path, monkeypatch):
+        missing = tmp_path / "no-such-sitemap.xml"
+        monkeypatch.setattr("gsc_index_audit.LOCAL_SITEMAP", missing)
+
+        root = ET.Element("urlset")
+        loc = ET.SubElement(root, "loc")
+        loc.text = f"{_SITE}/downloaded/"
+        content = ET.tostring(root)
+
+        class _FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return content
+
+        def _fake_urlopen(url, timeout):
+            assert url == gia.SITEMAP_URL
+            return _FakeResponse()
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+        urls = gia._load_sitemap_urls()
+        assert urls == [f"{_SITE}/downloaded/"]
+
+    def test_download_failure_exits_1(self, tmp_path, monkeypatch):
+        missing = tmp_path / "no-such-sitemap.xml"
+        monkeypatch.setattr("gsc_index_audit.LOCAL_SITEMAP", missing)
+
+        def _fake_urlopen(url, timeout):
+            raise OSError("network unreachable")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gia._load_sitemap_urls()
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _extract_category
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCategory:
+    def test_root_url_with_trailing_slash(self):
+        assert gia._extract_category(f"{_SITE}/") == "(root)"
+
+    def test_root_url_without_trailing_slash(self):
+        assert gia._extract_category(_SITE) == "(root)"
+
+    def test_single_segment_category(self):
+        assert gia._extract_category(f"{_SITE}/crypto-news/") == "crypto-news"
+
+    def test_nested_path_uses_first_segment(self):
+        assert gia._extract_category(f"{_SITE}/crypto-news/some-post/") == "crypto-news"
+
+    def test_no_trailing_slash_still_extracts_first_segment(self):
+        assert gia._extract_category(f"{_SITE}/about") == "about"
+
+
+# ---------------------------------------------------------------------------
+# _classify
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        ("coverage_state", "expected_bucket"),
+        [
+            ("Submitted and indexed", "INDEXED"),
+            ("Indexed, not submitted in sitemap", "INDEXED"),
+            ("Discovered - currently not indexed", "DISCOVERED_NOT_INDEXED"),
+            ("Crawled - currently not indexed", "CRAWLED_NOT_INDEXED"),
+            ("Not found (404)", "NOT_FOUND_404"),
+            ("Page with redirect", "REDIRECT"),
+            ("Blocked by robots.txt", "BLOCKED"),
+            ("Blocked due to access forbidden (403)", "BLOCKED"),
+        ],
+    )
+    def test_known_states(self, coverage_state, expected_bucket):
+        assert gia._classify(coverage_state) == expected_bucket
+
+    def test_unknown_state_maps_to_other(self):
+        assert gia._classify("Some new state Google invented") == "OTHER"
+
+    def test_empty_state_maps_to_other(self):
+        assert gia._classify("") == "OTHER"
+
+
+# ---------------------------------------------------------------------------
+# _inspect_urls
+# ---------------------------------------------------------------------------
+
+
+class TestInspectUrls:
+    def test_success_buckets_by_coverage_state(self):
+        service = _ScriptedService([_resp("Submitted and indexed")])
+        buckets = gia._inspect_urls(service, [f"{_SITE}/a/"], f"{_SITE}/", 0.0, 100)
+
+        assert list(buckets.keys()) == ["INDEXED"]
+        assert buckets["INDEXED"][0]["url"] == f"{_SITE}/a/"
+        assert buckets["INDEXED"][0]["coverageState"] == "Submitted and indexed"
+
+    def test_quota_hit_backs_off_and_retries_successfully(self, sleep_calls):
+        service = _ScriptedService(
+            [
+                Exception("429 Too Many Requests"),
+                _resp("Submitted and indexed"),
+            ]
+        )
+        buckets = gia._inspect_urls(service, [f"{_SITE}/a/"], f"{_SITE}/", 0.0, 100)
+
+        assert sleep_calls.calls == [60.0]
+        assert buckets["INDEXED"][0]["url"] == f"{_SITE}/a/"
+        assert service.call_count == 2
+
+    def test_quota_hit_retry_also_fails_counts_as_one_failure(self, sleep_calls):
+        service = _ScriptedService(
+            [
+                Exception("429 Too Many Requests"),
+                Exception("still failing"),
+            ]
+        )
+        buckets = gia._inspect_urls(service, [f"{_SITE}/a/"], f"{_SITE}/", 0.0, 100)
+
+        assert sleep_calls.calls == [60.0]
+        assert buckets == {}
+
+    def test_non_quota_exception_continues_to_next_url(self):
+        service = _ScriptedService(
+            [
+                Exception("boom"),
+                _resp("Submitted and indexed"),
+            ]
+        )
+        buckets = gia._inspect_urls(service, [f"{_SITE}/bad/", f"{_SITE}/good/"], f"{_SITE}/", 0.0, 100)
+
+        assert buckets["INDEXED"][0]["url"] == f"{_SITE}/good/"
+        assert sum(len(v) for v in buckets.values()) == 1
+
+    def test_consecutive_failure_cutoff_breaks_before_exhausting_urls(self):
+        # 정확히 50건의 실패만 소비되고 나머지 10개 URL은 손대지 않아야 한다.
+        # 컷오프가 없다면 51번째 execute() 호출에서 스크립트 소진으로
+        # IndexError 가 나 테스트가 실패하므로, 이 자체가 회귀 감지 장치다.
+        script = [Exception("boom")] * 50
+        urls = [f"{_SITE}/{i}/" for i in range(60)]
+        service = _ScriptedService(script)
+
+        buckets = gia._inspect_urls(service, urls, f"{_SITE}/", 0.0, 100)
+
+        assert buckets == {}
+        assert service.call_count == 50
+
+    def test_max_per_state_cap_limits_stored_entries_but_inspects_all(self):
+        script = [_resp("Submitted and indexed") for _ in range(5)]
+        urls = [f"{_SITE}/{i}/" for i in range(5)]
+        service = _ScriptedService(script)
+
+        buckets = gia._inspect_urls(service, urls, f"{_SITE}/", 0.0, 2)
+
+        assert len(buckets["INDEXED"]) == 2
+        assert service.call_count == 5
+
+    def test_max_per_state_zero_means_unlimited(self):
+        script = [_resp("Submitted and indexed") for _ in range(5)]
+        urls = [f"{_SITE}/{i}/" for i in range(5)]
+        service = _ScriptedService(script)
+
+        buckets = gia._inspect_urls(service, urls, f"{_SITE}/", 0.0, 0)
+
+        assert len(buckets["INDEXED"]) == 5
+
+    def test_unmapped_coverage_state_lands_in_other_bucket(self):
+        service = _ScriptedService([_resp("A brand new coverage state")])
+        buckets = gia._inspect_urls(service, [f"{_SITE}/a/"], f"{_SITE}/", 0.0, 100)
+
+        assert buckets["OTHER"][0]["coverageState"] == "A brand new coverage state"
+
+
+# ---------------------------------------------------------------------------
+# _build_report
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReport:
+    def test_full_report_sections_and_cap_note(self):
+        buckets = {
+            "NOT_FOUND_404": [
+                {
+                    "url": f"{_SITE}/gone/",
+                    "coverageState": "Not found (404)",
+                    "verdict": "FAIL",
+                    "lastCrawlTime": "",
+                    "googleCanonical": "",
+                    "robotsTxtState": "",
+                    "indexingState": "",
+                }
+            ],
+            "INDEXED": [
+                {
+                    "url": f"{_SITE}/crypto-news/a/",
+                    "coverageState": "Submitted and indexed",
+                    "verdict": "PASS",
+                    "lastCrawlTime": "2026-08-01T00:00:00Z",
+                    "googleCanonical": f"{_SITE}/crypto-news/a/",
+                    "robotsTxtState": "ALLOWED",
+                    "indexingState": "INDEXING_ALLOWED",
+                },
+                {
+                    "url": f"{_SITE}/crypto-news/b/",
+                    "coverageState": "Submitted and indexed",
+                    "verdict": "PASS",
+                    "lastCrawlTime": "2026-08-02T00:00:00Z",
+                    "googleCanonical": "",
+                    "robotsTxtState": "ALLOWED",
+                    "indexingState": "INDEXING_ALLOWED",
+                },
+            ],
+        }
+        all_urls = [f"{_SITE}/gone/", f"{_SITE}/crypto-news/a/", f"{_SITE}/crypto-news/b/"]
+
+        report = gia._build_report(
+            buckets=buckets,
+            all_urls=all_urls,
+            inspected_count=3,
+            max_per_state=2,
+            audit_date="2026-08-25",
+        )
+
+        assert "# GSC Index Audit — 2026-08-25" in report
+        assert "Inspected **3** of **3** sitemap URLs" in report
+        assert "| 404 Not Found | 1 | 33.3% |" in report
+        assert "| Indexed | 2+ | 66.7% |" in report
+        assert "| **Total stored** | 3 | 100% |" in report
+        assert "| crypto-news | 2 | 2 | 0 | 0 | 0 | 0 |" in report
+        assert "| gone | 1 | 0 | 0 | 0 | 1 | 0 |" in report
+        assert "## 404 URLs" in report
+        assert f"`{_SITE}/gone/`" in report
+        # INDEXED 는 detail_buckets 목록에 없으므로 상세 섹션이 없어야 한다.
+        assert "## Indexed" not in report
+        assert "**Fix 1 404s**" in report
+        assert "Discovered-NI" not in report
+        assert "Crawled-NI" not in report
+        assert "Re-run this audit" in report
+
+    def test_empty_buckets_avoids_zero_division_and_skips_detail_sections(self):
+        report = gia._build_report(
+            buckets={},
+            all_urls=[],
+            inspected_count=0,
+            max_per_state=100,
+            audit_date="2026-08-25",
+        )
+
+        assert "Inspected **0** of **0** sitemap URLs" in report
+        assert "| 404 Not Found | 0 | 0.0% |" in report
+        assert "| **Total stored** | 0 | 100% |" in report
+        assert "## 404 URLs" not in report
+        assert "**Fix" not in report
+        assert "Re-run this audit" in report
+
+    def test_canonical_note_only_shown_when_canonical_differs_from_url(self):
+        buckets = {
+            "REDIRECT": [
+                {
+                    "url": f"{_SITE}/old/",
+                    "coverageState": "Page with redirect",
+                    "verdict": "NEUTRAL",
+                    "lastCrawlTime": "",
+                    "googleCanonical": f"{_SITE}/new/",
+                    "robotsTxtState": "",
+                    "indexingState": "",
+                }
+            ]
+        }
+        report = gia._build_report(
+            buckets=buckets,
+            all_urls=[f"{_SITE}/old/"],
+            inspected_count=1,
+            max_per_state=100,
+            audit_date="2026-08-25",
+        )
+        assert f"→ canonical: {_SITE}/new/" in report
+        assert "never crawled" in report
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_requires_source_group(self):
+        with pytest.raises(SystemExit) as exc_info:
+            gia.main([])
+        assert exc_info.value.code == 2
+
+    def test_from_sitemap_and_urls_are_mutually_exclusive(self):
+        with pytest.raises(SystemExit) as exc_info:
+            gia.main(["--from-sitemap", "--urls", f"{_SITE}/a/"])
+        assert exc_info.value.code == 2
+
+    def test_no_urls_returns_1(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gia, "_load_sitemap_urls", list)
+        rc = gia.main(["--from-sitemap", "--output", str(tmp_path / "out.md")])
+        assert rc == 1
+
+    def test_urls_mode_full_flow_writes_report(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("GSC_SITE_URL", raising=False)
+        captured = {}
+
+        monkeypatch.setattr(gia, "_build_service", lambda: "fake-service")
+
+        def _fake_inspect_urls(service, urls, site_url, sleep_s, max_per_state):
+            captured["service"] = service
+            captured["urls"] = urls
+            captured["site_url"] = site_url
+            captured["sleep_s"] = sleep_s
+            captured["max_per_state"] = max_per_state
+            return {
+                "INDEXED": [
+                    {
+                        "url": urls[0],
+                        "coverageState": "Submitted and indexed",
+                        "verdict": "PASS",
+                        "lastCrawlTime": "",
+                        "googleCanonical": "",
+                        "robotsTxtState": "",
+                        "indexingState": "",
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(gia, "_inspect_urls", _fake_inspect_urls)
+
+        output = tmp_path / "audit.md"
+        rc = gia.main(
+            [
+                "--urls",
+                f"{_SITE}/a/",
+                f"{_SITE}/b/",
+                "--output",
+                str(output),
+                "--site",
+                _SITE,
+                "--limit",
+                "1",
+                "--sleep",
+                "0.0",
+                "--max-per-state",
+                "5",
+            ]
+        )
+
+        assert rc == 0
+        # --limit 1 이 URL 목록에 적용되어야 한다.
+        assert captured["urls"] == [f"{_SITE}/a/"]
+        # --site 에 슬래시가 없으면 자동으로 붙는다.
+        assert captured["site_url"] == f"{_SITE}/"
+        assert captured["sleep_s"] == 0.0
+        assert captured["max_per_state"] == 5
+        assert captured["service"] == "fake-service"
+
+        assert output.exists()
+        content = output.read_text(encoding="utf-8")
+        assert "# GSC Index Audit" in content
+
+        out = capsys.readouterr().out
+        assert "Audit complete — 1 URLs inspected" in out
+        assert f"Report: {output}" in out
+
+    def test_default_site_used_when_no_site_arg_or_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GSC_SITE_URL", raising=False)
+        captured = {}
+
+        monkeypatch.setattr(gia, "_build_service", lambda: "fake-service")
+
+        def _fake_inspect_urls(service, urls, site_url, sleep_s, max_per_state):
+            captured["site_url"] = site_url
+            return {}
+
+        monkeypatch.setattr(gia, "_inspect_urls", _fake_inspect_urls)
+
+        output = tmp_path / "audit.md"
+        rc = gia.main(["--urls", f"{_SITE}/a/", "--output", str(output)])
+
+        assert rc == 0
+        assert captured["site_url"] == gia.DEFAULT_SITE_URL
+
+    def test_from_sitemap_wires_loaded_urls_into_inspection(self, tmp_path, monkeypatch):
+        local = tmp_path / "sitemap.xml"
+        _write_sitemap(local, [f"{_SITE}/x/", f"{_SITE}/y/"], with_namespace=True)
+        monkeypatch.setattr("gsc_index_audit.LOCAL_SITEMAP", local)
+        monkeypatch.setattr(gia, "_build_service", lambda: "fake-service")
+
+        captured = {}
+
+        def _fake_inspect_urls(service, urls, site_url, sleep_s, max_per_state):
+            captured["urls"] = urls
+            return {}
+
+        monkeypatch.setattr(gia, "_inspect_urls", _fake_inspect_urls)
+
+        output = tmp_path / "audit.md"
+        rc = gia.main(["--from-sitemap", "--output", str(output)])
+
+        assert rc == 0
+        assert captured["urls"] == [f"{_SITE}/x/", f"{_SITE}/y/"]

--- a/tests/test_i18n_healthcheck.py
+++ b/tests/test_i18n_healthcheck.py
@@ -1,0 +1,311 @@
+"""`tests/_i18n_healthcheck.py` 단위 테스트 — Playwright / Jekyll 불필요.
+
+## 왜 있나
+
+`tests/i18n/conftest.py` 의 서버 대기 루프는 conftest 안에 있어서 import 가 불가능했고,
+그래서 **한 번도 검증된 적이 없었다.** 그 사이 서버가 없을 때 30초를 통째로 태우는
+동작이 자리잡았다 (2026-08-25 실측 `16 skipped in 30.43s`, setup phase 30.40s).
+
+이 파일은 `i18n_e2e` 마커를 **일부러 붙이지 않는다.** 브라우저도 서버도 필요 없으므로
+`code-quality.yml` 의 `-m "not i18n_e2e"` 스위트에서 항상 돌아야 한다.
+
+시계와 소켓을 주입해서 실제 대기 없이 검증한다 — 유예 로직을 실제 2초 기다리며
+확인하면 이 파일 자체가 느린 테스트가 된다.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+
+import pytest
+from _i18n_healthcheck import (
+    DEFAULT_BASE_URL,
+    FAST_FAIL_GRACE_S,
+    HEALTHCHECK_INTERVAL_S,
+    HEALTHCHECK_TIMEOUT_S,
+    REASON_DEADLINE,
+    REASON_OK,
+    REASON_REFUSED,
+    Probe,
+    is_connection_refused,
+    resolve_base_url,
+    should_fail_hard,
+    unreachable_message,
+    wait_for_server,
+)
+
+
+class _FakeClock:
+    """가짜 단조 시계. **잠들 때만** 시간이 흐른다.
+
+    읽을 때마다 흐르게 만들면 `wait_for_server` 가 한 번의 반복에서 시계를 몇 번
+    읽는지에 결과가 좌우된다 — 구현의 내부 사정이 테스트 결과를 바꾸는 것이라
+    유예 시간을 검증하는 테스트가 조용히 틀린 값을 재게 된다(실제로 그렇게 짰다가
+    `test_refused_then_ready_still_succeeds` 가 2회째에 포기하는 것으로 나왔다).
+    현실과 같게, `sleep()` 이 호출될 때만 진행시킨다.
+    """
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakeResponse:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _refused() -> urllib.error.URLError:
+    """`urlopen` 이 실제로 올리는 형태 — 원 예외를 `reason` 에 감싼 URLError."""
+    return urllib.error.URLError(ConnectionRefusedError(61, "Connection refused"))
+
+
+def _timed_out() -> TimeoutError:
+    return TimeoutError("timed out")
+
+
+def _opener(outcomes):
+    """`outcomes` 를 순서대로 내놓고, 소진되면 마지막 것을 계속 반복하는 opener."""
+    calls = list(outcomes)
+
+    def open_url(_url, timeout=None):  # noqa: ARG001
+        outcome = calls.pop(0) if len(calls) > 1 else calls[0]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    return open_url
+
+
+# ---------------------------------------------------------------------------
+# refused 판별
+# ---------------------------------------------------------------------------
+
+
+def test_wrapped_connection_refused_is_detected() -> None:
+    """`urlopen` 은 원 예외를 `URLError.reason` 에 감싼다 — 그 형태를 잡아야 한다."""
+    assert is_connection_refused(_refused()) is True
+
+
+def test_bare_connection_refused_is_detected() -> None:
+    """감싸지 않고 올라오는 경로도 있다."""
+    assert is_connection_refused(ConnectionRefusedError(61, "Connection refused")) is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        TimeoutError("timed out"),
+        urllib.error.URLError("name resolution failed"),
+        urllib.error.HTTPError("http://x/", 503, "Service Unavailable", {}, None),
+    ],
+    ids=["timeout", "urlerror-str-reason", "httperror"],
+)
+def test_non_refused_failures_are_not_misread(exc: BaseException) -> None:
+    """timeout·DNS·HTTPError 는 "포트에 누가 있다" 쪽이다.
+
+    특히 `HTTPError.reason` 은 문자열이라, `isinstance` 검사가 문자열에 걸려 오탐하면
+    살아 있는 서버를 부재로 판정하게 된다.
+    """
+    assert is_connection_refused(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# fast-fail
+# ---------------------------------------------------------------------------
+
+
+def test_all_refused_gives_up_after_grace_not_full_budget() -> None:
+    """AC1 — 아무도 안 듣고 있으면 전체 예산이 아니라 유예 시간에 포기한다."""
+    clock = _FakeClock()
+    probe = wait_for_server(
+        "http://127.0.0.1:4000",
+        timeout_s=30.0,
+        grace_s=2.0,
+        opener=_opener([_refused()]),
+        sleep=clock.sleep,
+        monotonic=clock,
+    )
+
+    assert probe.ok is False
+    assert probe.reason == REASON_REFUSED
+    # 30s 예산을 다 썼다면 시도 횟수가 수십 회다. 유예 2s / 0.5s 단위이므로 한 자릿수.
+    assert probe.attempts <= 6, f"유예를 넘겨 계속 시도했다 ({probe.attempts}회)"
+
+
+def test_zero_grace_gives_up_on_first_refusal() -> None:
+    """`I18N_E2E_FAST_FAIL_GRACE=0` 은 즉시 포기를 뜻한다."""
+    clock = _FakeClock()
+    probe = wait_for_server(
+        "http://127.0.0.1:4000",
+        timeout_s=30.0,
+        grace_s=0.0,
+        opener=_opener([_refused()]),
+        sleep=clock.sleep,
+        monotonic=clock,
+    )
+
+    assert probe.reason == REASON_REFUSED
+    assert probe.attempts == 1
+
+
+def test_refused_then_ready_still_succeeds() -> None:
+    """AC2 — 유예 안에 포트가 열리면(startup race) 정상 성공이다.
+
+    `jekyll serve --detach` 는 셸 명령이 리턴한 뒤에 바인드한다. 이 케이스를 잃으면
+    "방금 serve 띄웠는데 skip 된다" 가 된다.
+    """
+    clock = _FakeClock()
+    probe = wait_for_server(
+        "http://127.0.0.1:4000",
+        timeout_s=30.0,
+        grace_s=2.0,
+        opener=_opener([_refused(), _refused(), _FakeResponse(200)]),
+        sleep=clock.sleep,
+        monotonic=clock,
+    )
+
+    assert probe.ok is True
+    assert probe.reason == REASON_OK
+    assert probe.attempts == 3
+
+
+def test_timeouts_use_the_full_budget_not_the_grace() -> None:
+    """AC3 — 바인드는 됐는데 느린 서버에는 fast-fail 이 걸리면 안 된다.
+
+    이 단언이 red 가 되지 않으면 `only_refused` 갱신이 죽은 것이다 — 그때는 느린
+    서버까지 2초 만에 포기하게 된다.
+    """
+    clock = _FakeClock()
+    probe = wait_for_server(
+        "http://127.0.0.1:4000",
+        timeout_s=10.0,
+        grace_s=2.0,
+        opener=_opener([_timed_out()]),
+        sleep=clock.sleep,
+        monotonic=clock,
+    )
+
+    assert probe.ok is False
+    assert probe.reason == REASON_DEADLINE
+    # 유예(2s = 4회)를 훨씬 넘겨 예산(10s)까지 갔어야 한다.
+    assert probe.attempts > 6, f"유예 구간에서 포기했다 ({probe.attempts}회)"
+
+
+def test_first_refused_then_timeout_switches_to_full_budget() -> None:
+    """refused 로 시작해도 non-refused 가 한 번 나오면 fast-fail 을 포기한다."""
+    clock = _FakeClock()
+    probe = wait_for_server(
+        "http://127.0.0.1:4000",
+        timeout_s=10.0,
+        grace_s=2.0,
+        opener=_opener([_refused(), _timed_out()]),
+        sleep=clock.sleep,
+        monotonic=clock,
+    )
+
+    assert probe.reason == REASON_DEADLINE
+    assert probe.attempts > 6
+
+
+def test_5xx_response_is_not_ready_but_counts_as_listening() -> None:
+    """5xx 는 준비 안 된 것이지만 포트에는 누가 있다 — fast-fail 대상이 아니다."""
+    clock = _FakeClock()
+    probe = wait_for_server(
+        "http://127.0.0.1:4000",
+        timeout_s=10.0,
+        grace_s=2.0,
+        opener=_opener([_FakeResponse(503)]),
+        sleep=clock.sleep,
+        monotonic=clock,
+    )
+
+    assert probe.reason == REASON_DEADLINE
+    assert probe.attempts > 6
+
+
+@pytest.mark.parametrize("status", [200, 301, 404, 499])
+def test_any_non_5xx_status_counts_as_ready(status: int) -> None:
+    """홈페이지가 무엇이든 돌려주면 서버는 뜬 것이다(404 도 포함)."""
+    clock = _FakeClock()
+    probe = wait_for_server(
+        "http://127.0.0.1:4000",
+        timeout_s=10.0,
+        grace_s=2.0,
+        opener=_opener([_FakeResponse(status)]),
+        sleep=clock.sleep,
+        monotonic=clock,
+    )
+
+    assert probe.ok is True
+
+
+def test_zero_timeout_never_probes() -> None:
+    """예산이 0이면 시도 자체를 하지 않는다 — 기존 동작 보존."""
+    clock = _FakeClock()
+
+    def _explode(_url, timeout=None):  # noqa: ARG001
+        raise AssertionError("timeout_s=0 인데 요청을 보냈다")
+
+    probe = wait_for_server(
+        "http://127.0.0.1:4000",
+        timeout_s=0.0,
+        grace_s=2.0,
+        opener=_explode,
+        sleep=clock.sleep,
+        monotonic=clock,
+    )
+
+    assert probe == Probe(False, REASON_DEADLINE, 0, None)
+
+
+# ---------------------------------------------------------------------------
+# 메시지 · 환경
+# ---------------------------------------------------------------------------
+
+
+def test_message_distinguishes_the_two_causes() -> None:
+    """AC6 — 두 사유가 다른 행동을 지시해야 한다."""
+    refused = unreachable_message("http://127.0.0.1:4000", Probe(False, REASON_REFUSED, 4))
+    deadline = unreachable_message("http://127.0.0.1:4000", Probe(False, REASON_DEADLINE, 60))
+
+    assert "jekyll serve" in refused, "서버를 띄우라는 지시가 없다"
+    assert "I18N_E2E_HEALTHCHECK_TIMEOUT" in deadline, "예산을 늘리라는 지시가 없다"
+    assert refused != deadline
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [({}, False), ({"CI": ""}, False), ({"CI": "true"}, True), ({"CI": "1"}, True)],
+    ids=["absent", "empty", "true", "one"],
+)
+def test_ci_turns_unreachable_into_a_hard_failure(env: dict, expected: bool) -> None:
+    """AC7 — CI 에서 서버가 사라지면 skip 이 아니라 fail 이어야 한다.
+
+    `i18n-e2e.yml` 은 pytest 앞의 `curl` 루프로 서버를 보장하지만, 그 체크와 pytest
+    사이에 서버가 죽으면 16건이 skip 되고 **잡은 green 으로 끝난다.**
+    """
+    assert should_fail_hard(env) is expected
+
+
+def test_base_url_override_and_trailing_slash() -> None:
+    assert resolve_base_url({}) == DEFAULT_BASE_URL
+    assert resolve_base_url({"I18N_E2E_BASE_URL": "http://127.0.0.1:4001/"}) == "http://127.0.0.1:4001"
+
+
+def test_module_defaults_stay_sane() -> None:
+    """AC4 의 기본값 쪽 — 상수가 조용히 어긋나면 fast-fail 이 무의미해진다."""
+    assert 0 <= FAST_FAIL_GRACE_S <= 5.0, "유예가 너무 길면 fast-fail 의 의미가 없다"
+    assert FAST_FAIL_GRACE_S < HEALTHCHECK_TIMEOUT_S, "유예가 예산보다 크면 fast-fail 이 죽은 코드다"
+    assert HEALTHCHECK_INTERVAL_S > 0

--- a/tests/test_pytest_plugin_install_sync_guard.py
+++ b/tests/test_pytest_plugin_install_sync_guard.py
@@ -69,9 +69,10 @@ _ADDOPTS_FLAGS: dict[str, str] = {
 _SLOWEST_OBSERVED_S = 1.9
 
 #: i18n 을 디셀렉트하지 않았을 때 매 런 발생하는 setup phase 실측(2026-08-25).
-#: `tests/i18n/conftest.py` 의 세션 fixture 가 `HEALTHCHECK_TIMEOUT_S=30` 동안
-#: 서버를 폴링한 뒤 skip 한다 — `16 skipped in 30.43s`.
-_I18N_HEALTHCHECK_SETUP_S = 30.4
+#: `tests/_i18n_healthcheck.py` 의 fast-fail 도입 **후** 값이다 — 도입 전에는
+#: `HEALTHCHECK_TIMEOUT_S=30` 을 꽉 채워 `16 skipped in 30.43s` 였다.
+#: 지금은 refused 가 이어지면 `FAST_FAIL_GRACE_S=2.0` 에서 포기한다 (`16 skipped in 2.05s`).
+_I18N_HEALTHCHECK_SETUP_S = 2.1
 
 
 def _ini_options() -> dict:
@@ -191,16 +192,17 @@ def test_code_quality_deselects_i18n_e2e() -> None:
     """`code-quality.yml` 은 `-m "not i18n_e2e"` 로 Playwright 스위트를 빼야 한다.
 
     이 잡은 :4000 에 Jekyll 을 띄우지 않으므로 `tests/i18n/**` 16건은 **항상**
-    skip 된다. 문제는 공짜로 skip 되지 않는다는 것이다 — `tests/i18n/conftest.py`
-    의 세션 fixture 가 `HEALTHCHECK_TIMEOUT_S=30` 동안 서버를 폴링한 뒤에야
-    skip 한다. 2026-08-25 실측: `16 skipped in 30.43s`, 그중 setup phase 30.40s.
+    skip 된다. 브라우저도 서버도 없이 도는 것이라 커버리지 기여도 0이다.
 
     두 가지가 걸려 있다:
 
-    1. 매 런 30초 낭비. skip 이라 로그에는 `s` 열여섯 개로만 보인다.
+    1. **비용.** skip 이 공짜가 아니다 — 세션 fixture 가 서버를 폴링한 뒤에야 skip
+       한다. 도입 초기에는 `HEALTHCHECK_TIMEOUT_S=30` 을 꽉 채워 매 런 30초였고
+       (`16 skipped in 30.43s`), fast-fail 도입 후에도 `_I18N_HEALTHCHECK_SETUP_S`
+       만큼은 든다. skip 이라 로그에는 `s` 열여섯 개로만 보인다.
     2. **`timeout` 산정의 전제.** 디셀렉트하지 않으면 이 잡의 최장 test item phase
-       가 1.9s 가 아니라 30.4s 가 되고, `_SLOWEST_OBSERVED_S` 를 근거로 낮춘
-       per-test 상한이 그 순간 근거를 잃는다. 위
+       가 `_SLOWEST_OBSERVED_S` 가 아니라 그 setup phase 가 되고, 그 값을 근거로
+       낮춘 per-test 상한이 근거를 잃는다. 위
        `test_timeout_value_exceeds_slowest_observed_test` 는 상수만 보므로 이
        전제가 깨지는 것을 스스로는 알아채지 못한다.
 


### PR DESCRIPTION
두 건. 커밋도 둘로 나눠 두었다. 한 PR 로 묶은 이유는 **둘 다 새 테스트 파일을 추가**하기 때문이다 — `docs/component-counts.md` 는 저장소 전체를 스캔하므로 브랜치별로 green 이던 것이 머지 후 main red 가 된다(기록된 함정).

| # | 커밋 | 요약 |
|---|---|---|
| 1 | `e4d00e1` | i18n 헬스체크 fail-fast — 서버 부재 판정 **30.43s → 2.05s** |
| 2 | `57c54b1` | 0% 커버리지 스크립트 상위 3개 테스트 — 전체 **74.37% → 77.07%** |

---

## 1. i18n 헬스체크 fail-fast (`e4d00e1`)

이전 구현은 실패를 한 덩어리로 잡았다:

```python
except (urllib.error.URLError, ConnectionError, TimeoutError):
```

그래서 **포트에 아무도 안 붙어 있어도** `HEALTHCHECK_TIMEOUT_S=30` 을 꽉 채운 뒤에야 skip 했다.

세 실패는 의미가 다르다:

| 예외 | 의미 | 재시도 가치 |
|---|---|---|
| `ConnectionRefusedError` | 포트에 바인드된 프로세스가 **없다** | 낮음 |
| `socket.timeout` / `TimeoutError` | 바인드는 됐는데 응답이 느리다 | 높음 |
| `HTTPError`(상태코드) | 서버가 살아 있다 | 높음 |

refused 만 연속으로 나오고 `FAST_FAIL_GRACE_S`(2.0s = 4회)가 지나면 즉시 포기. 그 외 결과가 한 번이라도 나오면 전체 예산을 그대로 쓴다. 즉시 포기가 아니라 유예를 두는 이유는 `jekyll serve --detach` 가 셸 명령이 리턴한 **뒤에** 바인드하기 때문 — 그 startup race 는 `test_refused_then_ready_still_succeeds` 가 고정한다.

**로직을 conftest 밖으로 꺼냈다.** conftest 는 이름으로 import 할 수 없어서 이 30초짜리 루프는 **한 번도 검증된 적이 없었다.** `tests/_i18n_healthcheck.py` 로 옮기고(`_tree_write_guard`·`_golden` 과 같은 밑줄 헬퍼 규약) 시계·소켓·sleep 을 주입 가능하게 만들어 실제 대기 없이 검증한다.

**CI 에서는 skip 이 아니라 fail.** 별개지만 같은 함수에 얽힌 기존 결함이다 — `i18n-e2e.yml` 은 pytest 앞의 `curl` 루프로 서버를 보장하지만, 그 사이에 서버가 죽으면 16건이 skip 되고 **잡은 green 으로 끝난다.**

| | before | after |
|---|---|---|
| `pytest tests/i18n/` (서버 없음) | 30.43s | **2.05s** |

## 2. 0% 커버리지 상위 3개 (`57c54b1`)

| 스크립트 | statements | before | after | 테스트 |
|---|---|---|---|---|
| `scripts/backfill_images.py` | 317 | 0% | **83%** | 72 |
| `scripts/tools/gsc_index_audit.py` | 234 | 0% | **98%** | 46 |
| `scripts/backfill_signal_history_btc_price.py` | 181 | 0% | **99%** | 53 |

전체 **74.37% → 77.07%**. 게이트 73 대비 헤드룸 1.36pt → **4.07pt**.

"안 터진다"가 아니라 동작을 고정한다 — 429 백오프(`sleep_calls.calls == [60.0]`), 50회 연속 실패 컷오프(스크립트된 서비스를 일부러 소진시켜 컷오프가 회귀하면 테스트가 스스로 깨지게), 3단 폴백 체인의 **순서**와 source 라벨/값 일치, 한국어 본문 파싱 엣지케이스.

### 발견한 실제 결함: `sys.modules` 교체가 격리 fixture 를 무력화한다

세 파일은 각각 **단독으로는 통과**하는데 전체 스위트에서 **60건이 red** 였다:

```
AssertionError: 테스트가 커밋된 레포 트리에 썼습니다:
  open -> assets/images/generated/sector-heatmap-2026-02-12.png
```

원인은 프로덕션 코드다. `_load_image_generator()` 가 `sys.modules["common.image_generator"] = mod` 로 **이미 import 된 모듈 객체를 통째로 교체**한다(`backfill_images.py:527`). conftest 의 autouse `_isolate_generated_images` 는 그 시점의 **옛 객체**에 `IMAGES_DIR` 를 monkeypatch 해 둔 상태라, 교체 이후의 import 는 리다이렉트 없는 새 객체를 받는다. monkeypatch 의 되돌리기도 옛 객체에 적용되므로 **오염이 세션 끝까지 남는다** — 그래서 12건이 아니라 60건이었다.

`TestLoadImageGenerator` 에 `sys.modules` 스냅샷/복원 fixture 를 추가했다. 프로덕션 로딩 의미론은 건드리지 않는다(범위 밖이고, 실제 실행 경로 검증이 그 테스트의 목적이다).

**단독 실행에서는 절대 안 보이는 종류다.** 새 테스트 파일은 반드시 풀 스위트로 확인할 것.

---

## 검증

```
pytest tests/ -m "not i18n_e2e"
  → 5911 passed, 5 skipped, 16 deselected
  → Required test coverage of 73% reached. Total coverage: 77.07%

pytest tests/i18n/  (서버 없음)  → 16 skipped in 2.05s   (before: 30.43s)
pytest tests/test_i18n_healthcheck.py → 23 passed

ruff check / format --check    All checks passed
basedpyright                   0 errors, 0 warnings, 0 notes
격리 가드 전수(hermetic/suite-isolation/falsifiability/coverage-floor/plugin-sync) → 51 passed
스위트 후 git status 클린 (트리 쓰기 없음)
```

### 뮤테이션 검증

i18n fast-fail — 3건 전부 포착:

| 뮤테이션 | red |
|---|---|
| `only_refused` 갱신 제거 | `test_timeouts_use_the_full_budget_not_the_grace` + 1건 |
| fast-fail 분기 제거 | `test_all_refused_gives_up_after_grace_not_full_budget` + 1건 |
| `is_connection_refused` → `reason is not None` | HTTPError/URLError 오탐 2건 |

신규 테스트 — 6건 전부 포착: `get_post_type`→None 고정 / `_dedupe_keywords` 무력화 / `_MAX_CONSECUTIVE_FAILURES` 50→5 / `_QUOTA_SLEEP` 60.0→0.0 / `fetch_btc_price` 폴백 무력화 / `_price_direction` 상수화.

두 하네스에서 각각 함정을 밟았고 둘 다 고쳤다 — (a) 가짜 시계를 **읽을 때마다** 흐르게 만들어 구현의 내부 사정이 결과를 바꿨고, (b) 셸 따옴표 충돌로 주입이 **적용되지 않은 채** "VACUOUS" 로 보고됐다(이제 `ast.parse` 로 실행 가능성을 먼저 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
