### PR TITLE
chore(ci): 커버리지 하한 73 → 75

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          python3 -m coverage report --fail-under=73
+          python3 -m coverage report --fail-under=75
           python3 -m coverage html -d coverage-html
           python3 -m coverage json -o coverage.json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ quote-style = "double"
 relative_files = true
 
 [tool.pytest.ini_options]
-addopts = "--cov=scripts --cov-fail-under=73"
+addopts = "--cov=scripts --cov-fail-under=75"
 # 베어 `pytest` 가 Jekyll 빌드 산출물(_site/) 내 복사된 테스트를 수집해
 # ImportError 로 깨지던 문제 방지. CI 는 명시적으로 `pytest tests/` 를 호출하므로 영향 없음.
 testpaths = ["tests"]

--- a/tests/test_coverage_floor_guard.py
+++ b/tests/test_coverage_floor_guard.py
@@ -9,32 +9,40 @@ at or above :data:`_MIN_FLOOR`:
 * ``.github/workflows/code-quality.yml`` — a dedicated
   ``coverage report --fail-under=NN`` step re-checks the same data in CI.
 
-The floor was ratcheted 55 -> 65 (P3-1/P3-2) -> 70 (P3-3) -> 73 (2026-08-25) to
-lock existing coverage as a regression baseline. Without this guard the floor
-could be quietly dropped back — re-opening the gap between "tests deleted" and
-"build still green".
+The floor was ratcheted 55 -> 65 (P3-1/P3-2) -> 70 (P3-3) -> 73 -> 75 (both
+2026-08-25) to lock existing coverage as a regression baseline. Without this guard
+the floor could be quietly dropped back — re-opening the gap between "tests
+deleted" and "build still green".
 
-The 73 step was measured, not guessed. Actual total is **74.36%**
-(18413/24761 statements), and the measurement is deterministic:
+Every step is measured, not guessed. Actual total is **77.03%**
+(19091/24771 statements), and the measurement is deterministic:
 
-* local, same tree, 5 consecutive runs -> ``24761 6348 74%`` every time, spread 0
-* CI, 25 runs over 2026-08-18..08-25 (``python-coverage-comment-action-data``
-  branch ``data.json``) -> 74.304 .. 74.309, spread **0.005pt**
+* local, same tree, 5 consecutive runs -> ``24771 5680 77%`` every time, spread 0
+* CI on main -> 77.025 (``python-coverage-comment-action-data`` branch ``data.json``)
+* CI noise baseline, 25 runs over 2026-08-18..08-25 -> spread **0.005pt**
 
-So the 1.36pt headroom at 73 is ~270x the observed measurement noise; this floor
+So the 2.03pt headroom at 75 is ~400x the observed measurement noise; this floor
 cannot go red from noise. What it *does* cost: a new fully-untested script is
-allowed only up to ~462 statements before the gate trips (for scale, the largest
-existing 0%-covered script is ``scripts/backfill_images.py`` at 317). That is the
-intended ratchet — past that point, write tests or lower the floor deliberately.
+allowed only up to ~683 statements before the gate trips. For scale, scripts in
+this repo run 43..490 statements, and the largest remaining low-coverage module is
+``scripts/collect_geopolitical.py`` (490 stmts at 17%). That is the intended
+ratchet — past that point, write tests or lower the floor deliberately.
+
+Why 75 and not 76: the 73 step was accepted with 1.36pt / 462 statements of
+headroom. 76 would give 1.03pt / 348 — *tighter* than the bar agreed hours
+earlier, which is a stricter policy than anyone signed up for. 75 banks most of
+the gain without moving that bar.
 
 An earlier note claimed a ~1.3pt run-to-run swing (2026-07-27, when the total was
 ~71%). That is no longer reproducible; the hermetic-test hardening since then
 removed it. Re-measure before citing it again.
 
-Direction: floor is ``>=`` — ratcheting UP (73 -> 75 ...) stays green; only
-removing a gate or lowering it below 73 trips this test. If the floor is lowered
+Direction: floor is ``>=`` — ratcheting UP (75 -> 77 ...) stays green; only
+removing a gate or lowering it below 75 trips this test. If the floor is lowered
 intentionally, update ``_MIN_FLOOR`` here AND both ``--fail-under`` values
-together.
+together. The falsifiability harness derives its mutation anchors from the current
+value (``guard_falsifiability._current_coverage_floor``), so ratcheting needs no
+edit there.
 
 The workflow gate that scopes coverage to ``summary_sections.py`` (a stricter
 95% per-module floor) is intentionally excluded here — it is guarded separately
@@ -67,7 +75,7 @@ _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "code-quality.yml"
 
 # The global scripts coverage floor both gates must enforce.
-_MIN_FLOOR = 73
+_MIN_FLOOR = 75
 
 # The measurement scope the floor is meaningful against. `--cov=scripts` in
 # pyproject addopts applies to every pytest run; the CI step additionally names


### PR DESCRIPTION
#1222 로 0% 스크립트 상위 3개를 덮으면서 실측이 74.4% → **77.03%** 가 됐다. 게이트 73 대비 헤드룸 4.03pt.

측정은 여전히 결정적이다:

| 측정 | 결과 |
|---|---|
| 로컬 5회 반복(동일 트리) | `24771 5680 77%` / 77.07% ×5 — **스프레드 0** |
| main CI (`data.json`) | **77.025** |
| CI 노이즈 baseline (25런, 08-18~08-25) | 스프레드 0.005pt |

## 왜 75 이고 76 이 아닌가

| 게이트 | 헤드룸 | 허용 미커버 statement |
|---|---|---|
| 73 (현재) | 4.03pt | 1381 |
| **75** | **2.03pt** | **683** |
| 76 | 1.03pt | 348 |

73 을 정할 때 수용한 헤드룸은 **1.36pt / 462 stmts** 였다. 76 은 1.03pt / 348 로 **그보다 빡빡하다** — 노이즈 안전성(0.005pt 대비 200배)과는 별개로, 몇 시간 전에 합의한 기준을 조용히 조이는 셈이라 정책적으로 맞지 않는다. 75 는 그 기준을 건드리지 않으면서 상승분을 거의 다 잠근다.

이 저장소의 스크립트는 43~490 statement 범위다. 남은 저커버리지 재고는 10개 파일 1433 statement (최대 `collect_geopolitical.py` 490 stmts @17%, `respond_ai_mentions.py` 259 @20%, `generate_weekly_report.py` 216 @13%) — 앞으로 더 올릴 여지가 남아 있다.

## 앵커는 손대지 않았다 ✅

#1221 에서 `guard_falsifiability.py` 의 STATIC_CASES 앵커를 `pyproject.toml` 의 현재 값에서 파생시켜 두었다. 이번 상향에서 그 5개 앵커는 **자동으로 75 를 따라갔고 수정이 0건**이었다:

```
FALSIFIABLE  커버리지 하한 하향 (75 -> 50)          ← 자동 갱신
FALSIFIABLE  워크플로우 전역 커버리지 하한 하향 (75 -> 40)  ← 자동 갱신
FALSIFIABLE  커버리지 게이트 제거 (addopts)
FALSIFIABLE  커버리지 측정 범위 축소 (pyproject --cov)
FALSIFIABLE  커버리지 측정 범위 축소 (워크플로우 --cov)
FALSIFIABLE  커버리지 게이트 비차단화 (continue-on-error)
FALSIFIABLE  커버리지 게이트에서 모듈 제외 (--omit)
FALSIFIABLE  커버리지 설정에서 모듈 제외 ([tool.coverage.run] omit)
```

직전 상향(70→73)에서는 같은 앵커 5개가 한꺼번에 깨져 `test_static_case_anchors_are_unique_in_their_targets` 가 red 였다. 그 수정이 바로 효과를 봤다.

## 검증

```
pytest tests/ -m "not i18n_e2e"
  → 5911 passed, 5 skipped, 16 deselected
  → Required test coverage of 75% reached. Total coverage: 77.07%

ruff check / format --check    All checks passed
actionlint                     rc=0
커버리지 게이트 STATIC_CASES 8건 전부 FALSIFIABLE
```

세 지점을 함께 옮겼다 — `pyproject.toml` addopts · `code-quality.yml` 의 `coverage report --fail-under` · `tests/test_coverage_floor_guard.py` 의 `_MIN_FLOOR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
